### PR TITLE
fix(tags): preserve null when user omits optional tags attribute (fixes #93)

### DIFF
--- a/internal/provider/backup_data_source.go
+++ b/internal/provider/backup_data_source.go
@@ -170,7 +170,7 @@ func (d *BackupDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		data.BillingPeriod = types.StringNull()
 	}
 
-	data.Tags = TagsToList(backup.Metadata.Tags)
+	data.Tags = TagsToListPreserveNull(backup.Metadata.Tags, data.Tags)
 
 	tflog.Trace(ctx, "read a Backup data source", map[string]interface{}{"backup_id": backupID})
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/backup_resource.go
+++ b/internal/provider/backup_resource.go
@@ -370,7 +370,7 @@ func (r *BackupResource) Read(ctx context.Context, req resource.ReadRequest, res
 			data.BillingPeriod = types.StringValue(*backup.Properties.BillingPeriod)
 		}
 
-		data.Tags = TagsToList(backup.Metadata.Tags)
+		data.Tags = TagsToListPreserveNull(backup.Metadata.Tags, data.Tags)
 	} else {
 		resp.State.RemoveResource(ctx)
 		return

--- a/internal/provider/blockstorage_data_source.go
+++ b/internal/provider/blockstorage_data_source.go
@@ -183,7 +183,7 @@ func (d *BlockStorageDataSource) Read(ctx context.Context, req datasource.ReadRe
 	data.BillingPeriod = types.StringNull()
 	data.SnapshotId = types.StringNull()
 
-	data.Tags = TagsToList(volume.Metadata.Tags)
+	data.Tags = TagsToListPreserveNull(volume.Metadata.Tags, data.Tags)
 
 	tflog.Trace(ctx, "read a Block Storage data source", map[string]interface{}{"volume_id": volumeID})
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/blockstorage_resource.go
+++ b/internal/provider/blockstorage_resource.go
@@ -450,7 +450,7 @@ func (r *BlockStorageResource) Read(ctx context.Context, req resource.ReadReques
 			data.Image = types.StringNull()
 		}
 
-		data.Tags = TagsToList(volume.Metadata.Tags)
+		data.Tags = TagsToListPreserveNull(volume.Metadata.Tags, data.Tags)
 	} else {
 		resp.State.RemoveResource(ctx)
 		return

--- a/internal/provider/cloudserver_data_source.go
+++ b/internal/provider/cloudserver_data_source.go
@@ -191,7 +191,7 @@ func (d *CloudServerDataSource) Read(ctx context.Context, req datasource.ReadReq
 	data.UserData = types.StringNull()
 	data.BootVolumeUriRef = types.StringNull()
 
-	data.Tags = TagsToList(server.Metadata.Tags)
+	data.Tags = TagsToListPreserveNull(server.Metadata.Tags, data.Tags)
 
 	tflog.Trace(ctx, "read a CloudServer data source", map[string]interface{}{"server_id": serverID})
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/cloudserver_resource.go
+++ b/internal/provider/cloudserver_resource.go
@@ -588,7 +588,7 @@ func (r *CloudServerResource) Read(ctx context.Context, req resource.ReadRequest
 
 	data.Zone = resolveAPIStringRef(server.Properties.Zone, originalState.Zone)
 
-	data.Tags = TagsToList(server.Metadata.Tags)
+	data.Tags = TagsToListPreserveNull(server.Metadata.Tags, data.Tags)
 
 	// VPC URI is returned by the API; map it directly to detect drift.
 	vpcUriRef := resolveAPIStringRef(server.Properties.VPC.URI, originalNetworkModel.VpcUriRef)
@@ -790,7 +790,7 @@ func (r *CloudServerResource) Update(ctx context.Context, req resource.UpdateReq
 		if response.Data.Metadata.Name != nil && *response.Data.Metadata.Name != "" {
 			data.Name = types.StringValue(*response.Data.Metadata.Name)
 		}
-		data.Tags = TagsToList(response.Data.Metadata.Tags)
+		data.Tags = TagsToListPreserveNull(response.Data.Metadata.Tags, data.Tags)
 	}
 
 	// Ensure immutable fields are set from state/plan before saving

--- a/internal/provider/containerregistry_data_source.go
+++ b/internal/provider/containerregistry_data_source.go
@@ -193,7 +193,7 @@ func (d *ContainerRegistryDataSource) Read(ctx context.Context, req datasource.R
 		data.ConcurrentUsersFlavor = types.StringNull()
 	}
 
-	data.Tags = TagsToList(registry.Metadata.Tags)
+	data.Tags = TagsToListPreserveNull(registry.Metadata.Tags, data.Tags)
 
 	tflog.Trace(ctx, "read a Container Registry data source", map[string]interface{}{"registry_id": registryID})
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/containerregistry_resource.go
+++ b/internal/provider/containerregistry_resource.go
@@ -550,7 +550,7 @@ func (r *ContainerRegistryResource) Read(ctx context.Context, req resource.ReadR
 			data.BillingPeriod = types.StringNull()
 		}
 
-		data.Tags = TagsToList(registry.Metadata.Tags)
+		data.Tags = TagsToListPreserveNull(registry.Metadata.Tags, data.Tags)
 	} else {
 		resp.State.RemoveResource(ctx)
 		return
@@ -878,7 +878,7 @@ func (r *ContainerRegistryResource) Update(ctx context.Context, req resource.Upd
 			data.BillingPeriod = types.StringNull()
 		}
 
-		data.Tags = TagsToList(registry.Metadata.Tags)
+		data.Tags = TagsToListPreserveNull(registry.Metadata.Tags, data.Tags)
 	} else {
 		// If re-read fails, preserve immutable fields from state
 		data.Uri = state.Uri

--- a/internal/provider/databasebackup_data_source.go
+++ b/internal/provider/databasebackup_data_source.go
@@ -152,7 +152,7 @@ func (d *DatabaseBackupDataSource) Read(ctx context.Context, req datasource.Read
 	data.DBaaSID = types.StringNull()
 	data.Database = types.StringNull()
 
-	data.Tags = TagsToList(backup.Metadata.Tags)
+	data.Tags = TagsToListPreserveNull(backup.Metadata.Tags, data.Tags)
 
 	tflog.Trace(ctx, "read a Database Backup data source", map[string]interface{}{"backup_id": backupID})
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/dbaas_data_source.go
+++ b/internal/provider/dbaas_data_source.go
@@ -224,7 +224,7 @@ func (d *DBaaSDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 	data.SecurityGroupUriRef = types.StringNull()
 	data.ElasticIpUriRef = types.StringNull()
 
-	data.Tags = TagsToList(dbaas.Metadata.Tags)
+	data.Tags = TagsToListPreserveNull(dbaas.Metadata.Tags, data.Tags)
 
 	tflog.Trace(ctx, "read a DBaaS data source", map[string]interface{}{"dbaas_id": dbaasID})
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/dbaas_resource.go
+++ b/internal/provider/dbaas_resource.go
@@ -704,7 +704,7 @@ func (r *DBaaSResource) Read(ctx context.Context, req resource.ReadRequest, resp
 			data.Network = networkObj
 		}
 
-		data.Tags = TagsToList(dbaas.Metadata.Tags)
+		data.Tags = TagsToListPreserveNull(dbaas.Metadata.Tags, data.Tags)
 	} else {
 		resp.State.RemoveResource(ctx)
 		return

--- a/internal/provider/elasticip_data_source.go
+++ b/internal/provider/elasticip_data_source.go
@@ -148,7 +148,7 @@ func (d *ElasticIPDataSource) Read(ctx context.Context, req datasource.ReadReque
 		data.BillingPeriod = types.StringNull()
 	}
 
-	data.Tags = TagsToList(eip.Metadata.Tags)
+	data.Tags = TagsToListPreserveNull(eip.Metadata.Tags, data.Tags)
 
 	tflog.Trace(ctx, "read an Elastic IP data source", map[string]interface{}{"eip_id": eipID})
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/elasticip_resource.go
+++ b/internal/provider/elasticip_resource.go
@@ -412,7 +412,7 @@ func (r *ElasticIPResource) Read(ctx context.Context, req resource.ReadRequest, 
 			data.BillingPeriod = types.StringValue("Hour")
 		}
 
-		data.Tags = TagsToList(eip.Metadata.Tags)
+		data.Tags = TagsToListPreserveNull(eip.Metadata.Tags, data.Tags)
 	} else {
 		resp.State.RemoveResource(ctx)
 		return

--- a/internal/provider/kaas_data_source.go
+++ b/internal/provider/kaas_data_source.go
@@ -354,7 +354,7 @@ func (d *KaaSDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		data.NodePools = types.ListValueMust(nodePoolType, []attr.Value{})
 	}
 
-	data.Tags = TagsToList(kaas.Metadata.Tags)
+	data.Tags = TagsToListPreserveNull(kaas.Metadata.Tags, data.Tags)
 
 	// Download kubeconfig (API returns base64-encoded content), when cluster has management IP
 	if kaas.Properties.ManagementIP != nil && *kaas.Properties.ManagementIP != "" {

--- a/internal/provider/kaas_resource.go
+++ b/internal/provider/kaas_resource.go
@@ -852,7 +852,7 @@ func (r *KaaSResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		}
 		data.Settings = settingsObj
 
-		data.Tags = TagsToList(kaas.Metadata.Tags)
+		data.Tags = TagsToListPreserveNull(kaas.Metadata.Tags, data.Tags)
 
 		// Refresh kubeconfig when cluster is available (e.g. has management IP or is active). API returns base64-encoded content.
 		if kaas.Properties.ManagementIP != nil && *kaas.Properties.ManagementIP != "" {
@@ -1312,7 +1312,7 @@ func (r *KaaSResource) Update(ctx context.Context, req resource.UpdateRequest, r
 			data.Settings = state.Settings // Fallback to state on error
 		}
 
-		data.Tags = TagsToList(kaas.Metadata.Tags)
+		data.Tags = TagsToListPreserveNull(kaas.Metadata.Tags, data.Tags)
 	} else {
 		// If re-read fails, preserve fields from state
 		data.Uri = state.Uri

--- a/internal/provider/keypair_data_source.go
+++ b/internal/provider/keypair_data_source.go
@@ -138,7 +138,7 @@ func (d *KeypairDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		data.Value = types.StringNull()
 	}
 
-	data.Tags = TagsToList(keypair.Metadata.Tags)
+	data.Tags = TagsToListPreserveNull(keypair.Metadata.Tags, data.Tags)
 
 	tflog.Trace(ctx, "read a Keypair data source", map[string]interface{}{"keypair_id": keypairID})
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/kms_resource.go
+++ b/internal/provider/kms_resource.go
@@ -343,7 +343,7 @@ func (r *KMSResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 		if kms.Metadata.LocationResponse != nil {
 			data.Location = types.StringValue(kms.Metadata.LocationResponse.Value)
 		}
-		data.Tags = TagsToList(kms.Metadata.Tags)
+		data.Tags = TagsToListPreserveNull(kms.Metadata.Tags, data.Tags)
 		if kms.Properties.BillingPeriod != "" {
 			data.BillingPeriod = types.StringValue(kms.Properties.BillingPeriod)
 		}

--- a/internal/provider/project_data_source.go
+++ b/internal/provider/project_data_source.go
@@ -111,7 +111,7 @@ func (d *ProjectDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		data.Description = types.StringNull()
 	}
 
-	data.Tags = TagsToList(project.Metadata.Tags)
+	data.Tags = TagsToListPreserveNull(project.Metadata.Tags, data.Tags)
 
 	tflog.Trace(ctx, "read project data source", map[string]interface{}{"project_id": projectID})
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/restore_resource.go
+++ b/internal/provider/restore_resource.go
@@ -357,7 +357,7 @@ func (r *RestoreResource) Read(ctx context.Context, req resource.ReadRequest, re
 		// VolumeID is stored from the create request, preserve from state if needed
 		// If Target is needed, check SDK for correct field name
 
-		data.Tags = TagsToList(restore.Metadata.Tags)
+		data.Tags = TagsToListPreserveNull(restore.Metadata.Tags, data.Tags)
 	} else {
 		resp.State.RemoveResource(ctx)
 		return

--- a/internal/provider/securitygroup_data_source.go
+++ b/internal/provider/securitygroup_data_source.go
@@ -125,7 +125,7 @@ func (d *SecurityGroupDataSource) Read(ctx context.Context, req datasource.ReadR
 	data.ProjectId = types.StringValue(projectID)
 	data.VpcId = types.StringValue(vpcID)
 
-	data.Tags = TagsToList(sg.Metadata.Tags)
+	data.Tags = TagsToListPreserveNull(sg.Metadata.Tags, data.Tags)
 
 	tflog.Trace(ctx, "read a Security Group data source", map[string]interface{}{"security_group_id": sgID})
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/securitygroup_resource.go
+++ b/internal/provider/securitygroup_resource.go
@@ -212,7 +212,7 @@ func (r *SecurityGroupResource) Create(ctx context.Context, req resource.CreateR
 		if getResp.Data.Metadata.LocationResponse != nil {
 			data.Location = types.StringValue(getResp.Data.Metadata.LocationResponse.Value)
 		}
-		data.Tags = TagsToList(getResp.Data.Metadata.Tags)
+		data.Tags = TagsToListPreserveNull(getResp.Data.Metadata.Tags, data.Tags)
 	} else if err != nil {
 		// If Get fails, log but don't fail - we already have the ID from create response
 		tflog.Warn(ctx, fmt.Sprintf("Failed to refresh Security Group after creation: %v", err))
@@ -332,7 +332,7 @@ func (r *SecurityGroupResource) Read(ctx context.Context, req resource.ReadReque
 			data.Location = types.StringValue(sg.Metadata.LocationResponse.Value)
 		}
 
-		data.Tags = TagsToList(sg.Metadata.Tags)
+		data.Tags = TagsToListPreserveNull(sg.Metadata.Tags, data.Tags)
 	} else {
 		resp.State.RemoveResource(ctx)
 		return

--- a/internal/provider/securityrule_data_source.go
+++ b/internal/provider/securityrule_data_source.go
@@ -182,7 +182,7 @@ func (d *SecurityRuleDataSource) Read(ctx context.Context, req datasource.ReadRe
 		data.TargetValue = types.StringNull()
 	}
 
-	data.Tags = TagsToList(rule.Metadata.Tags)
+	data.Tags = TagsToListPreserveNull(rule.Metadata.Tags, data.Tags)
 
 	tflog.Trace(ctx, "read a Security Rule data source", map[string]interface{}{"rule_id": ruleID})
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/snapshot_resource.go
+++ b/internal/provider/snapshot_resource.go
@@ -246,7 +246,7 @@ func (r *SnapshotResource) Create(ctx context.Context, req resource.CreateReques
 		if getResp.Data.Metadata.LocationResponse != nil {
 			data.Location = types.StringValue(getResp.Data.Metadata.LocationResponse.Value)
 		}
-		data.Tags = TagsToList(getResp.Data.Metadata.Tags)
+		data.Tags = TagsToListPreserveNull(getResp.Data.Metadata.Tags, data.Tags)
 	} else if err != nil {
 		// If Get fails, log but don't fail - we already have the ID from create response
 		tflog.Warn(ctx, fmt.Sprintf("Failed to refresh Snapshot after creation: %v", err))
@@ -546,7 +546,7 @@ func (r *SnapshotResource) Update(ctx context.Context, req resource.UpdateReques
 		} else {
 			data.Uri = state.Uri
 		}
-		data.Tags = TagsToList(response.Data.Metadata.Tags)
+		data.Tags = TagsToListPreserveNull(response.Data.Metadata.Tags, data.Tags)
 	} else {
 		// If no response, preserve URI and tags from state
 		data.Uri = state.Uri

--- a/internal/provider/subnet_data_source.go
+++ b/internal/provider/subnet_data_source.go
@@ -256,7 +256,7 @@ func (d *SubnetDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		data.Dns = types.ListValueMust(types.StringType, []attr.Value{})
 	}
 
-	data.Tags = TagsToList(subnet.Metadata.Tags)
+	data.Tags = TagsToListPreserveNull(subnet.Metadata.Tags, data.Tags)
 
 	tflog.Trace(ctx, "read a Subnet data source", map[string]interface{}{"subnet_id": subnetID})
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/subnet_resource.go
+++ b/internal/provider/subnet_resource.go
@@ -477,7 +477,7 @@ func (r *SubnetResource) Create(ctx context.Context, req resource.CreateRequest,
 		if getResp.Data.Metadata.LocationResponse != nil {
 			data.Location = types.StringValue(getResp.Data.Metadata.LocationResponse.Value)
 		}
-		data.Tags = TagsToList(getResp.Data.Metadata.Tags)
+		data.Tags = TagsToListPreserveNull(getResp.Data.Metadata.Tags, data.Tags)
 	} else if err != nil {
 		// If Get fails, log but don't fail - we already have the ID from create response
 		tflog.Warn(ctx, fmt.Sprintf("Failed to refresh Subnet after creation: %v", err))
@@ -769,7 +769,7 @@ func (r *SubnetResource) Read(ctx context.Context, req resource.ReadRequest, res
 			data.Network = types.ObjectNull(networkAttrTypes)
 		}
 
-		data.Tags = TagsToList(subnet.Metadata.Tags)
+		data.Tags = TagsToListPreserveNull(subnet.Metadata.Tags, data.Tags)
 	} else {
 		resp.State.RemoveResource(ctx)
 		return

--- a/internal/provider/tag_helpers.go
+++ b/internal/provider/tag_helpers.go
@@ -18,6 +18,18 @@ func TagsToList(tags []string) types.List {
 	return types.ListValueMust(types.StringType, values)
 }
 
+// TagsToListPreserveNull is like TagsToList but avoids a null→[] inconsistency
+// when the user omitted the optional tags attribute. If the API returns no tags
+// AND the prior state/plan value was null (user never set the attribute), null
+// is returned so Terraform does not flag a phantom diff. If the prior value was
+// an explicit list (empty or populated), the API value is used as-is.
+func TagsToListPreserveNull(tags []string, prior types.List) types.List {
+	if len(tags) == 0 && prior.IsNull() {
+		return types.ListNull(types.StringType)
+	}
+	return TagsToList(tags)
+}
+
 // ListToTags converts a types.List of strings from Terraform state into a
 // []string suitable for API requests. Null and unknown lists return nil without
 // appending any diagnostics.

--- a/internal/provider/tag_helpers_test.go
+++ b/internal/provider/tag_helpers_test.go
@@ -67,6 +67,94 @@ func TestTagsToList(t *testing.T) {
 	}
 }
 
+func TestTagsToListPreserveNull(t *testing.T) {
+	makeList := func(tags ...string) types.List {
+		vals := make([]attr.Value, len(tags))
+		for i, tag := range tags {
+			vals[i] = types.StringValue(tag)
+		}
+		return types.ListValueMust(types.StringType, vals)
+	}
+
+	cases := []struct {
+		name     string
+		apiTags  []string
+		prior    types.List
+		wantNull bool
+		wantLen  int
+		wantTags []string
+	}{
+		{
+			name:     "API empty + prior null → null (no phantom diff for omitted attribute)",
+			apiTags:  nil,
+			prior:    types.ListNull(types.StringType),
+			wantNull: true,
+		},
+		{
+			name:     "API empty slice + prior null → null",
+			apiTags:  []string{},
+			prior:    types.ListNull(types.StringType),
+			wantNull: true,
+		},
+		{
+			name:     "API empty + prior empty list → empty list (user set tags = [])",
+			apiTags:  nil,
+			prior:    makeList(),
+			wantNull: false,
+			wantLen:  0,
+			wantTags: []string{},
+		},
+		{
+			name:     "API empty + prior had tags → empty list (tags cleared)",
+			apiTags:  nil,
+			prior:    makeList("env:prod"),
+			wantNull: false,
+			wantLen:  0,
+			wantTags: []string{},
+		},
+		{
+			name:     "API has tags + prior null → list with tags",
+			apiTags:  []string{"env:prod"},
+			prior:    types.ListNull(types.StringType),
+			wantNull: false,
+			wantLen:  1,
+			wantTags: []string{"env:prod"},
+		},
+		{
+			name:     "API has tags + prior matches → list with tags",
+			apiTags:  []string{"env:prod", "team:platform"},
+			prior:    makeList("env:prod", "team:platform"),
+			wantNull: false,
+			wantLen:  2,
+			wantTags: []string{"env:prod", "team:platform"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := TagsToListPreserveNull(tc.apiTags, tc.prior)
+			if tc.wantNull {
+				if !got.IsNull() {
+					t.Fatalf("expected null list, got %v", got)
+				}
+				return
+			}
+			if got.IsNull() {
+				t.Fatal("expected non-null list, got null")
+			}
+			if len(got.Elements()) != tc.wantLen {
+				t.Fatalf("expected %d elements, got %d", tc.wantLen, len(got.Elements()))
+			}
+			var tags []string
+			got.ElementsAs(context.Background(), &tags, false)
+			for i, want := range tc.wantTags {
+				if tags[i] != want {
+					t.Errorf("element[%d]: got %q, want %q", i, tags[i], want)
+				}
+			}
+		})
+	}
+}
+
 func TestListToTags(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/provider/vpc_data_source.go
+++ b/internal/provider/vpc_data_source.go
@@ -118,7 +118,7 @@ func (d *VPCDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 	}
 	data.ProjectId = types.StringValue(projectID)
 
-	data.Tags = TagsToList(vpc.Metadata.Tags)
+	data.Tags = TagsToListPreserveNull(vpc.Metadata.Tags, data.Tags)
 
 	tflog.Trace(ctx, "read a VPC data source", map[string]interface{}{"vpc_id": vpcID})
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/vpc_resource.go
+++ b/internal/provider/vpc_resource.go
@@ -214,7 +214,7 @@ func (r *VPCResource) Create(ctx context.Context, req resource.CreateRequest, re
 		if getResp.Data.Metadata.LocationResponse != nil {
 			data.Location = types.StringValue(getResp.Data.Metadata.LocationResponse.Value)
 		}
-		data.Tags = TagsToList(getResp.Data.Metadata.Tags)
+		data.Tags = TagsToListPreserveNull(getResp.Data.Metadata.Tags, data.Tags)
 	} else if err != nil {
 		// If Get fails, log but don't fail - we already have the ID from create response
 		tflog.Warn(ctx, fmt.Sprintf("Failed to refresh VPC after creation: %v", err))
@@ -333,7 +333,7 @@ func (r *VPCResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 			data.Location = types.StringValue(vpc.Metadata.LocationResponse.Value)
 		}
 
-		data.Tags = TagsToList(vpc.Metadata.Tags)
+		data.Tags = TagsToListPreserveNull(vpc.Metadata.Tags, data.Tags)
 	} else {
 		resp.State.RemoveResource(ctx)
 		return

--- a/internal/provider/vpcpeering_resource.go
+++ b/internal/provider/vpcpeering_resource.go
@@ -313,7 +313,7 @@ func (r *VpcPeeringResource) Read(ctx context.Context, req resource.ReadRequest,
 			data.PeerVpc = types.StringValue(peering.Properties.RemoteVPC.URI)
 		}
 
-		data.Tags = TagsToList(peering.Metadata.Tags)
+		data.Tags = TagsToListPreserveNull(peering.Metadata.Tags, data.Tags)
 	} else {
 		resp.State.RemoveResource(ctx)
 		return

--- a/internal/provider/vpcpeeringroute_resource.go
+++ b/internal/provider/vpcpeeringroute_resource.go
@@ -317,7 +317,7 @@ func (r *VpcPeeringRouteResource) Read(ctx context.Context, req resource.ReadReq
 			data.BillingPeriod = types.StringValue(route.Properties.BillingPlan.BillingPeriod)
 		}
 
-		data.Tags = TagsToList(route.Metadata.Tags)
+		data.Tags = TagsToListPreserveNull(route.Metadata.Tags, data.Tags)
 	} else {
 		resp.State.RemoveResource(ctx)
 		return

--- a/internal/provider/vpnroute_resource.go
+++ b/internal/provider/vpnroute_resource.go
@@ -350,7 +350,7 @@ func (r *VPNRouteResource) Read(ctx context.Context, req resource.ReadRequest, r
 			data.Properties = propertiesObj
 		}
 
-		data.Tags = TagsToList(route.Metadata.Tags)
+		data.Tags = TagsToListPreserveNull(route.Metadata.Tags, data.Tags)
 	} else {
 		resp.State.RemoveResource(ctx)
 		return

--- a/internal/provider/vpntunnel_resource.go
+++ b/internal/provider/vpntunnel_resource.go
@@ -713,7 +713,7 @@ func (r *VPNTunnelResource) Read(ctx context.Context, req resource.ReadRequest, 
 			data.Location = types.StringValue(tunnel.Metadata.LocationResponse.Value)
 		}
 
-		data.Tags = TagsToList(tunnel.Metadata.Tags)
+		data.Tags = TagsToListPreserveNull(tunnel.Metadata.Tags, data.Tags)
 
 		// Note: Properties are complex nested structures - for now, we preserve the existing state
 		// A full implementation would reconstruct the properties object from the API response


### PR DESCRIPTION
## Summary

- Fixes `Provider produced inconsistent result after apply` / `.tags: was null, but now cty.ListValEmpty(cty.String)` when a resource is defined without the optional `tags` attribute
- Adds `TagsToListPreserveNull(apiTags, prior)` helper to `tag_helpers.go`
- Replaces all 38 `data.Tags = TagsToList(...)` call sites across 26 resource and data-source files

## Root cause

`TagsToList` always converts nil/empty API responses to an empty list `[]`.
In every resource `Read()` and `Create()`, `data.Tags` is overwritten with this empty list, but the Terraform plan held `null` (user omitted the attribute). Terraform rejects the `null → []` inconsistency.

## Fix

New helper `TagsToListPreserveNull(apiTags []string, prior types.List) types.List`:
- API returned no tags **AND** prior was `null` → returns `null` (no phantom diff)
- API returned no tags **AND** prior was explicit list → returns `[]` (reflects reality)
- API returned tags → returns the tag list (normal path)

All Read() and Create() call sites now pass `data.Tags` as the prior value — at that point it holds the state or plan value loaded earlier in the same function.

## Test plan

- [x] 6 new table-driven unit tests covering every branch of `TagsToListPreserveNull`
- [x] `go build ./...` passes
- [x] `go test ./internal/provider/...` passes (all unit tests)
- [x] `golangci-lint` — 0 issues
- [x] Manual: `terraform apply` on a resource without `tags` no longer errors

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)