### PR TITLE
fix: Read() removes from state on empty own ID — framework contract compliance (fixes #70)

### DIFF
--- a/internal/provider/backup_resource.go
+++ b/internal/provider/backup_resource.go
@@ -265,10 +265,16 @@ func (r *BackupResource) Read(ctx context.Context, req resource.ReadRequest, res
 	projectID := data.ProjectID.ValueString()
 	backupID := data.Id.ValueString()
 
-	if projectID == "" || backupID == "" {
+	if data.Id.IsUnknown() || data.Id.IsNull() || backupID == "" {
+		tflog.Debug(ctx, "Backup ID is empty, removing resource from state", map[string]interface{}{"backup_id": backupID})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if projectID == "" {
 		resp.Diagnostics.AddError(
 			"Missing Required Fields",
-			"Project ID and Backup ID are required to read the backup",
+			"Project ID is required to read the backup",
 		)
 		return
 	}

--- a/internal/provider/blockstorage_resource.go
+++ b/internal/provider/blockstorage_resource.go
@@ -327,31 +327,13 @@ func (r *BlockStorageResource) Read(ctx context.Context, req resource.ReadReques
 	projectID := data.ProjectID.ValueString()
 	volumeID := data.Id.ValueString()
 
-	// If ID is unknown or null, check if this is a new resource (no state) or existing resource (state exists but ID missing)
-	// For new resources (during plan), we can return early
-	// For existing resources, we need the ID to read - if it's missing, that's an error
 	if data.Id.IsUnknown() || data.Id.IsNull() || volumeID == "" {
-		// Check if we have any other state data that indicates this is an existing resource
-		// If name is set in state, this is likely an existing resource with missing ID (error case)
-		if !data.Name.IsUnknown() && !data.Name.IsNull() && data.Name.ValueString() != "" {
-			tflog.Error(ctx, "Block Storage exists in state but ID is missing - this indicates a state corruption issue")
-			resp.Diagnostics.AddError(
-				"Missing Block Storage ID",
-				"Block Storage ID is required to read the block storage. The resource exists in state but the ID is missing. This may indicate a state corruption issue. Try running 'terraform refresh' or 'terraform import arubacloud_blockstorage.test <volume_id>'.",
-			)
-			return
-		}
-		// Otherwise, this is likely a new resource during plan - return early
-		tflog.Info(ctx, "Block Storage ID is unknown or null during read, skipping API call (likely new resource).")
-		return // Do not error, as this is expected during plan for new resources
+		tflog.Debug(ctx, "Block Storage ID is empty, removing resource from state", map[string]interface{}{"volume_id": volumeID})
+		resp.State.RemoveResource(ctx)
+		return
 	}
 
 	if projectID == "" {
-		// Check if ProjectID is unknown (new resource) vs missing (error)
-		if data.ProjectID.IsUnknown() || data.ProjectID.IsNull() {
-			tflog.Info(ctx, "Block Storage Project ID is unknown or null during read, skipping API call (likely new resource).")
-			return // Do not error, as this is expected during plan for new resources
-		}
 		resp.Diagnostics.AddError(
 			"Missing Required Fields",
 			"Project ID is required to read the block storage",

--- a/internal/provider/cloudserver_resource.go
+++ b/internal/provider/cloudserver_resource.go
@@ -438,10 +438,16 @@ func (r *CloudServerResource) Read(ctx context.Context, req resource.ReadRequest
 	projectID := originalState.ProjectID.ValueString()
 	serverID := originalState.Id.ValueString()
 
-	if projectID == "" || serverID == "" {
+	if originalState.Id.IsUnknown() || originalState.Id.IsNull() || serverID == "" {
+		tflog.Debug(ctx, "Cloud Server ID is empty, removing resource from state", map[string]interface{}{"server_id": serverID})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if projectID == "" {
 		resp.Diagnostics.AddError(
 			"Missing Required Fields",
-			"Project ID and Server ID are required to read the cloud server",
+			"Project ID is required to read the cloud server",
 		)
 		return
 	}

--- a/internal/provider/containerregistry_resource.go
+++ b/internal/provider/containerregistry_resource.go
@@ -367,10 +367,16 @@ func (r *ContainerRegistryResource) Read(ctx context.Context, req resource.ReadR
 	projectID := data.ProjectID.ValueString()
 	registryID := data.Id.ValueString()
 
-	if projectID == "" || registryID == "" {
+	if data.Id.IsUnknown() || data.Id.IsNull() || registryID == "" {
+		tflog.Debug(ctx, "Container Registry ID is empty, removing resource from state", map[string]interface{}{"registry_id": registryID})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if projectID == "" {
 		resp.Diagnostics.AddError(
 			"Missing Required Fields",
-			"Project ID and Registry ID are required to read the container registry",
+			"Project ID is required to read the container registry",
 		)
 		return
 	}

--- a/internal/provider/database_resource.go
+++ b/internal/provider/database_resource.go
@@ -177,10 +177,16 @@ func (r *DatabaseResource) Read(ctx context.Context, req resource.ReadRequest, r
 	dbaasID := data.DBaaSID.ValueString()
 	databaseName := data.Id.ValueString()
 
-	if projectID == "" || dbaasID == "" || databaseName == "" {
+	if data.Id.IsUnknown() || data.Id.IsNull() || databaseName == "" {
+		tflog.Debug(ctx, "Database ID is empty, removing resource from state", map[string]interface{}{"database_name": databaseName})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if projectID == "" || dbaasID == "" {
 		resp.Diagnostics.AddError(
 			"Missing Required Fields",
-			"Project ID, DBaaS ID, and Database Name are required to read the database",
+			"Project ID and DBaaS ID are required to read the database",
 		)
 		return
 	}

--- a/internal/provider/databasebackup_resource.go
+++ b/internal/provider/databasebackup_resource.go
@@ -250,10 +250,16 @@ func (r *DatabaseBackupResource) Read(ctx context.Context, req resource.ReadRequ
 	projectID := data.ProjectID.ValueString()
 	backupID := data.Id.ValueString()
 
-	if projectID == "" || backupID == "" {
+	if data.Id.IsUnknown() || data.Id.IsNull() || backupID == "" {
+		tflog.Debug(ctx, "Database Backup ID is empty, removing resource from state", map[string]interface{}{"backup_id": backupID})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if projectID == "" {
 		resp.Diagnostics.AddError(
 			"Missing Required Fields",
-			"Project ID and Backup ID are required to read the database backup",
+			"Project ID is required to read the database backup",
 		)
 		return
 	}

--- a/internal/provider/databasegrant_resource.go
+++ b/internal/provider/databasegrant_resource.go
@@ -169,6 +169,12 @@ func (r *DatabaseGrantResource) Read(ctx context.Context, req resource.ReadReque
 	databaseName := data.Database.ValueString()
 	userID := data.UserID.ValueString()
 
+	if data.Id.IsUnknown() || data.Id.IsNull() || data.Id.ValueString() == "" {
+		tflog.Debug(ctx, "Database Grant ID is empty, removing resource from state", map[string]interface{}{"grant_id": data.Id.ValueString()})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	if projectID == "" || dbaasID == "" || databaseName == "" || userID == "" {
 		resp.Diagnostics.AddError(
 			"Missing Required Fields",

--- a/internal/provider/dbaas_resource.go
+++ b/internal/provider/dbaas_resource.go
@@ -486,10 +486,16 @@ func (r *DBaaSResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	projectID := data.ProjectID.ValueString()
 	dbaasID := data.Id.ValueString()
 
-	if projectID == "" || dbaasID == "" {
+	if data.Id.IsUnknown() || data.Id.IsNull() || dbaasID == "" {
+		tflog.Debug(ctx, "DBaaS ID is empty, removing resource from state", map[string]interface{}{"dbaas_id": dbaasID})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if projectID == "" {
 		resp.Diagnostics.AddError(
 			"Missing Required Fields",
-			"Project ID and DBaaS ID are required to read the DBaaS instance",
+			"Project ID is required to read the DBaaS instance",
 		)
 		return
 	}

--- a/internal/provider/dbaasuser_resource.go
+++ b/internal/provider/dbaasuser_resource.go
@@ -187,10 +187,16 @@ func (r *DBaaSUserResource) Read(ctx context.Context, req resource.ReadRequest, 
 	dbaasID := data.DBaaSID.ValueString()
 	username := data.Id.ValueString()
 
-	if projectID == "" || dbaasID == "" || username == "" {
+	if data.Id.IsUnknown() || data.Id.IsNull() || username == "" {
+		tflog.Debug(ctx, "DBaaS User ID is empty, removing resource from state", map[string]interface{}{"username": username})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if projectID == "" || dbaasID == "" {
 		resp.Diagnostics.AddError(
 			"Missing Required Fields",
-			"Project ID, DBaaS ID, and Username are required to read the DBaaS user",
+			"Project ID and DBaaS ID are required to read the DBaaS user",
 		)
 		return
 	}

--- a/internal/provider/elasticip_resource.go
+++ b/internal/provider/elasticip_resource.go
@@ -315,12 +315,9 @@ func (r *ElasticIPResource) Read(ctx context.Context, req resource.ReadRequest, 
 	projectID := data.ProjectId.ValueString()
 	eipID := data.Id.ValueString()
 
-	// If ID is unknown or empty, the resource doesn't exist yet (e.g., during plan for new resources)
-	// Return early without error - this is expected behavior
 	if data.Id.IsUnknown() || data.Id.IsNull() || eipID == "" {
-		tflog.Debug(ctx, "Elastic IP ID is unknown or empty, skipping read", map[string]interface{}{
-			"eip_id": eipID,
-		})
+		tflog.Debug(ctx, "Elastic IP ID is empty, removing resource from state", map[string]interface{}{"eip_id": eipID})
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/provider/kaas_resource.go
+++ b/internal/provider/kaas_resource.go
@@ -558,10 +558,16 @@ func (r *KaaSResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	projectID := data.ProjectID.ValueString()
 	kaasID := data.Id.ValueString()
 
-	if projectID == "" || kaasID == "" {
+	if data.Id.IsUnknown() || data.Id.IsNull() || kaasID == "" {
+		tflog.Debug(ctx, "KaaS ID is empty, removing resource from state", map[string]interface{}{"kaas_id": kaasID})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if projectID == "" {
 		resp.Diagnostics.AddError(
 			"Missing Required Fields",
-			"Project ID and KaaS ID are required to read the KaaS cluster",
+			"Project ID is required to read the KaaS cluster",
 		)
 		return
 	}

--- a/internal/provider/key_resource.go
+++ b/internal/provider/key_resource.go
@@ -243,10 +243,16 @@ func (r *KeyResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 		"key_id":     keyID,
 	})
 
-	if projectID == "" || kmsID == "" || keyID == "" {
+	if data.Id.IsUnknown() || data.Id.IsNull() || keyID == "" {
+		tflog.Debug(ctx, "Key ID is empty, removing resource from state", map[string]interface{}{"key_id": keyID})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if projectID == "" || kmsID == "" {
 		resp.Diagnostics.AddError(
 			"Missing Required Fields",
-			"Project ID, KMS ID, and Key ID are required to read the Key",
+			"Project ID and KMS ID are required to read the Key",
 		)
 		return
 	}

--- a/internal/provider/keypair_resource.go
+++ b/internal/provider/keypair_resource.go
@@ -222,29 +222,13 @@ func (r *KeypairResource) Read(ctx context.Context, req resource.ReadRequest, re
 	projectID := data.ProjectID.ValueString()
 	keypairID := data.Id.ValueString()
 
-	// If ID is unknown or null, check if this is a new resource (no state) or existing resource (state exists but ID missing)
-	// For new resources (during plan), we can return early
-	// For existing resources, we need the ID to read - if it's missing, that's an error
 	if data.Id.IsUnknown() || data.Id.IsNull() || keypairID == "" {
-		// Check if ProjectID is also unknown - if so, this is definitely a new resource
-		if data.ProjectID.IsUnknown() || data.ProjectID.IsNull() {
-			tflog.Info(ctx, "Keypair ID and Project ID are unknown or null during read, skipping API call (likely new resource).")
-			return // Do not error, as this is expected during plan for new resources
-		}
-		// If ProjectID is set but ID is unknown, still skip (new resource)
-		if keypairID == "" {
-			tflog.Info(ctx, "Keypair ID is unknown or null during read, skipping API call (likely new resource).")
-			return // Do not error, as this is expected during plan for new resources
-		}
+		tflog.Debug(ctx, "Keypair ID is empty, removing resource from state", map[string]interface{}{"keypair_id": keypairID})
+		resp.State.RemoveResource(ctx)
+		return
 	}
 
-	// If ProjectID is missing, we can't read the keypair
 	if projectID == "" {
-		// Check if ProjectID is unknown (new resource) vs missing (error)
-		if data.ProjectID.IsUnknown() || data.ProjectID.IsNull() {
-			tflog.Info(ctx, "Keypair Project ID is unknown or null during read, skipping API call (likely new resource).")
-			return // Do not error, as this is expected during plan for new resources
-		}
 		resp.Diagnostics.AddError(
 			"Missing Required Fields",
 			"Project ID is required to read the keypair",

--- a/internal/provider/kmip_resource.go
+++ b/internal/provider/kmip_resource.go
@@ -185,10 +185,16 @@ func (r *KMIPResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	kmsID := data.KMSID.ValueString()
 	kmipID := data.Id.ValueString()
 
-	if projectID == "" || kmsID == "" || kmipID == "" {
+	if data.Id.IsUnknown() || data.Id.IsNull() || kmipID == "" {
+		tflog.Debug(ctx, "KMIP ID is empty, removing resource from state", map[string]interface{}{"kmip_id": kmipID})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if projectID == "" || kmsID == "" {
 		resp.Diagnostics.AddError(
 			"Missing Required Fields",
-			"Project ID, KMS ID, and KMIP ID are required to read the KMIP",
+			"Project ID and KMS ID are required to read the KMIP",
 		)
 		return
 	}

--- a/internal/provider/kms_resource.go
+++ b/internal/provider/kms_resource.go
@@ -254,10 +254,16 @@ func (r *KMSResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 	projectID := data.ProjectID.ValueString()
 	kmsID := data.Id.ValueString()
 
-	if projectID == "" || kmsID == "" {
+	if data.Id.IsUnknown() || data.Id.IsNull() || kmsID == "" {
+		tflog.Debug(ctx, "KMS ID is empty, removing resource from state", map[string]interface{}{"kms_id": kmsID})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if projectID == "" {
 		resp.Diagnostics.AddError(
 			"Missing Required Fields",
-			"Project ID and KMS ID are required to read the KMS",
+			"Project ID is required to read the KMS",
 		)
 		return
 	}

--- a/internal/provider/project_resource.go
+++ b/internal/provider/project_resource.go
@@ -196,26 +196,10 @@ func (r *ProjectResource) Read(ctx context.Context, req resource.ReadRequest, re
 	// Get project ID from state
 	projectID := data.Id.ValueString()
 
-	// If ID is unknown or null, check if this is a new resource (no state) or existing resource (state exists but ID missing)
-	// For new resources (during plan), we can return early
-	// For existing resources, we need the ID to read - if it's missing, that's a state corruption issue
 	if data.Id.IsUnknown() || data.Id.IsNull() || projectID == "" {
-		// Check if we have any other state data that indicates this is an existing resource
-		// If name is set in state, this is likely an existing resource with missing ID (state corruption)
-		if !data.Name.IsUnknown() && !data.Name.IsNull() && data.Name.ValueString() != "" {
-			tflog.Error(ctx, "Project exists in state but ID is missing - this indicates a state corruption issue")
-			resp.Diagnostics.AddError(
-				"Missing Project ID",
-				"Project ID is required to read the project. The resource exists in state but the ID is missing. This indicates a state corruption issue. To fix this, you can:\n"+
-					"1. Find the project ID using: acloud management project list\n"+
-					"2. Import the resource: terraform import arubacloud_project.test <project_id>\n"+
-					"Or manually edit the terraform.tfstate file to add the ID.",
-			)
-			return
-		}
-		// Otherwise, this is likely a new resource during plan - return early
-		tflog.Info(ctx, "Project ID is unknown or null during read, skipping API call (likely new resource).")
-		return // Do not error, as this is expected during plan for new resources
+		tflog.Debug(ctx, "Project ID is empty, removing resource from state", map[string]interface{}{"project_id": projectID})
+		resp.State.RemoveResource(ctx)
+		return
 	}
 
 	// Get project details using the SDK

--- a/internal/provider/read_empty_id_test.go
+++ b/internal/provider/read_empty_id_test.go
@@ -1,0 +1,179 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// These tests demonstrate and guard against the Read-empty-ID bug across every
+// resource in the provider. The Plugin Framework contract says Read should
+// treat an empty / null / unknown own id as "the resource is gone" and call
+// resp.State.RemoveResource(ctx) so the caller plans a Create. Returning a
+// hard diagnostic instead breaks `terraform apply -refresh-only`,
+// state-recovery flows, and Crossplane/upjet Observe.
+//
+// TestAllResourcesReadEmptyID_RemovesState sweeps every resource registered
+// on the provider so new resources are covered automatically and can't
+// silently reintroduce the buggy pattern. TestVPCRead_EmptyParentID_StillErrors
+// pins the companion invariant a fix must preserve: an empty *parent* id
+// (e.g. project_id) is a genuine misconfiguration and must still produce a
+// diagnostic.
+
+type emptyIDCase struct {
+	name string
+	val  tftypes.Value
+}
+
+func emptyIDCases() []emptyIDCase {
+	return []emptyIDCase{
+		{"empty string", tftypes.NewValue(tftypes.String, "")},
+		{"null", tftypes.NewValue(tftypes.String, nil)},
+		{"unknown", tftypes.NewValue(tftypes.String, tftypes.UnknownValue)},
+	}
+}
+
+// stateForEmptyIDRead builds a tfsdk.State matching the resource's schema
+// where `id` is set to idVal and every other top-level string attribute
+// (typical home of parent ids like project_id / vpc_id) is filled with a
+// non-empty placeholder so the "own id empty" branch is isolated from the
+// "parent id empty" branch. Non-string attributes are left null.
+func stateForEmptyIDRead(ctx context.Context, t *testing.T, r resource.Resource, idVal tftypes.Value) tfsdk.State {
+	t.Helper()
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("schema error: %v", schemaResp.Diagnostics)
+	}
+	objType, ok := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	if !ok {
+		t.Fatalf("schema top type is not an object")
+	}
+	attrs := make(map[string]tftypes.Value, len(objType.AttributeTypes))
+	for name, ty := range objType.AttributeTypes {
+		switch {
+		case name == "id":
+			attrs[name] = idVal
+		case ty.Is(tftypes.String):
+			attrs[name] = tftypes.NewValue(tftypes.String, "placeholder")
+		default:
+			attrs[name] = tftypes.NewValue(ty, nil)
+		}
+	}
+	return tfsdk.State{
+		Raw:    tftypes.NewValue(objType, attrs),
+		Schema: schemaResp.Schema,
+	}
+}
+
+func TestAllResourcesReadEmptyID_RemovesState(t *testing.T) {
+	ctx := context.Background()
+	p := New("test")()
+
+	resources := p.Resources(ctx)
+	if len(resources) == 0 {
+		t.Fatal("provider registered zero resources; sweep would be vacuous")
+	}
+
+	for _, mk := range resources {
+		r := mk()
+
+		metaResp := &resource.MetadataResponse{}
+		r.Metadata(ctx, resource.MetadataRequest{ProviderTypeName: "arubacloud"}, metaResp)
+		name := metaResp.TypeName
+
+		schemaResp := &resource.SchemaResponse{}
+		r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+		if schemaResp.Diagnostics.HasError() {
+			t.Errorf("%s: schema returned diagnostics: %v", name, schemaResp.Diagnostics)
+			continue
+		}
+		if _, ok := schemaResp.Schema.Attributes["id"]; !ok {
+			t.Errorf("%s: schema has no top-level id attribute, cannot sweep", name)
+			continue
+		}
+
+		for _, tc := range emptyIDCases() {
+			t.Run(fmt.Sprintf("%s/%s", name, tc.name), func(t *testing.T) {
+				state := stateForEmptyIDRead(ctx, t, r, tc.val)
+				req := resource.ReadRequest{State: state}
+				resp := &resource.ReadResponse{State: tfsdk.State{Schema: state.Schema}}
+
+				// Some buggy Read paths fall through to an unconfigured API
+				// client and panic on a nil deref — treat that as a (louder)
+				// flavour of the same bug.
+				defer func() {
+					if rec := recover(); rec != nil {
+						t.Fatalf(
+							"%s Read with own id=%s panicked instead of handling the empty-id case.\n"+
+								"Panic: %v",
+							name, tc.name, rec,
+						)
+					}
+				}()
+
+				r.Read(ctx, req, resp)
+
+				if resp.Diagnostics.HasError() {
+					t.Fatalf(
+						"%s Read with own id=%s returned a hard error, violating the framework contract.\n"+
+							"Expected: resp.State.RemoveResource(ctx) so the caller plans a Create.\n"+
+							"Got diagnostics: %v",
+						name, tc.name, resp.Diagnostics,
+					)
+				}
+				if !resp.State.Raw.IsNull() {
+					t.Fatalf(
+						"%s Read with own id=%s did not remove the resource from state.\n"+
+							"Expected: resp.State.Raw.IsNull() == true.\n"+
+							"Got: %v",
+						name, tc.name, resp.State.Raw,
+					)
+				}
+			})
+		}
+	}
+}
+
+// TestVPCRead_EmptyParentID_StillErrors pins the companion invariant: a
+// missing parent id (project_id) is a real misconfiguration and must keep
+// erroring. A fix that calls RemoveResource unconditionally would flip this
+// test to green, so it acts as a guard against over-broad fixes.
+func TestVPCRead_EmptyParentID_StillErrors(t *testing.T) {
+	ctx := context.Background()
+	r := &VPCResource{}
+
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("schema error: %v", schemaResp.Diagnostics)
+	}
+
+	objType, ok := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	if !ok {
+		t.Fatalf("schema top type is not an object")
+	}
+	attrs := make(map[string]tftypes.Value, len(objType.AttributeTypes))
+	for name, ty := range objType.AttributeTypes {
+		attrs[name] = tftypes.NewValue(ty, nil)
+	}
+	attrs["id"] = tftypes.NewValue(tftypes.String, "some-vpc-id")
+	attrs["project_id"] = tftypes.NewValue(tftypes.String, "")
+
+	req := resource.ReadRequest{
+		State: tfsdk.State{
+			Raw:    tftypes.NewValue(objType, attrs),
+			Schema: schemaResp.Schema,
+		},
+	}
+	resp := &resource.ReadResponse{State: tfsdk.State{Schema: schemaResp.Schema}}
+	r.Read(ctx, req, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("Read with empty parent project_id should have errored (genuine misconfiguration), got no diagnostics")
+	}
+}

--- a/internal/provider/restore_resource.go
+++ b/internal/provider/restore_resource.go
@@ -264,10 +264,16 @@ func (r *RestoreResource) Read(ctx context.Context, req resource.ReadRequest, re
 	backupID := data.BackupID.ValueString()
 	restoreID := data.Id.ValueString()
 
-	if projectID == "" || backupID == "" || restoreID == "" {
+	if data.Id.IsUnknown() || data.Id.IsNull() || restoreID == "" {
+		tflog.Debug(ctx, "Restore ID is empty, removing resource from state", map[string]interface{}{"restore_id": restoreID})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if projectID == "" || backupID == "" {
 		resp.Diagnostics.AddError(
 			"Missing Required Fields",
-			"Project ID, Backup ID, and Restore ID are required to read the restore",
+			"Project ID and Backup ID are required to read the restore",
 		)
 		return
 	}

--- a/internal/provider/schedulejob_resource.go
+++ b/internal/provider/schedulejob_resource.go
@@ -370,10 +370,16 @@ func (r *ScheduleJobResource) Read(ctx context.Context, req resource.ReadRequest
 	projectID := data.ProjectID.ValueString()
 	jobID := data.Id.ValueString()
 
-	if projectID == "" || jobID == "" {
+	if data.Id.IsUnknown() || data.Id.IsNull() || jobID == "" {
+		tflog.Debug(ctx, "Schedule Job ID is empty, removing resource from state", map[string]interface{}{"job_id": jobID})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if projectID == "" {
 		resp.Diagnostics.AddError(
 			"Missing Required Fields",
-			"Project ID and Job ID are required to read the schedule job",
+			"Project ID is required to read the schedule job",
 		)
 		return
 	}

--- a/internal/provider/securitygroup_resource.go
+++ b/internal/provider/securitygroup_resource.go
@@ -261,10 +261,15 @@ func (r *SecurityGroupResource) Read(ctx context.Context, req resource.ReadReque
 	vpcID := data.VpcId.ValueString()
 	sgID := data.Id.ValueString()
 
-	if projectID == "" || vpcID == "" || sgID == "" {
+	if data.Id.IsUnknown() || data.Id.IsNull() || sgID == "" {
+		tflog.Debug(ctx, "Security Group ID is empty, removing resource from state", map[string]interface{}{"sg_id": sgID})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if projectID == "" || vpcID == "" {
 		resp.Diagnostics.AddError(
 			"Missing Required Fields",
-			"Project ID, VPC ID, and Security Group ID are required to read the security group",
+			"Project ID and VPC ID are required to read the security group",
 		)
 		return
 	}

--- a/internal/provider/securityrule_resource.go
+++ b/internal/provider/securityrule_resource.go
@@ -662,10 +662,15 @@ func (r *SecurityRuleResource) Read(ctx context.Context, req resource.ReadReques
 	securityGroupID := data.SecurityGroupId.ValueString()
 	ruleID := data.Id.ValueString()
 
-	if projectID == "" || vpcID == "" || securityGroupID == "" || ruleID == "" {
+	if data.Id.IsUnknown() || data.Id.IsNull() || ruleID == "" {
+		tflog.Debug(ctx, "Security Rule ID is empty, removing resource from state", map[string]interface{}{"rule_id": ruleID})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if projectID == "" || vpcID == "" || securityGroupID == "" {
 		resp.Diagnostics.AddError(
 			"Missing Required Fields",
-			"Project ID, VPC ID, Security Group ID, and Rule ID are required to read the security rule",
+			"Project ID, VPC ID, and Security Group ID are required to read the security rule",
 		)
 		return
 	}

--- a/internal/provider/snapshot_resource.go
+++ b/internal/provider/snapshot_resource.go
@@ -289,31 +289,13 @@ func (r *SnapshotResource) Read(ctx context.Context, req resource.ReadRequest, r
 	projectID := data.ProjectId.ValueString()
 	snapshotID := data.Id.ValueString()
 
-	// If ID is unknown or null, check if this is a new resource (no state) or existing resource (state exists but ID missing)
-	// For new resources (during plan), we can return early
-	// For existing resources, we need the ID to read - if it's missing, that's an error
 	if data.Id.IsUnknown() || data.Id.IsNull() || snapshotID == "" {
-		// Check if we have any other state data that indicates this is an existing resource
-		// If name is set in state, this is likely an existing resource with missing ID (error case)
-		if !data.Name.IsUnknown() && !data.Name.IsNull() && data.Name.ValueString() != "" {
-			tflog.Error(ctx, "Snapshot exists in state but ID is missing - this indicates a state corruption issue")
-			resp.Diagnostics.AddError(
-				"Missing Snapshot ID",
-				"Snapshot ID is required to read the snapshot. The resource exists in state but the ID is missing. This may indicate a state corruption issue. Try running 'terraform refresh' or 'terraform import arubacloud_snapshot.test <snapshot_id>'.",
-			)
-			return
-		}
-		// Otherwise, this is likely a new resource during plan - return early
-		tflog.Info(ctx, "Snapshot ID is unknown or null during read, skipping API call (likely new resource).")
-		return // Do not error, as this is expected during plan for new resources
+		tflog.Debug(ctx, "Snapshot ID is empty, removing resource from state", map[string]interface{}{"snapshot_id": snapshotID})
+		resp.State.RemoveResource(ctx)
+		return
 	}
 
 	if projectID == "" {
-		// Check if ProjectID is unknown (new resource) vs missing (error)
-		if data.ProjectId.IsUnknown() || data.ProjectId.IsNull() {
-			tflog.Info(ctx, "Snapshot Project ID is unknown or null during read, skipping API call (likely new resource).")
-			return // Do not error, as this is expected during plan for new resources
-		}
 		resp.Diagnostics.AddError(
 			"Missing Required Fields",
 			"Project ID is required to read the snapshot",

--- a/internal/provider/subnet_resource.go
+++ b/internal/provider/subnet_resource.go
@@ -518,10 +518,15 @@ func (r *SubnetResource) Read(ctx context.Context, req resource.ReadRequest, res
 	vpcID := data.VpcId.ValueString()
 	subnetID := data.Id.ValueString()
 
-	if projectID == "" || vpcID == "" || subnetID == "" {
+	if data.Id.IsUnknown() || data.Id.IsNull() || subnetID == "" {
+		tflog.Debug(ctx, "Subnet ID is empty, removing resource from state", map[string]interface{}{"subnet_id": subnetID})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if projectID == "" || vpcID == "" {
 		resp.Diagnostics.AddError(
 			"Missing Required Fields",
-			"Project ID, VPC ID, and Subnet ID are required to read the subnet",
+			"Project ID and VPC ID are required to read the subnet",
 		)
 		return
 	}

--- a/internal/provider/vpc_resource.go
+++ b/internal/provider/vpc_resource.go
@@ -262,10 +262,15 @@ func (r *VPCResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 	projectID := data.ProjectID.ValueString()
 	vpcID := data.Id.ValueString()
 
-	if projectID == "" || vpcID == "" {
+	if data.Id.IsUnknown() || data.Id.IsNull() || vpcID == "" {
+		tflog.Debug(ctx, "VPC ID is empty, removing resource from state", map[string]interface{}{"vpc_id": vpcID})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if projectID == "" {
 		resp.Diagnostics.AddError(
 			"Missing Required Fields",
-			"Project ID and VPC ID are required to read the VPC",
+			"Project ID is required to read the VPC",
 		)
 		return
 	}

--- a/internal/provider/vpcpeering_resource.go
+++ b/internal/provider/vpcpeering_resource.go
@@ -221,10 +221,15 @@ func (r *VpcPeeringResource) Read(ctx context.Context, req resource.ReadRequest,
 	vpcID := data.VpcId.ValueString()
 	peeringID := data.Id.ValueString()
 
-	if projectID == "" || vpcID == "" || peeringID == "" {
+	if data.Id.IsUnknown() || data.Id.IsNull() || peeringID == "" {
+		tflog.Debug(ctx, "VPC Peering ID is empty, removing resource from state", map[string]interface{}{"peering_id": peeringID})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if projectID == "" || vpcID == "" {
 		resp.Diagnostics.AddError(
 			"Missing Required Fields",
-			"Project ID, VPC ID, and Peering ID are required to read the VPC peering",
+			"Project ID and VPC ID are required to read the VPC peering",
 		)
 		return
 	}

--- a/internal/provider/vpcpeeringroute_resource.go
+++ b/internal/provider/vpcpeeringroute_resource.go
@@ -226,10 +226,15 @@ func (r *VpcPeeringRouteResource) Read(ctx context.Context, req resource.ReadReq
 	peeringID := data.VpcPeeringId.ValueString()
 	routeID := data.Id.ValueString()
 
-	if projectID == "" || vpcID == "" || peeringID == "" || routeID == "" {
+	if data.Id.IsUnknown() || data.Id.IsNull() || routeID == "" {
+		tflog.Debug(ctx, "VPC Peering Route ID is empty, removing resource from state", map[string]interface{}{"route_id": routeID})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if projectID == "" || vpcID == "" || peeringID == "" {
 		resp.Diagnostics.AddError(
 			"Missing Required Fields",
-			"Project ID, VPC ID, VPC Peering ID, and Route ID are required to read the VPC peering route",
+			"Project ID, VPC ID, and VPC Peering ID are required to read the VPC peering route",
 		)
 		return
 	}

--- a/internal/provider/vpnroute_resource.go
+++ b/internal/provider/vpnroute_resource.go
@@ -245,10 +245,15 @@ func (r *VPNRouteResource) Read(ctx context.Context, req resource.ReadRequest, r
 	vpnTunnelID := data.VPNTunnelId.ValueString()
 	routeID := data.Id.ValueString()
 
-	if projectID == "" || vpnTunnelID == "" || routeID == "" {
+	if data.Id.IsUnknown() || data.Id.IsNull() || routeID == "" {
+		tflog.Debug(ctx, "VPN Route ID is empty, removing resource from state", map[string]interface{}{"route_id": routeID})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if projectID == "" || vpnTunnelID == "" {
 		resp.Diagnostics.AddError(
 			"Missing Required Fields",
-			"Project ID, VPN Tunnel ID, and Route ID are required to read the VPN route",
+			"Project ID and VPN Tunnel ID are required to read the VPN route",
 		)
 		return
 	}

--- a/internal/provider/vpntunnel_resource.go
+++ b/internal/provider/vpntunnel_resource.go
@@ -624,10 +624,15 @@ func (r *VPNTunnelResource) Read(ctx context.Context, req resource.ReadRequest, 
 	projectID := data.ProjectId.ValueString()
 	tunnelID := data.Id.ValueString()
 
-	if projectID == "" || tunnelID == "" {
+	if data.Id.IsUnknown() || data.Id.IsNull() || tunnelID == "" {
+		tflog.Debug(ctx, "VPN Tunnel ID is empty, removing resource from state", map[string]interface{}{"tunnel_id": tunnelID})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if projectID == "" {
 		resp.Diagnostics.AddError(
 			"Missing Required Fields",
-			"Project ID and Tunnel ID are required to read the VPN tunnel",
+			"Project ID is required to read the VPN tunnel",
 		)
 		return
 	}


### PR DESCRIPTION
## Summary

- Fixes #70: 21 resources returned `AddError` when their own `id` was empty/null/unknown, violating the Plugin Framework contract for `Read`
- 6 resources already had a plain early `return` but still left the resource in state, breaking Crossplane/upjet's Observe flow

## Changes

**27 resource `Read()` methods updated** across `internal/provider/*_resource.go`:

- **22 resources (Group 1)** — split the combined `if parentID == "" || ownID == ""` check:
  - Own ID empty/null/unknown → `resp.State.RemoveResource(ctx)` + `return` (no error — framework "resource is gone" signal)
  - Parent IDs empty (`project_id`, `vpc_id`, …) → keep `AddError` (genuine misconfiguration)
  - Affected: `backup`, `cloudserver`, `containerregistry`, `database`, `databasebackup`, `databasegrant`, `dbaas`, `dbaasuser`, `kaas`, `key`, `kmip`, `kms`, `restore`, `schedulejob`, `securitygroup`, `securityrule`, `subnet`, `vpc`, `vpcpeering`, `vpcpeeringroute`, `vpnroute`, `vpntunnel`

- **5 resources (Group 2)** — upgrade plain `return` to `resp.State.RemoveResource(ctx)` + `return`:
  - Affected: `blockstorage`, `elasticip`, `keypair`, `project`, `snapshot`

## Why `RemoveResource` and not just `return`

Returning early without touching state leaves the resource in tfstate. Any caller that checks `state.GetAttributes()` (upjet, some TF tooling) sees `Exists: true` and never drives Create. Only `resp.State.RemoveResource(ctx)` clears the state entry so the caller proceeds to Create.

## Impact

- **Vanilla Terraform**: `apply -refresh-only` and state-repair flows that blank a resource ID now correctly plan a Create instead of erroring
- **Crossplane/upjet**: the Observe → Create reconciliation loop now works for all 27 resource kinds (previously stuck in `Synced=False` forever)
- **Backward compatible**: normal plan/apply/destroy flows never produce an empty `data.Id` in `Read`, so this path is not exercised for existing users

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/provider/...` passes
- [ ] Verify `terraform apply -refresh-only` with a blanked ID returns no error and plans a Create
- [ ] Reference PR with unit tests: https://github.com/ricCap/terraform-provider-arubacloud/pull/2

🤖 Generated with [Claude Code](https://claude.com/claude-code)