### PR TITLE
test: make TestAccDbaasDataSource self-contained

### DIFF
--- a/internal/provider/dbaas_data_source_test.go
+++ b/internal/provider/dbaas_data_source_test.go
@@ -13,9 +13,8 @@ import (
 
 func TestAccDbaasDataSource(t *testing.T) {
 	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
-	dbaasID := os.Getenv("ARUBACLOUD_DBAAS_ID")
-	if projectID == "" || dbaasID == "" {
-		t.Skip("ARUBACLOUD_PROJECT_ID and ARUBACLOUD_DBAAS_ID must be set for acceptance tests")
+	if projectID == "" {
+		t.Skip("ARUBACLOUD_PROJECT_ID must be set for acceptance tests")
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -23,7 +22,7 @@ func TestAccDbaasDataSource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDbaasDataSourceConfig(projectID, dbaasID),
+				Config: testAccDbaasDataSourceConfig(projectID),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"data.arubacloud_dbaas.test",
@@ -66,11 +65,52 @@ func TestAccDbaasDataSource(t *testing.T) {
 	})
 }
 
-func testAccDbaasDataSourceConfig(projectID, dbaasID string) string {
+func testAccDbaasDataSourceConfig(projectID string) string {
 	return fmt.Sprintf(`
-data "arubacloud_dbaas" "test" {
-  id         = %[1]q
-  project_id = %[2]q
+resource "arubacloud_vpc" "test" {
+  name       = "test-ds-dbaas-vpc"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
 }
-`, dbaasID, projectID)
+
+resource "arubacloud_subnet" "test" {
+  name       = "test-ds-dbaas-subnet"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+  vpc_id     = arubacloud_vpc.test.id
+  type       = "Basic"
+}
+
+resource "arubacloud_securitygroup" "test" {
+  name       = "test-ds-dbaas-sg"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+  vpc_id     = arubacloud_vpc.test.id
+}
+
+resource "arubacloud_dbaas" "test" {
+  name       = "test-ds-dbaas"
+  location   = "ITBG-Bergamo"
+  zone       = "ITBG-1"
+  project_id = %[1]q
+  engine_id  = "mysql-8.0"
+  flavor     = "DBO2A4"
+  tags       = ["acceptance-test"]
+
+  storage = {
+    size_gb = 20
+  }
+
+  network = {
+    vpc_uri_ref            = arubacloud_vpc.test.uri
+    subnet_uri_ref         = arubacloud_subnet.test.uri
+    security_group_uri_ref = arubacloud_securitygroup.test.uri
+  }
+}
+
+data "arubacloud_dbaas" "test" {
+  id         = arubacloud_dbaas.test.id
+  project_id = %[1]q
+}
+`, projectID)
 }


### PR DESCRIPTION
﻿## Summary

- TestAccDbaasDataSource now creates its own VPC, Subnet, SecurityGroup, and DBaaS cluster inline.
- Eliminated ARUBACLOUD_DBAAS_ID env-var dependency.
- Only ARUBACLOUD_PROJECT_ID and API credentials are required.

## Test plan

- Run TF_ACC=1 go test ./... -run TestAccDbaasDataSource - should pass without any DBAAS_ID set
- go test ./... (unit tests) still passes

Closes #103

Generated with Claude Code
