### PR TITLE
fix: downgrade Failed-state Read() error to warning to unblock terraform destroy (#116)

### DIFF
--- a/internal/provider/backup_resource.go
+++ b/internal/provider/backup_resource.go
@@ -297,12 +297,11 @@ func (r *BackupResource) Read(ctx context.Context, req resource.ReadRequest, res
 	if response.Data.Status.State != nil {
 		switch st := *response.Data.Status.State; {
 		case isFailedState(st):
-			resp.Diagnostics.AddError(
+			resp.Diagnostics.AddWarning(
 				"Resource in Failed State",
-				fmt.Sprintf("Backup %q reached a terminal failure state (%s) and will not recover on its own. "+
-					"Use `terraform apply -replace=<address>` to recreate it.", backupID, st),
+				fmt.Sprintf("Backup %q is in a terminal failure state (%s). "+
+					"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", backupID, st),
 			)
-			return
 		case IsCreatingState(st):
 			checker := func(ctx context.Context) (string, error) {
 				getResp, err := r.client.Client.FromStorage().Backups().Get(ctx, projectID, backupID, nil)

--- a/internal/provider/blockstorage_resource.go
+++ b/internal/provider/blockstorage_resource.go
@@ -359,12 +359,11 @@ func (r *BlockStorageResource) Read(ctx context.Context, req resource.ReadReques
 	if response.Data.Status.State != nil {
 		switch st := *response.Data.Status.State; {
 		case isFailedState(st):
-			resp.Diagnostics.AddError(
+			resp.Diagnostics.AddWarning(
 				"Resource in Failed State",
-				fmt.Sprintf("BlockStorage %q reached a terminal failure state (%s) and will not recover on its own. "+
-					"Use `terraform apply -replace=<address>` to recreate it.", volumeID, st),
+				fmt.Sprintf("BlockStorage %q is in a terminal failure state (%s). "+
+					"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", volumeID, st),
 			)
-			return
 		case IsCreatingState(st):
 			checker := func(ctx context.Context) (string, error) {
 				getResp, err := r.client.Client.FromStorage().Volumes().Get(ctx, projectID, volumeID, nil)

--- a/internal/provider/cloudserver_resource.go
+++ b/internal/provider/cloudserver_resource.go
@@ -499,12 +499,11 @@ func (r *CloudServerResource) Read(ctx context.Context, req resource.ReadRequest
 	if response.Data.Status.State != nil {
 		switch st := *response.Data.Status.State; {
 		case isFailedState(st):
-			resp.Diagnostics.AddError(
+			resp.Diagnostics.AddWarning(
 				"Resource in Failed State",
-				fmt.Sprintf("CloudServer %q reached a terminal failure state (%s) and will not recover on its own. "+
-					"Use `terraform apply -replace=<address>` to recreate it.", serverID, st),
+				fmt.Sprintf("CloudServer %q is in a terminal failure state (%s). "+
+					"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", serverID, st),
 			)
-			return
 		case IsCreatingState(st):
 			checker := func(ctx context.Context) (string, error) {
 				getResp, err := r.client.Client.FromCompute().CloudServers().Get(ctx, projectID, serverID, nil)

--- a/internal/provider/containerregistry_resource.go
+++ b/internal/provider/containerregistry_resource.go
@@ -418,12 +418,11 @@ func (r *ContainerRegistryResource) Read(ctx context.Context, req resource.ReadR
 	if response.Data.Status.State != nil {
 		switch st := *response.Data.Status.State; {
 		case isFailedState(st):
-			resp.Diagnostics.AddError(
+			resp.Diagnostics.AddWarning(
 				"Resource in Failed State",
-				fmt.Sprintf("ContainerRegistry %q reached a terminal failure state (%s) and will not recover on its own. "+
-					"Use `terraform apply -replace=<address>` to recreate it.", registryID, st),
+				fmt.Sprintf("ContainerRegistry %q is in a terminal failure state (%s). "+
+					"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", registryID, st),
 			)
-			return
 		case IsCreatingState(st):
 			checker := func(ctx context.Context) (string, error) {
 				getResp, err := registryClient.Get(ctx, projectID, registryID, nil)

--- a/internal/provider/databasebackup_resource.go
+++ b/internal/provider/databasebackup_resource.go
@@ -284,12 +284,11 @@ func (r *DatabaseBackupResource) Read(ctx context.Context, req resource.ReadRequ
 	if response.Data.Status.State != nil {
 		switch st := *response.Data.Status.State; {
 		case isFailedState(st):
-			resp.Diagnostics.AddError(
+			resp.Diagnostics.AddWarning(
 				"Resource in Failed State",
-				fmt.Sprintf("DatabaseBackup %q reached a terminal failure state (%s) and will not recover on its own. "+
-					"Use `terraform apply -replace=<address>` to recreate it.", backupID, st),
+				fmt.Sprintf("DatabaseBackup %q is in a terminal failure state (%s). "+
+					"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", backupID, st),
 			)
-			return
 		case IsCreatingState(st):
 			checker := func(ctx context.Context) (string, error) {
 				getResp, err := r.client.Client.FromDatabase().Backups().Get(ctx, projectID, backupID, nil)

--- a/internal/provider/dbaas_resource.go
+++ b/internal/provider/dbaas_resource.go
@@ -519,12 +519,11 @@ func (r *DBaaSResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	if response.Data.Status.State != nil {
 		switch st := *response.Data.Status.State; {
 		case isFailedState(st):
-			resp.Diagnostics.AddError(
+			resp.Diagnostics.AddWarning(
 				"Resource in Failed State",
-				fmt.Sprintf("DBaaS %q reached a terminal failure state (%s) and will not recover on its own. "+
-					"Use `terraform apply -replace=<address>` to recreate it.", dbaasID, st),
+				fmt.Sprintf("DBaaS %q is in a terminal failure state (%s). "+
+					"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", dbaasID, st),
 			)
-			return
 		case IsCreatingState(st):
 			checker := func(ctx context.Context) (string, error) {
 				getResp, err := r.client.Client.FromDatabase().DBaaS().Get(ctx, projectID, dbaasID, nil)

--- a/internal/provider/elasticip_resource.go
+++ b/internal/provider/elasticip_resource.go
@@ -340,12 +340,11 @@ func (r *ElasticIPResource) Read(ctx context.Context, req resource.ReadRequest, 
 	if response.Data.Status.State != nil {
 		switch st := *response.Data.Status.State; {
 		case isFailedState(st):
-			resp.Diagnostics.AddError(
+			resp.Diagnostics.AddWarning(
 				"Resource in Failed State",
-				fmt.Sprintf("ElasticIP %q reached a terminal failure state (%s) and will not recover on its own. "+
-					"Use `terraform apply -replace=<address>` to recreate it.", eipID, st),
+				fmt.Sprintf("ElasticIP %q is in a terminal failure state (%s). "+
+					"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", eipID, st),
 			)
-			return
 		case IsCreatingState(st):
 			checker := func(ctx context.Context) (string, error) {
 				getResp, err := r.client.Client.FromNetwork().ElasticIPs().Get(ctx, projectID, eipID, nil)

--- a/internal/provider/kaas_resource.go
+++ b/internal/provider/kaas_resource.go
@@ -590,12 +590,11 @@ func (r *KaaSResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	if response.Data.Status.State != nil {
 		switch st := *response.Data.Status.State; {
 		case isFailedState(st):
-			resp.Diagnostics.AddError(
+			resp.Diagnostics.AddWarning(
 				"Resource in Failed State",
-				fmt.Sprintf("KaaS %q reached a terminal failure state (%s) and will not recover on its own. "+
-					"Use `terraform apply -replace=<address>` to recreate it.", kaasID, st),
+				fmt.Sprintf("KaaS %q is in a terminal failure state (%s). "+
+					"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", kaasID, st),
 			)
-			return
 		case IsCreatingState(st):
 			checker := func(ctx context.Context) (string, error) {
 				getResp, err := r.client.Client.FromContainer().KaaS().Get(ctx, projectID, kaasID, nil)

--- a/internal/provider/kms_resource.go
+++ b/internal/provider/kms_resource.go
@@ -287,12 +287,11 @@ func (r *KMSResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 	if response.Data.Status.State != nil {
 		switch st := *response.Data.Status.State; {
 		case isFailedState(st):
-			resp.Diagnostics.AddError(
+			resp.Diagnostics.AddWarning(
 				"Resource in Failed State",
-				fmt.Sprintf("KMS %q reached a terminal failure state (%s) and will not recover on its own. "+
-					"Use `terraform apply -replace=<address>` to recreate it.", kmsID, st),
+				fmt.Sprintf("KMS %q is in a terminal failure state (%s). "+
+					"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", kmsID, st),
 			)
-			return
 		case IsCreatingState(st):
 			checker := func(ctx context.Context) (string, error) {
 				getResp, err := r.client.Client.FromSecurity().KMS().Get(ctx, projectID, kmsID, nil)

--- a/internal/provider/restore_resource.go
+++ b/internal/provider/restore_resource.go
@@ -296,12 +296,11 @@ func (r *RestoreResource) Read(ctx context.Context, req resource.ReadRequest, re
 	if response.Data.Status.State != nil {
 		switch st := *response.Data.Status.State; {
 		case isFailedState(st):
-			resp.Diagnostics.AddError(
+			resp.Diagnostics.AddWarning(
 				"Resource in Failed State",
-				fmt.Sprintf("Restore %q reached a terminal failure state (%s) and will not recover on its own. "+
-					"Use `terraform apply -replace=<address>` to recreate it.", restoreID, st),
+				fmt.Sprintf("Restore %q is in a terminal failure state (%s). "+
+					"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", restoreID, st),
 			)
-			return
 		case IsCreatingState(st):
 			checker := func(ctx context.Context) (string, error) {
 				getResp, err := r.client.Client.FromStorage().Restores().Get(ctx, projectID, backupID, restoreID, nil)

--- a/internal/provider/schedulejob_resource.go
+++ b/internal/provider/schedulejob_resource.go
@@ -405,12 +405,11 @@ func (r *ScheduleJobResource) Read(ctx context.Context, req resource.ReadRequest
 	if response.Data.Status.State != nil {
 		switch st := *response.Data.Status.State; {
 		case isFailedState(st):
-			resp.Diagnostics.AddError(
+			resp.Diagnostics.AddWarning(
 				"Resource in Failed State",
-				fmt.Sprintf("ScheduleJob %q reached a terminal failure state (%s) and will not recover on its own. "+
-					"Use `terraform apply -replace=<address>` to recreate it.", jobID, st),
+				fmt.Sprintf("ScheduleJob %q is in a terminal failure state (%s). "+
+					"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", jobID, st),
 			)
-			return
 		case IsCreatingState(st):
 			checker := func(ctx context.Context) (string, error) {
 				getResp, err := r.client.Client.FromSchedule().Jobs().Get(ctx, projectID, jobID, nil)

--- a/internal/provider/securitygroup_resource.go
+++ b/internal/provider/securitygroup_resource.go
@@ -274,12 +274,11 @@ func (r *SecurityGroupResource) Read(ctx context.Context, req resource.ReadReque
 	if response.Data.Status.State != nil {
 		switch st := *response.Data.Status.State; {
 		case isFailedState(st):
-			resp.Diagnostics.AddError(
+			resp.Diagnostics.AddWarning(
 				"Resource in Failed State",
-				fmt.Sprintf("SecurityGroup %q reached a terminal failure state (%s) and will not recover on its own. "+
-					"Use `terraform apply -replace=<address>` to recreate it.", sgID, st),
+				fmt.Sprintf("SecurityGroup %q is in a terminal failure state (%s). "+
+					"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", sgID, st),
 			)
-			return
 		case IsCreatingState(st):
 			checker := func(ctx context.Context) (string, error) {
 				getResp, err := r.client.Client.FromNetwork().SecurityGroups().Get(ctx, projectID, vpcID, sgID, nil)

--- a/internal/provider/securityrule_resource.go
+++ b/internal/provider/securityrule_resource.go
@@ -688,12 +688,11 @@ func (r *SecurityRuleResource) Read(ctx context.Context, req resource.ReadReques
 	if response.Data.Status.State != nil {
 		switch st := *response.Data.Status.State; {
 		case isFailedState(st):
-			resp.Diagnostics.AddError(
+			resp.Diagnostics.AddWarning(
 				"Resource in Failed State",
-				fmt.Sprintf("SecurityRule %q reached a terminal failure state (%s) and will not recover on its own. "+
-					"Use `terraform apply -replace=<address>` to recreate it.", ruleID, st),
+				fmt.Sprintf("SecurityRule %q is in a terminal failure state (%s). "+
+					"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", ruleID, st),
 			)
-			return
 		case IsCreatingState(st):
 			checker := func(ctx context.Context) (string, error) {
 				getResp, err := r.client.Client.FromNetwork().SecurityGroupRules().Get(ctx, projectID, vpcID, securityGroupID, ruleID, nil)

--- a/internal/provider/snapshot_resource.go
+++ b/internal/provider/snapshot_resource.go
@@ -308,12 +308,11 @@ func (r *SnapshotResource) Read(ctx context.Context, req resource.ReadRequest, r
 	if response.Data.Status.State != nil {
 		switch st := *response.Data.Status.State; {
 		case isFailedState(st):
-			resp.Diagnostics.AddError(
+			resp.Diagnostics.AddWarning(
 				"Resource in Failed State",
-				fmt.Sprintf("Snapshot %q reached a terminal failure state (%s) and will not recover on its own. "+
-					"Use `terraform apply -replace=<address>` to recreate it.", snapshotID, st),
+				fmt.Sprintf("Snapshot %q is in a terminal failure state (%s). "+
+					"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", snapshotID, st),
 			)
-			return
 		case IsCreatingState(st):
 			checker := func(ctx context.Context) (string, error) {
 				getResp, err := r.client.Client.FromStorage().Snapshots().Get(ctx, projectID, snapshotID, nil)

--- a/internal/provider/subnet_resource.go
+++ b/internal/provider/subnet_resource.go
@@ -539,12 +539,11 @@ func (r *SubnetResource) Read(ctx context.Context, req resource.ReadRequest, res
 	if response.Data.Status.State != nil {
 		switch st := *response.Data.Status.State; {
 		case isFailedState(st):
-			resp.Diagnostics.AddError(
+			resp.Diagnostics.AddWarning(
 				"Resource in Failed State",
-				fmt.Sprintf("Subnet %q reached a terminal failure state (%s) and will not recover on its own. "+
-					"Use `terraform apply -replace=<address>` to recreate it.", subnetID, st),
+				fmt.Sprintf("Subnet %q is in a terminal failure state (%s). "+
+					"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", subnetID, st),
 			)
-			return
 		case IsCreatingState(st):
 			checker := func(ctx context.Context) (string, error) {
 				getResp, err := r.client.Client.FromNetwork().Subnets().Get(ctx, projectID, vpcID, subnetID, nil)

--- a/internal/provider/vpc_resource.go
+++ b/internal/provider/vpc_resource.go
@@ -275,12 +275,11 @@ func (r *VPCResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 	if response.Data.Status.State != nil {
 		switch st := *response.Data.Status.State; {
 		case isFailedState(st):
-			resp.Diagnostics.AddError(
+			resp.Diagnostics.AddWarning(
 				"Resource in Failed State",
-				fmt.Sprintf("VPC %q reached a terminal failure state (%s) and will not recover on its own. "+
-					"Use `terraform apply -replace=<address>` to recreate it.", vpcID, st),
+				fmt.Sprintf("VPC %q is in a terminal failure state (%s). "+
+					"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", vpcID, st),
 			)
-			return
 		case IsCreatingState(st):
 			checker := func(ctx context.Context) (string, error) {
 				getResp, err := r.client.Client.FromNetwork().VPCs().Get(ctx, projectID, vpcID, nil)

--- a/internal/provider/vpcpeering_resource.go
+++ b/internal/provider/vpcpeering_resource.go
@@ -252,12 +252,11 @@ func (r *VpcPeeringResource) Read(ctx context.Context, req resource.ReadRequest,
 	if response.Data.Status.State != nil {
 		switch st := *response.Data.Status.State; {
 		case isFailedState(st):
-			resp.Diagnostics.AddError(
+			resp.Diagnostics.AddWarning(
 				"Resource in Failed State",
-				fmt.Sprintf("VpcPeering %q reached a terminal failure state (%s) and will not recover on its own. "+
-					"Use `terraform apply -replace=<address>` to recreate it.", peeringID, st),
+				fmt.Sprintf("VpcPeering %q is in a terminal failure state (%s). "+
+					"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", peeringID, st),
 			)
-			return
 		case IsCreatingState(st):
 			checker := func(ctx context.Context) (string, error) {
 				getResp, err := r.client.Client.FromNetwork().VPCPeerings().Get(ctx, projectID, vpcID, peeringID, nil)

--- a/internal/provider/vpcpeeringroute_resource.go
+++ b/internal/provider/vpcpeeringroute_resource.go
@@ -264,12 +264,11 @@ func (r *VpcPeeringRouteResource) Read(ctx context.Context, req resource.ReadReq
 	if response != nil && response.Data != nil && response.Data.Status.State != nil {
 		switch st := *response.Data.Status.State; {
 		case isFailedState(st):
-			resp.Diagnostics.AddError(
+			resp.Diagnostics.AddWarning(
 				"Resource in Failed State",
-				fmt.Sprintf("VpcPeeringRoute %q reached a terminal failure state (%s) and will not recover on its own. "+
-					"Use `terraform apply -replace=<address>` to recreate it.", routeID, st),
+				fmt.Sprintf("VpcPeeringRoute %q is in a terminal failure state (%s). "+
+					"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", routeID, st),
 			)
-			return
 		case IsCreatingState(st):
 			checker := func(ctx context.Context) (string, error) {
 				getResp, err := r.client.Client.FromNetwork().VPCPeeringRoutes().Get(ctx, projectID, vpcID, peeringID, routeID, nil)

--- a/internal/provider/vpnroute_resource.go
+++ b/internal/provider/vpnroute_resource.go
@@ -277,12 +277,11 @@ func (r *VPNRouteResource) Read(ctx context.Context, req resource.ReadRequest, r
 	if response.Data.Status.State != nil {
 		switch st := *response.Data.Status.State; {
 		case isFailedState(st):
-			resp.Diagnostics.AddError(
+			resp.Diagnostics.AddWarning(
 				"Resource in Failed State",
-				fmt.Sprintf("VPNRoute %q reached a terminal failure state (%s) and will not recover on its own. "+
-					"Use `terraform apply -replace=<address>` to recreate it.", routeID, st),
+				fmt.Sprintf("VPNRoute %q is in a terminal failure state (%s). "+
+					"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", routeID, st),
 			)
-			return
 		case IsCreatingState(st):
 			checker := func(ctx context.Context) (string, error) {
 				getResp, err := r.client.Client.FromNetwork().VPNRoutes().Get(ctx, projectID, vpnTunnelID, routeID, nil)

--- a/internal/provider/vpntunnel_resource.go
+++ b/internal/provider/vpntunnel_resource.go
@@ -655,12 +655,11 @@ func (r *VPNTunnelResource) Read(ctx context.Context, req resource.ReadRequest, 
 	if response.Data.Status.State != nil {
 		switch st := *response.Data.Status.State; {
 		case isFailedState(st):
-			resp.Diagnostics.AddError(
+			resp.Diagnostics.AddWarning(
 				"Resource in Failed State",
-				fmt.Sprintf("VPNTunnel %q reached a terminal failure state (%s) and will not recover on its own. "+
-					"Use `terraform apply -replace=<address>` to recreate it.", tunnelID, st),
+				fmt.Sprintf("VPNTunnel %q is in a terminal failure state (%s). "+
+					"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", tunnelID, st),
 			)
-			return
 		case IsCreatingState(st):
 			checker := func(ctx context.Context) (string, error) {
 				getResp, err := r.client.Client.FromNetwork().VPNTunnels().Get(ctx, projectID, tunnelID, nil)


### PR DESCRIPTION
## Summary

- `Read()` in all 20 resources was calling `AddError` when a resource was detected in a terminal `Failed` state, which blocked `terraform destroy` from running
- Changed to `AddWarning` + fall-through so Terraform can build a full destroy plan and call `Delete()` in the correct reverse-dependency order
- `Delete()` + `WaitForResourceDeleted()` already handle the actual cloud cleanup correctly with retries and 404 detection — no changes needed there

## Why the error was wrong

When a Create fails terminally, the provider intentionally saves the resource ID to state so that `terraform destroy` can target it later. But the `AddError` in `Read()` then blocked that very destroy from running — every `plan`, `apply`, and `destroy` call would error during the refresh phase, leaving CI pipelines with no automated recovery path.

Removing the resource from state (RemoveResource) would have been wrong too: it would leave orphaned cloud resources and break the dependency chain, since dependent resources referencing a failed parent would have nothing to delete against.

The correct fix is to let Terraform do what it is designed to do: call `Delete()` on each resource in reverse-dependency order (children before parents).

## Behaviour after this fix

| Operation | Before | After |
|-----------|--------|-------|
| `terraform apply` (resource fails) | Errors, saves ID to state | Same — no change |
| `terraform destroy` (resource in Failed state) | Errors in Read, nothing deleted | Emits warning, proceeds to delete in dependency order |
| `terraform plan` (resource in Failed state) | Errors | Emits warning, shows plan correctly |

## Affected resources (20)

`vpc`, `subnet`, `securitygroup`, `securityrule`, `elasticip`, `vpcpeering`, `vpcpeeringroute`, `vpntunnel`, `vpnroute`, `cloudserver`, `blockstorage`, `snapshot`, `backup`, `restore`, `dbaas`, `databasebackup`, `kaas`, `containerregistry`, `kms`, `schedulejob`

## Test plan

- [ ] Apply a config that causes a resource to reach `Failed` state
- [ ] Confirm `terraform destroy` completes without errors, removing resources in dependency order
- [ ] Confirm `terraform plan` shows a warning (not an error) and produces a valid plan

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)
