### PR TITLE
test: add CheckDestroy to all acceptance tests

### DIFF
--- a/internal/provider/backup_resource_test.go
+++ b/internal/provider/backup_resource_test.go
@@ -1,12 +1,14 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -14,6 +16,7 @@ func TestAccBackupResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckBackupDestroyed,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
@@ -82,6 +85,7 @@ func TestAccBackupResource_WithTags(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckBackupDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBackupResourceConfigWithTags("test-backup-tags", "ITBG-Bergamo"),
@@ -100,6 +104,31 @@ func TestAccBackupResource_WithTags(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testCheckBackupDestroyed(s *terraform.State) error {
+	client, err := testAccClient()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "arubacloud_backup" {
+			continue
+		}
+		resp, err := client.Client.FromStorage().Backups().Get(ctx, rs.Primary.Attributes["project_id"], rs.Primary.ID, nil)
+		if err != nil {
+			return nil
+		}
+		if apiErr := CheckResponse("get", "Backup", resp); apiErr != nil {
+			if IsNotFound(apiErr) {
+				continue
+			}
+			return apiErr
+		}
+		return fmt.Errorf("Backup %s still exists", rs.Primary.ID)
+	}
+	return nil
 }
 
 func testAccBackupResourceConfig(name, location, backupType string, retentionDays int) string {

--- a/internal/provider/backup_resource_test.go
+++ b/internal/provider/backup_resource_test.go
@@ -118,7 +118,7 @@ func testCheckBackupDestroyed(s *terraform.State) error {
 		}
 		resp, err := client.Client.FromStorage().Backups().Get(ctx, rs.Primary.Attributes["project_id"], rs.Primary.ID, nil)
 		if err != nil {
-			return nil
+			return err
 		}
 		if apiErr := CheckResponse("get", "Backup", resp); apiErr != nil {
 			if IsNotFound(apiErr) {

--- a/internal/provider/blockstorage_resource_test.go
+++ b/internal/provider/blockstorage_resource_test.go
@@ -127,7 +127,7 @@ func testCheckBlockstorageDestroyed(s *terraform.State) error {
 		}
 		resp, err := client.Client.FromStorage().Volumes().Get(ctx, rs.Primary.Attributes["project_id"], rs.Primary.ID, nil)
 		if err != nil {
-			return nil
+			return err
 		}
 		if apiErr := CheckResponse("get", "Blockstorage", resp); apiErr != nil {
 			if IsNotFound(apiErr) {

--- a/internal/provider/blockstorage_resource_test.go
+++ b/internal/provider/blockstorage_resource_test.go
@@ -1,12 +1,14 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -14,6 +16,7 @@ func TestAccBlockStorageResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckBlockstorageDestroyed,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
@@ -78,7 +81,6 @@ func TestAccBlockStorageResource(t *testing.T) {
 					),
 				},
 			},
-			// Delete testing automatically occurs in TestCase
 		},
 	})
 }
@@ -87,6 +89,7 @@ func TestAccBlockStorageResource_Bootable(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckBlockstorageDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBlockStorageResourceConfigBootable("test-bootable", 50),
@@ -110,6 +113,31 @@ func TestAccBlockStorageResource_Bootable(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testCheckBlockstorageDestroyed(s *terraform.State) error {
+	client, err := testAccClient()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "arubacloud_blockstorage" {
+			continue
+		}
+		resp, err := client.Client.FromStorage().Volumes().Get(ctx, rs.Primary.Attributes["project_id"], rs.Primary.ID, nil)
+		if err != nil {
+			return nil
+		}
+		if apiErr := CheckResponse("get", "Blockstorage", resp); apiErr != nil {
+			if IsNotFound(apiErr) {
+				continue
+			}
+			return apiErr
+		}
+		return fmt.Errorf("BlockStorage volume %s still exists", rs.Primary.ID)
+	}
+	return nil
 }
 
 func testAccBlockStorageResourceConfig(name string, sizeGB int, storageType string) string {

--- a/internal/provider/cloudserver_resource_test.go
+++ b/internal/provider/cloudserver_resource_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -8,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -15,6 +17,7 @@ func TestAccCloudserverResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckCloudserverDestroyed,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
@@ -61,6 +64,31 @@ func TestAccCloudserverResource(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testCheckCloudserverDestroyed(s *terraform.State) error {
+	client, err := testAccClient()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "arubacloud_cloudserver" {
+			continue
+		}
+		resp, err := client.Client.FromCompute().CloudServers().Get(ctx, rs.Primary.Attributes["project_id"], rs.Primary.ID, nil)
+		if err != nil {
+			return nil
+		}
+		if apiErr := CheckResponse("get", "Cloudserver", resp); apiErr != nil {
+			if IsNotFound(apiErr) {
+				continue
+			}
+			return apiErr
+		}
+		return fmt.Errorf("CloudServer %s still exists", rs.Primary.ID)
+	}
+	return nil
 }
 
 func TestResolveAPIStringRef(t *testing.T) {

--- a/internal/provider/cloudserver_resource_test.go
+++ b/internal/provider/cloudserver_resource_test.go
@@ -78,7 +78,7 @@ func testCheckCloudserverDestroyed(s *terraform.State) error {
 		}
 		resp, err := client.Client.FromCompute().CloudServers().Get(ctx, rs.Primary.Attributes["project_id"], rs.Primary.ID, nil)
 		if err != nil {
-			return nil
+			return err
 		}
 		if apiErr := CheckResponse("get", "Cloudserver", resp); apiErr != nil {
 			if IsNotFound(apiErr) {

--- a/internal/provider/containerregistry_resource_test.go
+++ b/internal/provider/containerregistry_resource_test.go
@@ -72,7 +72,7 @@ func testCheckContainerregistryDestroyed(s *terraform.State) error {
 		}
 		resp, err := client.Client.FromContainer().ContainerRegistry().Get(ctx, rs.Primary.Attributes["project_id"], rs.Primary.ID, nil)
 		if err != nil {
-			return nil
+			return err
 		}
 		if apiErr := CheckResponse("get", "Containerregistry", resp); apiErr != nil {
 			if IsNotFound(apiErr) {

--- a/internal/provider/containerregistry_resource_test.go
+++ b/internal/provider/containerregistry_resource_test.go
@@ -1,12 +1,14 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -14,6 +16,7 @@ func TestAccContainerregistryResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckContainerregistryDestroyed,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
@@ -57,6 +60,31 @@ func TestAccContainerregistryResource(t *testing.T) {
 	})
 }
 
+func testCheckContainerregistryDestroyed(s *terraform.State) error {
+	client, err := testAccClient()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "arubacloud_containerregistry" {
+			continue
+		}
+		resp, err := client.Client.FromContainer().ContainerRegistry().Get(ctx, rs.Primary.Attributes["project_id"], rs.Primary.ID, nil)
+		if err != nil {
+			return nil
+		}
+		if apiErr := CheckResponse("get", "Containerregistry", resp); apiErr != nil {
+			if IsNotFound(apiErr) {
+				continue
+			}
+			return apiErr
+		}
+		return fmt.Errorf("ContainerRegistry %s still exists", rs.Primary.ID)
+	}
+	return nil
+}
+
 func testAccContainerregistryResourceConfig(name string) string {
 	return fmt.Sprintf(`
 resource "arubacloud_containerregistry" "test" {
@@ -64,18 +92,18 @@ resource "arubacloud_containerregistry" "test" {
   location       = "it-1"
   project_id     = "test-project-id"
   billing_period = "Hour"
-  
+
   network = {
     vpc_uri_ref              = "test-vpc-uri"
     subnet_uri_ref           = "test-subnet-uri"
     security_group_uri_ref   = "test-sg-uri"
     public_ip_uri_ref        = "test-eip-uri"
   }
-  
+
   storage = {
     block_storage_uri_ref = "test-storage-uri"
   }
-  
+
   settings = {
     admin_user               = "admin"
     concurrent_users_flavor  = "small"

--- a/internal/provider/database_resource_test.go
+++ b/internal/provider/database_resource_test.go
@@ -73,7 +73,7 @@ func testCheckDatabaseDestroyed(s *terraform.State) error {
 		dbaasID := rs.Primary.Attributes["dbaas_id"]
 		resp, err := client.Client.FromDatabase().Databases().Get(ctx, rs.Primary.Attributes["project_id"], dbaasID, rs.Primary.ID, nil)
 		if err != nil {
-			return nil
+			return err
 		}
 		if apiErr := CheckResponse("get", "Database", resp); apiErr != nil {
 			if IsNotFound(apiErr) {

--- a/internal/provider/database_resource_test.go
+++ b/internal/provider/database_resource_test.go
@@ -1,12 +1,14 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -14,6 +16,7 @@ func TestAccDatabaseResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckDatabaseDestroyed,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
@@ -55,6 +58,32 @@ func TestAccDatabaseResource(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testCheckDatabaseDestroyed(s *terraform.State) error {
+	client, err := testAccClient()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "arubacloud_database" {
+			continue
+		}
+		dbaasID := rs.Primary.Attributes["dbaas_id"]
+		resp, err := client.Client.FromDatabase().Databases().Get(ctx, rs.Primary.Attributes["project_id"], dbaasID, rs.Primary.ID, nil)
+		if err != nil {
+			return nil
+		}
+		if apiErr := CheckResponse("get", "Database", resp); apiErr != nil {
+			if IsNotFound(apiErr) {
+				continue
+			}
+			return apiErr
+		}
+		return fmt.Errorf("Database %s still exists", rs.Primary.ID)
+	}
+	return nil
 }
 
 func testAccDatabaseResourceConfig(name string) string {

--- a/internal/provider/databasebackup_resource_test.go
+++ b/internal/provider/databasebackup_resource_test.go
@@ -72,7 +72,7 @@ func testCheckDatabasebackupDestroyed(s *terraform.State) error {
 		}
 		resp, err := client.Client.FromDatabase().Backups().Get(ctx, rs.Primary.Attributes["project_id"], rs.Primary.ID, nil)
 		if err != nil {
-			return nil
+			return err
 		}
 		if apiErr := CheckResponse("get", "Databasebackup", resp); apiErr != nil {
 			if IsNotFound(apiErr) {

--- a/internal/provider/databasebackup_resource_test.go
+++ b/internal/provider/databasebackup_resource_test.go
@@ -1,12 +1,14 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -14,6 +16,7 @@ func TestAccDatabasebackupResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckDatabasebackupDestroyed,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
@@ -55,6 +58,31 @@ func TestAccDatabasebackupResource(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testCheckDatabasebackupDestroyed(s *terraform.State) error {
+	client, err := testAccClient()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "arubacloud_databasebackup" {
+			continue
+		}
+		resp, err := client.Client.FromDatabase().Backups().Get(ctx, rs.Primary.Attributes["project_id"], rs.Primary.ID, nil)
+		if err != nil {
+			return nil
+		}
+		if apiErr := CheckResponse("get", "Databasebackup", resp); apiErr != nil {
+			if IsNotFound(apiErr) {
+				continue
+			}
+			return apiErr
+		}
+		return fmt.Errorf("DatabaseBackup %s still exists", rs.Primary.ID)
+	}
+	return nil
 }
 
 func testAccDatabasebackupResourceConfig(name string) string {

--- a/internal/provider/databasegrant_resource_test.go
+++ b/internal/provider/databasegrant_resource_test.go
@@ -75,7 +75,7 @@ func testCheckDatabasegrantDestroyed(s *terraform.State) error {
 		userID := rs.Primary.Attributes["user_id"]
 		resp, err := client.Client.FromDatabase().Grants().Get(ctx, rs.Primary.Attributes["project_id"], dbaasID, database, userID, nil)
 		if err != nil {
-			return nil
+			return err
 		}
 		if apiErr := CheckResponse("get", "Databasegrant", resp); apiErr != nil {
 			if IsNotFound(apiErr) {

--- a/internal/provider/databasegrant_resource_test.go
+++ b/internal/provider/databasegrant_resource_test.go
@@ -1,12 +1,14 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -14,6 +16,7 @@ func TestAccDatabasegrantResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckDatabasegrantDestroyed,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
@@ -55,6 +58,34 @@ func TestAccDatabasegrantResource(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testCheckDatabasegrantDestroyed(s *terraform.State) error {
+	client, err := testAccClient()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "arubacloud_databasegrant" {
+			continue
+		}
+		dbaasID := rs.Primary.Attributes["dbaas_id"]
+		database := rs.Primary.Attributes["database"]
+		userID := rs.Primary.Attributes["user_id"]
+		resp, err := client.Client.FromDatabase().Grants().Get(ctx, rs.Primary.Attributes["project_id"], dbaasID, database, userID, nil)
+		if err != nil {
+			return nil
+		}
+		if apiErr := CheckResponse("get", "Databasegrant", resp); apiErr != nil {
+			if IsNotFound(apiErr) {
+				continue
+			}
+			return apiErr
+		}
+		return fmt.Errorf("DatabaseGrant %s still exists", rs.Primary.ID)
+	}
+	return nil
 }
 
 func testAccDatabasegrantResourceConfig(name string) string {

--- a/internal/provider/dbaas_resource_test.go
+++ b/internal/provider/dbaas_resource_test.go
@@ -1,12 +1,14 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -14,6 +16,7 @@ func TestAccDbaasResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckDbaasDestroyed,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
@@ -57,6 +60,31 @@ func TestAccDbaasResource(t *testing.T) {
 	})
 }
 
+func testCheckDbaasDestroyed(s *terraform.State) error {
+	client, err := testAccClient()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "arubacloud_dbaas" {
+			continue
+		}
+		resp, err := client.Client.FromDatabase().DBaaS().Get(ctx, rs.Primary.Attributes["project_id"], rs.Primary.ID, nil)
+		if err != nil {
+			return nil
+		}
+		if apiErr := CheckResponse("get", "Dbaas", resp); apiErr != nil {
+			if IsNotFound(apiErr) {
+				continue
+			}
+			return apiErr
+		}
+		return fmt.Errorf("DBaaS %s still exists", rs.Primary.ID)
+	}
+	return nil
+}
+
 func testAccDbaasResourceConfig(name string) string {
 	return fmt.Sprintf(`
 resource "arubacloud_dbaas" "test" {
@@ -66,11 +94,11 @@ resource "arubacloud_dbaas" "test" {
   project_id = "test-project-id"
   engine_id  = "mysql-8.0"
   flavor     = "DBO2A4"
-  
+
   storage = {
     size_gb = 20
   }
-  
+
   network = {
     vpc_uri_ref            = "test-vpc-uri"
     subnet_uri_ref         = "test-subnet-uri"

--- a/internal/provider/dbaas_resource_test.go
+++ b/internal/provider/dbaas_resource_test.go
@@ -72,7 +72,7 @@ func testCheckDbaasDestroyed(s *terraform.State) error {
 		}
 		resp, err := client.Client.FromDatabase().DBaaS().Get(ctx, rs.Primary.Attributes["project_id"], rs.Primary.ID, nil)
 		if err != nil {
-			return nil
+			return err
 		}
 		if apiErr := CheckResponse("get", "Dbaas", resp); apiErr != nil {
 			if IsNotFound(apiErr) {

--- a/internal/provider/dbaasuser_resource_test.go
+++ b/internal/provider/dbaasuser_resource_test.go
@@ -1,12 +1,14 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -14,6 +16,7 @@ func TestAccDbaasuserResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckDbaasuserDestroyed,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
@@ -55,6 +58,32 @@ func TestAccDbaasuserResource(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testCheckDbaasuserDestroyed(s *terraform.State) error {
+	client, err := testAccClient()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "arubacloud_dbaasuser" {
+			continue
+		}
+		dbaasID := rs.Primary.Attributes["dbaas_id"]
+		resp, err := client.Client.FromDatabase().Users().Get(ctx, rs.Primary.Attributes["project_id"], dbaasID, rs.Primary.ID, nil)
+		if err != nil {
+			return nil
+		}
+		if apiErr := CheckResponse("get", "Dbaasuser", resp); apiErr != nil {
+			if IsNotFound(apiErr) {
+				continue
+			}
+			return apiErr
+		}
+		return fmt.Errorf("DBaaSUser %s still exists", rs.Primary.ID)
+	}
+	return nil
 }
 
 func testAccDbaasuserResourceConfig(name string) string {

--- a/internal/provider/dbaasuser_resource_test.go
+++ b/internal/provider/dbaasuser_resource_test.go
@@ -73,7 +73,7 @@ func testCheckDbaasuserDestroyed(s *terraform.State) error {
 		dbaasID := rs.Primary.Attributes["dbaas_id"]
 		resp, err := client.Client.FromDatabase().Users().Get(ctx, rs.Primary.Attributes["project_id"], dbaasID, rs.Primary.ID, nil)
 		if err != nil {
-			return nil
+			return err
 		}
 		if apiErr := CheckResponse("get", "Dbaasuser", resp); apiErr != nil {
 			if IsNotFound(apiErr) {

--- a/internal/provider/elasticip_resource_test.go
+++ b/internal/provider/elasticip_resource_test.go
@@ -72,7 +72,7 @@ func testCheckElasticipDestroyed(s *terraform.State) error {
 		}
 		resp, err := client.Client.FromNetwork().ElasticIPs().Get(ctx, rs.Primary.Attributes["project_id"], rs.Primary.ID, nil)
 		if err != nil {
-			return nil
+			return err
 		}
 		if apiErr := CheckResponse("get", "Elasticip", resp); apiErr != nil {
 			if IsNotFound(apiErr) {

--- a/internal/provider/elasticip_resource_test.go
+++ b/internal/provider/elasticip_resource_test.go
@@ -1,12 +1,14 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -14,6 +16,7 @@ func TestAccElasticipResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckElasticipDestroyed,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
@@ -55,6 +58,31 @@ func TestAccElasticipResource(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testCheckElasticipDestroyed(s *terraform.State) error {
+	client, err := testAccClient()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "arubacloud_elasticip" {
+			continue
+		}
+		resp, err := client.Client.FromNetwork().ElasticIPs().Get(ctx, rs.Primary.Attributes["project_id"], rs.Primary.ID, nil)
+		if err != nil {
+			return nil
+		}
+		if apiErr := CheckResponse("get", "Elasticip", resp); apiErr != nil {
+			if IsNotFound(apiErr) {
+				continue
+			}
+			return apiErr
+		}
+		return fmt.Errorf("ElasticIP %s still exists", rs.Primary.ID)
+	}
+	return nil
 }
 
 func testAccElasticipResourceConfig(name string) string {

--- a/internal/provider/kaas_resource_test.go
+++ b/internal/provider/kaas_resource_test.go
@@ -72,7 +72,7 @@ func testCheckKaasDestroyed(s *terraform.State) error {
 		}
 		resp, err := client.Client.FromContainer().KaaS().Get(ctx, rs.Primary.Attributes["project_id"], rs.Primary.ID, nil)
 		if err != nil {
-			return nil
+			return err
 		}
 		if apiErr := CheckResponse("get", "Kaas", resp); apiErr != nil {
 			if IsNotFound(apiErr) {

--- a/internal/provider/kaas_resource_test.go
+++ b/internal/provider/kaas_resource_test.go
@@ -1,12 +1,14 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -14,6 +16,7 @@ func TestAccKaasResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckKaasDestroyed,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
@@ -57,6 +60,31 @@ func TestAccKaasResource(t *testing.T) {
 	})
 }
 
+func testCheckKaasDestroyed(s *terraform.State) error {
+	client, err := testAccClient()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "arubacloud_kaas" {
+			continue
+		}
+		resp, err := client.Client.FromContainer().KaaS().Get(ctx, rs.Primary.Attributes["project_id"], rs.Primary.ID, nil)
+		if err != nil {
+			return nil
+		}
+		if apiErr := CheckResponse("get", "Kaas", resp); apiErr != nil {
+			if IsNotFound(apiErr) {
+				continue
+			}
+			return apiErr
+		}
+		return fmt.Errorf("KaaS %s still exists", rs.Primary.ID)
+	}
+	return nil
+}
+
 func testAccKaasResourceConfig(name string) string {
 	return fmt.Sprintf(`
 resource "arubacloud_kaas" "test" {
@@ -64,7 +92,7 @@ resource "arubacloud_kaas" "test" {
   location       = "it-1"
   project_id     = "test-project-id"
   billing_period = "Hour"
-  
+
   network = {
     vpc_uri_ref         = "test-vpc-uri"
     subnet_uri_ref      = "test-subnet-uri"
@@ -74,7 +102,7 @@ resource "arubacloud_kaas" "test" {
       name    = "node-cidr"
     }
   }
-  
+
   settings = {
     kubernetes_version = "1.28"
     ha                 = false

--- a/internal/provider/keypair_resource_test.go
+++ b/internal/provider/keypair_resource_test.go
@@ -67,7 +67,7 @@ func testCheckKeypairDestroyed(s *terraform.State) error {
 		}
 		resp, err := client.Client.FromCompute().KeyPairs().Get(ctx, rs.Primary.Attributes["project_id"], rs.Primary.ID, nil)
 		if err != nil {
-			return nil
+			return err
 		}
 		if apiErr := CheckResponse("get", "Keypair", resp); apiErr != nil {
 			if IsNotFound(apiErr) {

--- a/internal/provider/keypair_resource_test.go
+++ b/internal/provider/keypair_resource_test.go
@@ -1,12 +1,14 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -14,6 +16,7 @@ func TestAccKeypairResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckKeypairDestroyed,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
@@ -50,6 +53,31 @@ func TestAccKeypairResource(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testCheckKeypairDestroyed(s *terraform.State) error {
+	client, err := testAccClient()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "arubacloud_keypair" {
+			continue
+		}
+		resp, err := client.Client.FromCompute().KeyPairs().Get(ctx, rs.Primary.Attributes["project_id"], rs.Primary.ID, nil)
+		if err != nil {
+			return nil
+		}
+		if apiErr := CheckResponse("get", "Keypair", resp); apiErr != nil {
+			if IsNotFound(apiErr) {
+				continue
+			}
+			return apiErr
+		}
+		return fmt.Errorf("Keypair %s still exists", rs.Primary.ID)
+	}
+	return nil
 }
 
 func testAccKeypairResourceConfig(name string) string {

--- a/internal/provider/kms_resource_test.go
+++ b/internal/provider/kms_resource_test.go
@@ -49,7 +49,7 @@ func testCheckKmsDestroyed(s *terraform.State) error {
 		}
 		resp, err := client.Client.FromSecurity().KMS().Get(ctx, rs.Primary.Attributes["project_id"], rs.Primary.ID, nil)
 		if err != nil {
-			return nil
+			return err
 		}
 		if apiErr := CheckResponse("get", "Kms", resp); apiErr != nil {
 			if IsNotFound(apiErr) {

--- a/internal/provider/kms_resource_test.go
+++ b/internal/provider/kms_resource_test.go
@@ -1,12 +1,14 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -14,47 +16,50 @@ func TestAccKmsResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckKmsDestroyed,
 		Steps: []resource.TestStep{
-			// Create and Read testing
 			{
 				Config: testAccKmsResourceConfig("test-kms"),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(
-						"arubacloud_kms.test",
-						tfjsonpath.New("name"),
-						knownvalue.StringExact("test-kms"),
-					),
-					statecheck.ExpectKnownValue(
-						"arubacloud_kms.test",
-						tfjsonpath.New("id"),
-						knownvalue.NotNull(),
-					),
-					statecheck.ExpectKnownValue(
-						"arubacloud_kms.test",
-						tfjsonpath.New("location"),
-						knownvalue.NotNull(),
-					),
+					statecheck.ExpectKnownValue("arubacloud_kms.test", tfjsonpath.New("name"), knownvalue.StringExact("test-kms")),
+					statecheck.ExpectKnownValue("arubacloud_kms.test", tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue("arubacloud_kms.test", tfjsonpath.New("location"), knownvalue.NotNull()),
 				},
 			},
-			// ImportState testing
-			{
-				ResourceName:      "arubacloud_kms.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			// Update and Read testing
+			{ResourceName: "arubacloud_kms.test", ImportState: true, ImportStateVerify: true},
 			{
 				Config: testAccKmsResourceConfig("test-kms-updated"),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(
-						"arubacloud_kms.test",
-						tfjsonpath.New("name"),
-						knownvalue.StringExact("test-kms-updated"),
-					),
+					statecheck.ExpectKnownValue("arubacloud_kms.test", tfjsonpath.New("name"), knownvalue.StringExact("test-kms-updated")),
 				},
 			},
 		},
 	})
+}
+
+func testCheckKmsDestroyed(s *terraform.State) error {
+	client, err := testAccClient()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "arubacloud_kms" {
+			continue
+		}
+		resp, err := client.Client.FromSecurity().KMS().Get(ctx, rs.Primary.Attributes["project_id"], rs.Primary.ID, nil)
+		if err != nil {
+			return nil
+		}
+		if apiErr := CheckResponse("get", "Kms", resp); apiErr != nil {
+			if IsNotFound(apiErr) {
+				continue
+			}
+			return apiErr
+		}
+		return fmt.Errorf("KMS key %s still exists", rs.Primary.ID)
+	}
+	return nil
 }
 
 func testAccKmsResourceConfig(name string) string {

--- a/internal/provider/project_resource_test.go
+++ b/internal/provider/project_resource_test.go
@@ -1,12 +1,14 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -16,6 +18,7 @@ func TestAccProjectResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckProjectDestroyed,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
@@ -52,6 +55,31 @@ func TestAccProjectResource(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testCheckProjectDestroyed(s *terraform.State) error {
+	client, err := testAccClient()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "arubacloud_project" {
+			continue
+		}
+		resp, err := client.Client.FromProject().Get(ctx, rs.Primary.ID, nil)
+		if err != nil {
+			return nil
+		}
+		if apiErr := CheckResponse("get", "Project", resp); apiErr != nil {
+			if IsNotFound(apiErr) {
+				continue
+			}
+			return apiErr
+		}
+		return fmt.Errorf("Project %s still exists", rs.Primary.ID)
+	}
+	return nil
 }
 
 func testAccProjectResourceConfig(name string) string {

--- a/internal/provider/project_resource_test.go
+++ b/internal/provider/project_resource_test.go
@@ -69,7 +69,7 @@ func testCheckProjectDestroyed(s *terraform.State) error {
 		}
 		resp, err := client.Client.FromProject().Get(ctx, rs.Primary.ID, nil)
 		if err != nil {
-			return nil
+			return err
 		}
 		if apiErr := CheckResponse("get", "Project", resp); apiErr != nil {
 			if IsNotFound(apiErr) {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,9 +1,12 @@
 package provider
 
 import (
+	"fmt"
 	"os"
 	"testing"
+	"time"
 
+	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
@@ -22,4 +25,21 @@ func testAccPreCheck(t *testing.T) {
 			t.Fatalf("acceptance tests require %s to be set", env)
 		}
 	}
+}
+
+// testAccClient builds an ArubaCloudClient from env vars for use in CheckDestroy functions.
+func testAccClient() (*ArubaCloudClient, error) {
+	apiKey := os.Getenv("ARUBACLOUD_API_KEY")
+	apiSecret := os.Getenv("ARUBACLOUD_API_SECRET")
+	if apiKey == "" || apiSecret == "" {
+		return nil, fmt.Errorf("ARUBACLOUD_API_KEY and ARUBACLOUD_API_SECRET must be set")
+	}
+	sdkClient, err := aruba.NewClient(aruba.DefaultOptions(apiKey, apiSecret))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create test client: %w", err)
+	}
+	return &ArubaCloudClient{
+		Client:          sdkClient,
+		ResourceTimeout: 10 * time.Minute,
+	}, nil
 }

--- a/internal/provider/restore_resource_test.go
+++ b/internal/provider/restore_resource_test.go
@@ -73,7 +73,7 @@ func testCheckRestoreDestroyed(s *terraform.State) error {
 		backupID := rs.Primary.Attributes["backup_id"]
 		resp, err := client.Client.FromStorage().Restores().Get(ctx, rs.Primary.Attributes["project_id"], backupID, rs.Primary.ID, nil)
 		if err != nil {
-			return nil
+			return err
 		}
 		if apiErr := CheckResponse("get", "Restore", resp); apiErr != nil {
 			if IsNotFound(apiErr) {

--- a/internal/provider/restore_resource_test.go
+++ b/internal/provider/restore_resource_test.go
@@ -1,12 +1,14 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -14,6 +16,7 @@ func TestAccRestoreResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckRestoreDestroyed,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
@@ -55,6 +58,32 @@ func TestAccRestoreResource(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testCheckRestoreDestroyed(s *terraform.State) error {
+	client, err := testAccClient()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "arubacloud_restore" {
+			continue
+		}
+		backupID := rs.Primary.Attributes["backup_id"]
+		resp, err := client.Client.FromStorage().Restores().Get(ctx, rs.Primary.Attributes["project_id"], backupID, rs.Primary.ID, nil)
+		if err != nil {
+			return nil
+		}
+		if apiErr := CheckResponse("get", "Restore", resp); apiErr != nil {
+			if IsNotFound(apiErr) {
+				continue
+			}
+			return apiErr
+		}
+		return fmt.Errorf("Restore %s still exists", rs.Primary.ID)
+	}
+	return nil
 }
 
 func testAccRestoreResourceConfig(name string) string {

--- a/internal/provider/schedulejob_resource_test.go
+++ b/internal/provider/schedulejob_resource_test.go
@@ -72,7 +72,7 @@ func testCheckSchedulejobDestroyed(s *terraform.State) error {
 		}
 		resp, err := client.Client.FromSchedule().Jobs().Get(ctx, rs.Primary.Attributes["project_id"], rs.Primary.ID, nil)
 		if err != nil {
-			return nil
+			return err
 		}
 		if apiErr := CheckResponse("get", "Schedulejob", resp); apiErr != nil {
 			if IsNotFound(apiErr) {

--- a/internal/provider/schedulejob_resource_test.go
+++ b/internal/provider/schedulejob_resource_test.go
@@ -1,12 +1,14 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -14,6 +16,7 @@ func TestAccSchedulejobResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckSchedulejobDestroyed,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
@@ -57,13 +60,38 @@ func TestAccSchedulejobResource(t *testing.T) {
 	})
 }
 
+func testCheckSchedulejobDestroyed(s *terraform.State) error {
+	client, err := testAccClient()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "arubacloud_schedulejob" {
+			continue
+		}
+		resp, err := client.Client.FromSchedule().Jobs().Get(ctx, rs.Primary.Attributes["project_id"], rs.Primary.ID, nil)
+		if err != nil {
+			return nil
+		}
+		if apiErr := CheckResponse("get", "Schedulejob", resp); apiErr != nil {
+			if IsNotFound(apiErr) {
+				continue
+			}
+			return apiErr
+		}
+		return fmt.Errorf("ScheduleJob %s still exists", rs.Primary.ID)
+	}
+	return nil
+}
+
 func testAccSchedulejobResourceConfig(name string) string {
 	return fmt.Sprintf(`
 resource "arubacloud_schedulejob" "test" {
   name       = %[1]q
   project_id = "test-project-id"
   location   = "it-1"
-  
+
   properties = {
     schedule_job_type = "OneShot"
     schedule_at       = "2025-12-31T23:59:59Z"

--- a/internal/provider/securitygroup_resource_test.go
+++ b/internal/provider/securitygroup_resource_test.go
@@ -73,7 +73,7 @@ func testCheckSecuritygroupDestroyed(s *terraform.State) error {
 		vpcID := rs.Primary.Attributes["vpc_id"]
 		resp, err := client.Client.FromNetwork().SecurityGroups().Get(ctx, rs.Primary.Attributes["project_id"], vpcID, rs.Primary.ID, nil)
 		if err != nil {
-			return nil
+			return err
 		}
 		if apiErr := CheckResponse("get", "Securitygroup", resp); apiErr != nil {
 			if IsNotFound(apiErr) {

--- a/internal/provider/securitygroup_resource_test.go
+++ b/internal/provider/securitygroup_resource_test.go
@@ -1,12 +1,14 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -14,6 +16,7 @@ func TestAccSecuritygroupResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckSecuritygroupDestroyed,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
@@ -55,6 +58,32 @@ func TestAccSecuritygroupResource(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testCheckSecuritygroupDestroyed(s *terraform.State) error {
+	client, err := testAccClient()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "arubacloud_securitygroup" {
+			continue
+		}
+		vpcID := rs.Primary.Attributes["vpc_id"]
+		resp, err := client.Client.FromNetwork().SecurityGroups().Get(ctx, rs.Primary.Attributes["project_id"], vpcID, rs.Primary.ID, nil)
+		if err != nil {
+			return nil
+		}
+		if apiErr := CheckResponse("get", "Securitygroup", resp); apiErr != nil {
+			if IsNotFound(apiErr) {
+				continue
+			}
+			return apiErr
+		}
+		return fmt.Errorf("SecurityGroup %s still exists", rs.Primary.ID)
+	}
+	return nil
 }
 
 func testAccSecuritygroupResourceConfig(name string) string {

--- a/internal/provider/securityrule_resource_test.go
+++ b/internal/provider/securityrule_resource_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -125,6 +126,7 @@ func TestAccSecurityruleResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckSecurityruleDestroyed,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
@@ -171,6 +173,33 @@ func TestAccSecurityruleResource(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testCheckSecurityruleDestroyed(s *terraform.State) error {
+	client, err := testAccClient()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "arubacloud_securityrule" {
+			continue
+		}
+		vpcID := rs.Primary.Attributes["vpc_id"]
+		sgID := rs.Primary.Attributes["security_group_id"]
+		resp, err := client.Client.FromNetwork().SecurityGroupRules().Get(ctx, rs.Primary.Attributes["project_id"], vpcID, sgID, rs.Primary.ID, nil)
+		if err != nil {
+			return nil
+		}
+		if apiErr := CheckResponse("get", "Securityrule", resp); apiErr != nil {
+			if IsNotFound(apiErr) {
+				continue
+			}
+			return apiErr
+		}
+		return fmt.Errorf("SecurityRule %s still exists", rs.Primary.ID)
+	}
+	return nil
 }
 
 func testAccSecurityruleResourceConfig(name string) string {

--- a/internal/provider/securityrule_resource_test.go
+++ b/internal/provider/securityrule_resource_test.go
@@ -189,7 +189,7 @@ func testCheckSecurityruleDestroyed(s *terraform.State) error {
 		sgID := rs.Primary.Attributes["security_group_id"]
 		resp, err := client.Client.FromNetwork().SecurityGroupRules().Get(ctx, rs.Primary.Attributes["project_id"], vpcID, sgID, rs.Primary.ID, nil)
 		if err != nil {
-			return nil
+			return err
 		}
 		if apiErr := CheckResponse("get", "Securityrule", resp); apiErr != nil {
 			if IsNotFound(apiErr) {

--- a/internal/provider/snapshot_resource_test.go
+++ b/internal/provider/snapshot_resource_test.go
@@ -1,12 +1,14 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -14,6 +16,7 @@ func TestAccSnapshotResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckSnapshotDestroyed,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
@@ -55,6 +58,31 @@ func TestAccSnapshotResource(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testCheckSnapshotDestroyed(s *terraform.State) error {
+	client, err := testAccClient()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "arubacloud_snapshot" {
+			continue
+		}
+		resp, err := client.Client.FromStorage().Snapshots().Get(ctx, rs.Primary.Attributes["project_id"], rs.Primary.ID, nil)
+		if err != nil {
+			return nil
+		}
+		if apiErr := CheckResponse("get", "Snapshot", resp); apiErr != nil {
+			if IsNotFound(apiErr) {
+				continue
+			}
+			return apiErr
+		}
+		return fmt.Errorf("Snapshot %s still exists", rs.Primary.ID)
+	}
+	return nil
 }
 
 func testAccSnapshotResourceConfig(name string) string {

--- a/internal/provider/snapshot_resource_test.go
+++ b/internal/provider/snapshot_resource_test.go
@@ -72,7 +72,7 @@ func testCheckSnapshotDestroyed(s *terraform.State) error {
 		}
 		resp, err := client.Client.FromStorage().Snapshots().Get(ctx, rs.Primary.Attributes["project_id"], rs.Primary.ID, nil)
 		if err != nil {
-			return nil
+			return err
 		}
 		if apiErr := CheckResponse("get", "Snapshot", resp); apiErr != nil {
 			if IsNotFound(apiErr) {

--- a/internal/provider/subnet_resource_test.go
+++ b/internal/provider/subnet_resource_test.go
@@ -78,7 +78,7 @@ func testCheckSubnetDestroyed(s *terraform.State) error {
 		vpcID := rs.Primary.Attributes["vpc_id"]
 		resp, err := client.Client.FromNetwork().Subnets().Get(ctx, rs.Primary.Attributes["project_id"], vpcID, rs.Primary.ID, nil)
 		if err != nil {
-			return nil
+			return err
 		}
 		if apiErr := CheckResponse("get", "Subnet", resp); apiErr != nil {
 			if IsNotFound(apiErr) {

--- a/internal/provider/subnet_resource_test.go
+++ b/internal/provider/subnet_resource_test.go
@@ -1,12 +1,14 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -14,6 +16,7 @@ func TestAccSubnetResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckSubnetDestroyed,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
@@ -62,6 +65,32 @@ func TestAccSubnetResource(t *testing.T) {
 	})
 }
 
+func testCheckSubnetDestroyed(s *terraform.State) error {
+	client, err := testAccClient()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "arubacloud_subnet" {
+			continue
+		}
+		vpcID := rs.Primary.Attributes["vpc_id"]
+		resp, err := client.Client.FromNetwork().Subnets().Get(ctx, rs.Primary.Attributes["project_id"], vpcID, rs.Primary.ID, nil)
+		if err != nil {
+			return nil
+		}
+		if apiErr := CheckResponse("get", "Subnet", resp); apiErr != nil {
+			if IsNotFound(apiErr) {
+				continue
+			}
+			return apiErr
+		}
+		return fmt.Errorf("Subnet %s still exists", rs.Primary.ID)
+	}
+	return nil
+}
+
 func testAccSubnetResourceConfig(name string) string {
 	return fmt.Sprintf(`
 resource "arubacloud_subnet" "test" {
@@ -70,7 +99,7 @@ resource "arubacloud_subnet" "test" {
   project_id = "test-project-id"
   vpc_id     = "test-vpc-id"
   type       = "Basic"
-  
+
   network = {
     address = "10.0.0.0/24"
   }

--- a/internal/provider/vpc_resource_test.go
+++ b/internal/provider/vpc_resource_test.go
@@ -1,12 +1,14 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -14,6 +16,7 @@ func TestAccVpcResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckVpcDestroyed,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
@@ -60,6 +63,31 @@ func TestAccVpcResource(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testCheckVpcDestroyed(s *terraform.State) error {
+	client, err := testAccClient()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "arubacloud_vpc" {
+			continue
+		}
+		resp, err := client.Client.FromNetwork().VPCs().Get(ctx, rs.Primary.Attributes["project_id"], rs.Primary.ID, nil)
+		if err != nil {
+			return nil
+		}
+		if apiErr := CheckResponse("get", "Vpc", resp); apiErr != nil {
+			if IsNotFound(apiErr) {
+				continue
+			}
+			return apiErr
+		}
+		return fmt.Errorf("VPC %s still exists", rs.Primary.ID)
+	}
+	return nil
 }
 
 func testAccVpcResourceConfig(name string) string {

--- a/internal/provider/vpc_resource_test.go
+++ b/internal/provider/vpc_resource_test.go
@@ -77,7 +77,7 @@ func testCheckVpcDestroyed(s *terraform.State) error {
 		}
 		resp, err := client.Client.FromNetwork().VPCs().Get(ctx, rs.Primary.Attributes["project_id"], rs.Primary.ID, nil)
 		if err != nil {
-			return nil
+			return err
 		}
 		if apiErr := CheckResponse("get", "Vpc", resp); apiErr != nil {
 			if IsNotFound(apiErr) {

--- a/internal/provider/vpcpeering_resource_test.go
+++ b/internal/provider/vpcpeering_resource_test.go
@@ -1,12 +1,14 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -14,6 +16,7 @@ func TestAccVpcpeeringResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckVpcpeeringDestroyed,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
@@ -55,6 +58,32 @@ func TestAccVpcpeeringResource(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testCheckVpcpeeringDestroyed(s *terraform.State) error {
+	client, err := testAccClient()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "arubacloud_vpcpeering" {
+			continue
+		}
+		vpcID := rs.Primary.Attributes["vpc_id"]
+		resp, err := client.Client.FromNetwork().VPCPeerings().Get(ctx, rs.Primary.Attributes["project_id"], vpcID, rs.Primary.ID, nil)
+		if err != nil {
+			return nil
+		}
+		if apiErr := CheckResponse("get", "Vpcpeering", resp); apiErr != nil {
+			if IsNotFound(apiErr) {
+				continue
+			}
+			return apiErr
+		}
+		return fmt.Errorf("VPCPeering %s still exists", rs.Primary.ID)
+	}
+	return nil
 }
 
 func testAccVpcpeeringResourceConfig(name string) string {

--- a/internal/provider/vpcpeering_resource_test.go
+++ b/internal/provider/vpcpeering_resource_test.go
@@ -73,7 +73,7 @@ func testCheckVpcpeeringDestroyed(s *terraform.State) error {
 		vpcID := rs.Primary.Attributes["vpc_id"]
 		resp, err := client.Client.FromNetwork().VPCPeerings().Get(ctx, rs.Primary.Attributes["project_id"], vpcID, rs.Primary.ID, nil)
 		if err != nil {
-			return nil
+			return err
 		}
 		if apiErr := CheckResponse("get", "Vpcpeering", resp); apiErr != nil {
 			if IsNotFound(apiErr) {

--- a/internal/provider/vpcpeeringroute_resource_test.go
+++ b/internal/provider/vpcpeeringroute_resource_test.go
@@ -1,12 +1,14 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -14,6 +16,7 @@ func TestAccVpcpeeringrouteResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckVpcpeeringrouteDestroyed,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
@@ -55,6 +58,33 @@ func TestAccVpcpeeringrouteResource(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testCheckVpcpeeringrouteDestroyed(s *terraform.State) error {
+	client, err := testAccClient()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "arubacloud_vpcpeeringroute" {
+			continue
+		}
+		vpcID := rs.Primary.Attributes["vpc_id"]
+		peeringID := rs.Primary.Attributes["vpc_peering_id"]
+		resp, err := client.Client.FromNetwork().VPCPeeringRoutes().Get(ctx, rs.Primary.Attributes["project_id"], vpcID, peeringID, rs.Primary.ID, nil)
+		if err != nil {
+			return nil
+		}
+		if apiErr := CheckResponse("get", "Vpcpeeringroute", resp); apiErr != nil {
+			if IsNotFound(apiErr) {
+				continue
+			}
+			return apiErr
+		}
+		return fmt.Errorf("VPCPeeringRoute %s still exists", rs.Primary.ID)
+	}
+	return nil
 }
 
 func testAccVpcpeeringrouteResourceConfig(name string) string {

--- a/internal/provider/vpcpeeringroute_resource_test.go
+++ b/internal/provider/vpcpeeringroute_resource_test.go
@@ -74,7 +74,7 @@ func testCheckVpcpeeringrouteDestroyed(s *terraform.State) error {
 		peeringID := rs.Primary.Attributes["vpc_peering_id"]
 		resp, err := client.Client.FromNetwork().VPCPeeringRoutes().Get(ctx, rs.Primary.Attributes["project_id"], vpcID, peeringID, rs.Primary.ID, nil)
 		if err != nil {
-			return nil
+			return err
 		}
 		if apiErr := CheckResponse("get", "Vpcpeeringroute", resp); apiErr != nil {
 			if IsNotFound(apiErr) {

--- a/internal/provider/vpnroute_resource_test.go
+++ b/internal/provider/vpnroute_resource_test.go
@@ -73,7 +73,7 @@ func testCheckVpnrouteDestroyed(s *terraform.State) error {
 		tunnelID := rs.Primary.Attributes["vpn_tunnel_id"]
 		resp, err := client.Client.FromNetwork().VPNRoutes().Get(ctx, rs.Primary.Attributes["project_id"], tunnelID, rs.Primary.ID, nil)
 		if err != nil {
-			return nil
+			return err
 		}
 		if apiErr := CheckResponse("get", "Vpnroute", resp); apiErr != nil {
 			if IsNotFound(apiErr) {

--- a/internal/provider/vpnroute_resource_test.go
+++ b/internal/provider/vpnroute_resource_test.go
@@ -1,12 +1,14 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -14,6 +16,7 @@ func TestAccVpnrouteResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckVpnrouteDestroyed,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
@@ -57,6 +60,32 @@ func TestAccVpnrouteResource(t *testing.T) {
 	})
 }
 
+func testCheckVpnrouteDestroyed(s *terraform.State) error {
+	client, err := testAccClient()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "arubacloud_vpnroute" {
+			continue
+		}
+		tunnelID := rs.Primary.Attributes["vpn_tunnel_id"]
+		resp, err := client.Client.FromNetwork().VPNRoutes().Get(ctx, rs.Primary.Attributes["project_id"], tunnelID, rs.Primary.ID, nil)
+		if err != nil {
+			return nil
+		}
+		if apiErr := CheckResponse("get", "Vpnroute", resp); apiErr != nil {
+			if IsNotFound(apiErr) {
+				continue
+			}
+			return apiErr
+		}
+		return fmt.Errorf("VPNRoute %s still exists", rs.Primary.ID)
+	}
+	return nil
+}
+
 func testAccVpnrouteResourceConfig(name string) string {
 	return fmt.Sprintf(`
 resource "arubacloud_vpnroute" "test" {
@@ -64,7 +93,7 @@ resource "arubacloud_vpnroute" "test" {
   location       = "it-1"
   project_id     = "test-project-id"
   vpn_tunnel_id  = "test-tunnel-id"
-  
+
   properties = {
     cloud_subnet   = "10.0.0.0/24"
     on_prem_subnet = "192.168.0.0/24"

--- a/internal/provider/vpntunnel_resource_test.go
+++ b/internal/provider/vpntunnel_resource_test.go
@@ -1,12 +1,14 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -14,6 +16,7 @@ func TestAccVpntunnelResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckVpntunnelDestroyed,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
@@ -57,13 +60,38 @@ func TestAccVpntunnelResource(t *testing.T) {
 	})
 }
 
+func testCheckVpntunnelDestroyed(s *terraform.State) error {
+	client, err := testAccClient()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "arubacloud_vpntunnel" {
+			continue
+		}
+		resp, err := client.Client.FromNetwork().VPNTunnels().Get(ctx, rs.Primary.Attributes["project_id"], rs.Primary.ID, nil)
+		if err != nil {
+			return nil
+		}
+		if apiErr := CheckResponse("get", "Vpntunnel", resp); apiErr != nil {
+			if IsNotFound(apiErr) {
+				continue
+			}
+			return apiErr
+		}
+		return fmt.Errorf("VPNTunnel %s still exists", rs.Primary.ID)
+	}
+	return nil
+}
+
 func testAccVpntunnelResourceConfig(name string) string {
 	return fmt.Sprintf(`
 resource "arubacloud_vpntunnel" "test" {
   name       = %[1]q
   location   = "it-1"
   project_id = "test-project-id"
-  
+
   properties = {
     vpn_type = "Site-To-Site"
   }

--- a/internal/provider/vpntunnel_resource_test.go
+++ b/internal/provider/vpntunnel_resource_test.go
@@ -72,7 +72,7 @@ func testCheckVpntunnelDestroyed(s *terraform.State) error {
 		}
 		resp, err := client.Client.FromNetwork().VPNTunnels().Get(ctx, rs.Primary.Attributes["project_id"], rs.Primary.ID, nil)
 		if err != nil {
-			return nil
+			return err
 		}
 		if apiErr := CheckResponse("get", "Vpntunnel", resp); apiErr != nil {
 			if IsNotFound(apiErr) {


### PR DESCRIPTION
## Summary

Closes #50.

- Added a `testAccClient()` shared helper in `provider_test.go` that builds an SDK client from `ARUBACLOUD_API_KEY` / `ARUBACLOUD_API_SECRET` env vars
- Added a `CheckDestroy` function to every `resource.TestCase` across all 26 `*_resource_test.go` files
- Each destroy function calls the appropriate SDK `Get` endpoint and asserts the resource is gone (404), confirming actual cloud-side deletion

## Resources covered

| Resource | SDK chain |
|---|---|
| `arubacloud_vpc` | `FromNetwork().VPCs().Get` |
| `arubacloud_subnet` | `FromNetwork().Subnets().Get` |
| `arubacloud_securitygroup` | `FromNetwork().SecurityGroups().Get` |
| `arubacloud_securityrule` | `FromNetwork().SecurityGroupRules().Get` |
| `arubacloud_vpcpeering` | `FromNetwork().VPCPeerings().Get` |
| `arubacloud_vpcpeeringroute` | `FromNetwork().VPCPeeringRoutes().Get` |
| `arubacloud_vpntunnel` | `FromNetwork().VPNTunnels().Get` |
| `arubacloud_vpnroute` | `FromNetwork().VPNRoutes().Get` |
| `arubacloud_elasticip` | `FromNetwork().ElasticIPs().Get` |
| `arubacloud_blockstorage` | `FromStorage().Volumes().Get` |
| `arubacloud_snapshot` | `FromStorage().Snapshots().Get` |
| `arubacloud_backup` | `FromStorage().Backups().Get` |
| `arubacloud_restore` | `FromStorage().Restores().Get` |
| `arubacloud_keypair` | `FromCompute().KeyPairs().Get` |
| `arubacloud_cloudserver` | `FromCompute().CloudServers().Get` |
| `arubacloud_kms` | `FromSecurity().KMS().Get` |
| `arubacloud_schedulejob` | `FromSchedule().Jobs().Get` |
| `arubacloud_dbaas` | `FromDatabase().DBaaS().Get` |
| `arubacloud_database` | `FromDatabase().Databases().Get` |
| `arubacloud_databasebackup` | `FromDatabase().Backups().Get` |
| `arubacloud_databasegrant` | `FromDatabase().Grants().Get` |
| `arubacloud_dbaasuser` | `FromDatabase().Users().Get` |
| `arubacloud_kaas` | `FromContainer().KaaS().Get` |
| `arubacloud_containerregistry` | `FromContainer().ContainerRegistry().Get` |
| `arubacloud_project` | `FromProject().Get` |

## Test plan

- [ ] `go vet ./internal/provider/...` passes (verified locally)
- [ ] Unit tests (`go test -run TestNormalize\|TestResolve\|TestProtocol`) still pass
- [ ] Acceptance tests run against live API via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)