### PR TITLE
fix: unblock terraform destroy for Failed-state resources (v0.1.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.1.7 (June 22, 2026)
+
+BUG FIXES:
+
+* **All stateful resources**: Resources that reach a terminal `Failed` state no longer block `terraform destroy` ([#116](https://github.com/Arubacloud/terraform-provider-arubacloud/issues/116)). Previously, `Read()` returned a hard error for `Failed`-state resources, which prevented every subsequent Terraform operation — including `destroy` — from running and left CI pipelines stuck with no automated recovery path. `Read()` now emits a warning instead, populates state normally (the API returns valid metadata for failed resources), and allows Terraform to build a full destroy plan so that `Delete()` is invoked in the correct reverse-dependency order.
+
 ## 0.1.6 (May 27, 2026)
 
 BUG FIXES:


### PR DESCRIPTION
## Summary

- Downgraded `Read()` diagnostics from `AddError` to `AddWarning` when a resource is in a terminal `Failed` state across all 20 stateful resources
- Failed-state resources now populate Terraform state normally so `terraform destroy` can build a full destroy plan and invoke `Delete()` in the correct reverse-dependency order
- Updates CHANGELOG for the v0.1.7 release (June 22, 2026)

## Problem

When a resource reached a `Failed` state during provisioning, the provider stored its ID in state (correct) but then returned a hard error on every subsequent `Read()` call — including the one `terraform destroy` performs before planning. This left CI pipelines permanently stuck with no automated recovery path (fixes #116).

## Test plan

- [ ] Apply a config that intentionally produces a Failed resource (or simulate via API mock)
- [ ] Confirm `terraform destroy` runs to completion without errors
- [ ] Confirm a warning is printed for the Failed resource during the refresh phase
- [ ] Confirm `terraform apply -replace=<address>` still works as an alternative recovery path

:robot: Generated with [Claude Code](https://claude.com/claude-code)