### PR TITLE
fix: adapt elasticip billing_period to API breaking change (v0.1.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.1.6 (May 27, 2026)
+
+BUG FIXES:
+
+* `arubacloud_elasticip`: Fix `billing_period` value sent to the API after backend breaking change — the ElasticIP API now uses `Hour`/`Month`/`Year` (same canonical form as all other resources) instead of the legacy `hourly`/`monthly`/`yearly` lowercase values. The create request was incorrectly sending the old lowercase form, causing API rejections.
+
 ## 0.0.1 (January 26, 2026)
 
 FEATURES:

--- a/internal/provider/elasticip_resource.go
+++ b/internal/provider/elasticip_resource.go
@@ -157,9 +157,9 @@ func (r *ElasticIPResource) Create(ctx context.Context, req resource.CreateReque
 			BillingPlan: sdktypes.BillingPeriodResource{
 				BillingPeriod: func() string {
 					if !data.BillingPeriod.IsNull() && !data.BillingPeriod.IsUnknown() {
-						return billingPeriodToAPI(data.BillingPeriod.ValueString())
+						return data.BillingPeriod.ValueString()
 					}
-					return "hourly"
+					return "Hour"
 				}(),
 			},
 		},

--- a/internal/provider/error_helper.go
+++ b/internal/provider/error_helper.go
@@ -1,24 +1,8 @@
 package provider
 
-// billingPeriodToAPI converts a Terraform-facing billing period value
-// (Hour, Month, Year) to the value expected by the Aruba API (hourly, monthly, yearly).
-// If the value is already in API form it is returned unchanged.
-func billingPeriodToAPI(s string) string {
-	switch s {
-	case "Hour":
-		return "hourly"
-	case "Month":
-		return "monthly"
-	case "Year":
-		return "yearly"
-	default:
-		return s
-	}
-}
-
-// billingPeriodFromAPI converts an API billing period value (hourly, monthly, yearly)
-// to the Terraform-facing canonical form (Hour, Month, Year).
-// If the value is already in canonical form it is returned unchanged.
+// billingPeriodFromAPI converts legacy API billing period values (hourly, monthly, yearly)
+// to the canonical Terraform form (Hour, Month, Year).
+// Values already in canonical form are returned unchanged.
 func billingPeriodFromAPI(s string) string {
 	switch s {
 	case "hourly":

--- a/internal/provider/error_helper_test.go
+++ b/internal/provider/error_helper_test.go
@@ -2,27 +2,6 @@ package provider
 
 import "testing"
 
-func TestBillingPeriodToAPI(t *testing.T) {
-	cases := []struct {
-		in   string
-		want string
-	}{
-		{"Hour", "hourly"},
-		{"Month", "monthly"},
-		{"Year", "yearly"},
-		{"hourly", "hourly"},   // already in API form
-		{"monthly", "monthly"}, // already in API form
-		{"yearly", "yearly"},   // already in API form
-		{"unknown", "unknown"}, // passthrough
-		{"", ""},               // empty passthrough
-	}
-	for _, tc := range cases {
-		if got := billingPeriodToAPI(tc.in); got != tc.want {
-			t.Errorf("billingPeriodToAPI(%q) = %q, want %q", tc.in, got, tc.want)
-		}
-	}
-}
-
 func TestBillingPeriodFromAPI(t *testing.T) {
 	cases := []struct {
 		in   string


### PR DESCRIPTION
## Summary

- **Breaking API change**: the ElasticIP backend now uses `Hour`/`Month`/`Year` (canonical form) for `billingPlan.billingPeriod`, replacing the legacy `hourly`/`monthly`/`yearly` lowercase values used before.
- Removed `billingPeriodToAPI` which was converting `Hour` → `hourly`, causing create requests to be rejected by the updated API.
- Fixed the create-request fallback default from `"hourly"` to `"Hour"`.
- Retained `billingPeriodFromAPI` for backward compatibility (read paths may still encounter the old lowercase form in existing state).
- Removed the now-obsolete `TestBillingPeriodToAPI` unit test.
- Added CHANGELOG entry for v0.1.6.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/provider/ -run TestBillingPeriod` passes
- [ ] Acceptance test: `terraform apply` on an `arubacloud_elasticip` resource succeeds without API error on `billing_period`
- [ ] `terraform plan` on an existing ElasticIP shows no unexpected drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)