### PR TITLE
fix(cloudserver): add RequiresReplace to immutable fields (closes #44)

### DIFF
--- a/docs/resources/cloudserver.md
+++ b/docs/resources/cloudserver.md
@@ -50,13 +50,13 @@ The following arguments are supported:
 
 #### Required
 
-- `location` (String) Region identifier for the resource (e.g., `ITBG-Bergamo`). See the [available locations and zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center).
+- `location` (String) Region identifier for the resource (e.g., `ITBG-Bergamo`). See the [available locations and zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center). Changing this value forces a new resource.
 - `name` (String) Display name for the CloudServer.
 - `network` (Attributes) Network configuration for the CloudServer. (see [below for nested schema](#nestedatt--network))
-- `project_id` (String) ID of the project that owns this resource.
+- `project_id` (String) ID of the project that owns this resource. Changing this value forces a new resource.
 - `settings` (Attributes) Compute and access settings for the CloudServer. (see [below for nested schema](#nestedatt--settings))
 - `storage` (Attributes) Storage configuration for the CloudServer. (see [below for nested schema](#nestedatt--storage))
-- `zone` (String) Availability zone within the region (e.g., `ITBG-1`). See [available zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center).
+- `zone` (String) Availability zone within the region (e.g., `ITBG-1`). See [available zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center). Changing this value forces a new resource.
 
 #### Optional
 
@@ -76,13 +76,13 @@ In addition to all arguments above, the following attributes are exported:
 
 Required:
 
-- `securitygroup_uri_refs` (List of String) List of security group URIs to apply to this CloudServer. Reference the `uri` attribute of each `arubacloud_securitygroup` resource.
-- `subnet_uri_refs` (List of String) List of subnet URIs to attach this CloudServer to. Reference the `uri` attribute of each `arubacloud_subnet` resource.
-- `vpc_uri_ref` (String) URI of the VPC to attach this CloudServer to. Reference the `uri` attribute of an `arubacloud_vpc` resource.
+- `securitygroup_uri_refs` (List of String) List of security group URIs to apply to this CloudServer. Reference the `uri` attribute of each `arubacloud_securitygroup` resource. Changing this value forces a new resource.
+- `subnet_uri_refs` (List of String) List of subnet URIs to attach this CloudServer to. Reference the `uri` attribute of each `arubacloud_subnet` resource. Changing this value forces a new resource.
+- `vpc_uri_ref` (String) URI of the VPC to attach this CloudServer to. Reference the `uri` attribute of an `arubacloud_vpc` resource. Changing this value forces a new resource.
 
 Optional:
 
-- `elastic_ip_uri_ref` (String) URI of an Elastic IP to associate with this CloudServer. Reference the `uri` attribute of an `arubacloud_elasticip` resource. Optional — omit to use a dynamic IP.
+- `elastic_ip_uri_ref` (String) URI of an Elastic IP to associate with this CloudServer. Reference the `uri` attribute of an `arubacloud_elasticip` resource. Optional — omit to use a dynamic IP. Changing this value forces a new resource.
 
 
 <a id="nestedatt--settings"></a>
@@ -95,7 +95,7 @@ Required:
 Optional:
 
 - `key_pair_uri_ref` (String) URI of the SSH key pair to inject at boot. Reference the `uri` attribute of an `arubacloud_keypair` resource.
-- `user_data` (String, Sensitive) Cloud-Init configuration passed verbatim to the instance at first boot (raw YAML or shell-script). Write-only — this value is sent to the API but is not returned in subsequent read responses.
+- `user_data` (String, Sensitive) Cloud-Init configuration passed verbatim to the instance at first boot (raw YAML or shell-script). Write-only — this value is sent to the API but is not returned in subsequent read responses. Changing this value forces a new resource.
 
 
 <a id="nestedatt--storage"></a>
@@ -103,7 +103,7 @@ Optional:
 
 Required:
 
-- `boot_volume_uri_ref` (String) URI of the bootable block storage volume. Reference the `uri` attribute of an `arubacloud_blockstorage` resource (must be bootable).
+- `boot_volume_uri_ref` (String) URI of the bootable block storage volume. Reference the `uri` attribute of an `arubacloud_blockstorage` resource (must be bootable). Changing this value forces a new resource.
 
 
 

--- a/internal/provider/cloudserver_resource.go
+++ b/internal/provider/cloudserver_resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -85,16 +86,25 @@ func (r *CloudServerResource) Schema(ctx context.Context, req resource.SchemaReq
 				Required:            true,
 			},
 			"location": schema.StringAttribute{
-				MarkdownDescription: "Region identifier for the resource (e.g., `ITBG-Bergamo`). See the [available locations and zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center).",
+				MarkdownDescription: "Region identifier for the resource (e.g., `ITBG-Bergamo`). See the [available locations and zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center). Changing this value forces a new resource.",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"project_id": schema.StringAttribute{
-				MarkdownDescription: "ID of the project that owns this resource.",
+				MarkdownDescription: "ID of the project that owns this resource. Changing this value forces a new resource.",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"zone": schema.StringAttribute{
-				MarkdownDescription: "Availability zone within the region (e.g., `ITBG-1`). See [available zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center).",
+				MarkdownDescription: "Availability zone within the region (e.g., `ITBG-1`). See [available zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center). Changing this value forces a new resource.",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"tags": schema.ListAttribute{
 				ElementType:         types.StringType,
@@ -106,28 +116,36 @@ func (r *CloudServerResource) Schema(ctx context.Context, req resource.SchemaReq
 				Required:            true,
 				Attributes: map[string]schema.Attribute{
 					"vpc_uri_ref": schema.StringAttribute{
-						MarkdownDescription: "URI of the VPC to attach this CloudServer to. Reference the `uri` attribute of an `arubacloud_vpc` resource.",
+						MarkdownDescription: "URI of the VPC to attach this CloudServer to. Reference the `uri` attribute of an `arubacloud_vpc` resource. Changing this value forces a new resource.",
 						Required:            true,
 						PlanModifiers: []planmodifier.String{
 							stringplanmodifier.UseStateForUnknown(),
+							stringplanmodifier.RequiresReplace(),
 						},
 					},
 					"elastic_ip_uri_ref": schema.StringAttribute{
-						MarkdownDescription: "URI of an Elastic IP to associate with this CloudServer. Reference the `uri` attribute of an `arubacloud_elasticip` resource. Optional — omit to use a dynamic IP.",
+						MarkdownDescription: "URI of an Elastic IP to associate with this CloudServer. Reference the `uri` attribute of an `arubacloud_elasticip` resource. Optional — omit to use a dynamic IP. Changing this value forces a new resource.",
 						Optional:            true,
 						PlanModifiers: []planmodifier.String{
 							stringplanmodifier.UseStateForUnknown(),
+							stringplanmodifier.RequiresReplace(),
 						},
 					},
 					"subnet_uri_refs": schema.ListAttribute{
 						ElementType:         types.StringType,
-						MarkdownDescription: "List of subnet URIs to attach this CloudServer to. Reference the `uri` attribute of each `arubacloud_subnet` resource.",
+						MarkdownDescription: "List of subnet URIs to attach this CloudServer to. Reference the `uri` attribute of each `arubacloud_subnet` resource. Changing this value forces a new resource.",
 						Required:            true,
+						PlanModifiers: []planmodifier.List{
+							listplanmodifier.RequiresReplace(),
+						},
 					},
 					"securitygroup_uri_refs": schema.ListAttribute{
 						ElementType:         types.StringType,
-						MarkdownDescription: "List of security group URIs to apply to this CloudServer. Reference the `uri` attribute of each `arubacloud_securitygroup` resource.",
+						MarkdownDescription: "List of security group URIs to apply to this CloudServer. Reference the `uri` attribute of each `arubacloud_securitygroup` resource. Changing this value forces a new resource.",
 						Required:            true,
+						PlanModifiers: []planmodifier.List{
+							listplanmodifier.RequiresReplace(),
+						},
 					},
 				},
 			},
@@ -147,9 +165,12 @@ func (r *CloudServerResource) Schema(ctx context.Context, req resource.SchemaReq
 						},
 					},
 					"user_data": schema.StringAttribute{
-						MarkdownDescription: "Cloud-Init configuration passed verbatim to the instance at first boot (raw YAML or shell-script). Write-only — this value is sent to the API but is not returned in subsequent read responses.",
+						MarkdownDescription: "Cloud-Init configuration passed verbatim to the instance at first boot (raw YAML or shell-script). Write-only — this value is sent to the API but is not returned in subsequent read responses. Changing this value forces a new resource.",
 						Optional:            true,
 						Sensitive:           true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.RequiresReplace(),
+						},
 					},
 				},
 			},
@@ -158,10 +179,11 @@ func (r *CloudServerResource) Schema(ctx context.Context, req resource.SchemaReq
 				Required:            true,
 				Attributes: map[string]schema.Attribute{
 					"boot_volume_uri_ref": schema.StringAttribute{
-						MarkdownDescription: "URI of the bootable block storage volume. Reference the `uri` attribute of an `arubacloud_blockstorage` resource (must be bootable).",
+						MarkdownDescription: "URI of the bootable block storage volume. Reference the `uri` attribute of an `arubacloud_blockstorage` resource (must be bootable). Changing this value forces a new resource.",
 						Required:            true,
 						PlanModifiers: []planmodifier.String{
 							stringplanmodifier.UseStateForUnknown(),
+							stringplanmodifier.RequiresReplace(),
 						},
 					},
 				},


### PR DESCRIPTION
## Summary

- Adds `stringplanmodifier.RequiresReplace()` to `location`, `project_id`, `zone`, `network.vpc_uri_ref`, `network.elastic_ip_uri_ref`, `settings.user_data`, and `storage.boot_volume_uri_ref`
- Adds `listplanmodifier.RequiresReplace()` to `network.subnet_uri_refs` and `network.securitygroup_uri_refs`
- Updates `MarkdownDescription` on each affected field with "Changing this value forces a new resource."

Previously, changes to these fields would produce a Terraform diff, the `Update()` would run without error, but the API was never told about the change — the state was saved with the new plan values, creating a false sense of success (TD-006).

## Test plan

- [ ] `go build ./...` passes ✅
- [ ] Change `location` in a `.tf` file → `terraform plan` shows the resource will be destroyed and recreated
- [ ] Same for `project_id`, `zone`, `vpc_uri_ref`, `subnet_uri_refs`, `securitygroup_uri_refs`, `elastic_ip_uri_ref`, `user_data`, `boot_volume_uri_ref`

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)