### PR TITLE
test: make TestAccContainerregistryDataSource self-contained

### DIFF
--- a/internal/provider/containerregistry_data_source_test.go
+++ b/internal/provider/containerregistry_data_source_test.go
@@ -13,9 +13,8 @@ import (
 
 func TestAccContainerregistryDataSource(t *testing.T) {
 	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
-	registryID := os.Getenv("ARUBACLOUD_CONTAINERREGISTRY_ID")
-	if projectID == "" || registryID == "" {
-		t.Skip("ARUBACLOUD_PROJECT_ID and ARUBACLOUD_CONTAINERREGISTRY_ID must be set for acceptance tests")
+	if projectID == "" {
+		t.Skip("ARUBACLOUD_PROJECT_ID must be set for acceptance tests")
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -23,7 +22,7 @@ func TestAccContainerregistryDataSource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerregistryDataSourceConfig(projectID, registryID),
+				Config: testAccContainerregistryDataSourceConfig(projectID),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"data.arubacloud_containerregistry.test",
@@ -56,11 +55,73 @@ func TestAccContainerregistryDataSource(t *testing.T) {
 	})
 }
 
-func testAccContainerregistryDataSourceConfig(projectID, registryID string) string {
+func testAccContainerregistryDataSourceConfig(projectID string) string {
 	return fmt.Sprintf(`
-data "arubacloud_containerregistry" "test" {
-  id         = %[1]q
-  project_id = %[2]q
+resource "arubacloud_vpc" "test" {
+  name       = "test-ds-cr-vpc"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
 }
-`, registryID, projectID)
+
+resource "arubacloud_subnet" "test" {
+  name       = "test-ds-cr-subnet"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+  vpc_id     = arubacloud_vpc.test.id
+  type       = "Basic"
+}
+
+resource "arubacloud_securitygroup" "test" {
+  name       = "test-ds-cr-sg"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+  vpc_id     = arubacloud_vpc.test.id
+}
+
+resource "arubacloud_elasticip" "test" {
+  name           = "test-ds-cr-eip"
+  location       = "ITBG-Bergamo"
+  project_id     = %[1]q
+  billing_period = "Hour"
+}
+
+resource "arubacloud_blockstorage" "test" {
+  name           = "test-ds-cr-storage"
+  project_id     = %[1]q
+  location       = "ITBG-Bergamo"
+  size_gb        = 50
+  billing_period = "Hour"
+  zone           = "ITBG-1"
+  type           = "Standard"
+}
+
+resource "arubacloud_containerregistry" "test" {
+  name           = "test-ds-containerregistry"
+  location       = "ITBG-Bergamo"
+  project_id     = %[1]q
+  billing_period = "Hour"
+  tags           = ["acceptance-test"]
+
+  network = {
+    vpc_uri_ref            = arubacloud_vpc.test.uri
+    subnet_uri_ref         = arubacloud_subnet.test.uri
+    security_group_uri_ref = arubacloud_securitygroup.test.uri
+    public_ip_uri_ref      = arubacloud_elasticip.test.uri
+  }
+
+  storage = {
+    block_storage_uri_ref = arubacloud_blockstorage.test.uri
+  }
+
+  settings = {
+    admin_user              = "admin"
+    concurrent_users_flavor = "small"
+  }
+}
+
+data "arubacloud_containerregistry" "test" {
+  id         = arubacloud_containerregistry.test.id
+  project_id = %[1]q
+}
+`, projectID)
 }


### PR DESCRIPTION
﻿## Summary

- TestAccContainerregistryDataSource now creates its own VPC, Subnet, SecurityGroup, ElasticIP, BlockStorage, and ContainerRegistry inline.
- Eliminated ARUBACLOUD_CONTAINERREGISTRY_ID env-var dependency.
- Only ARUBACLOUD_PROJECT_ID and API credentials are required.

## Test plan

- Run TF_ACC=1 go test ./... -run TestAccContainerregistryDataSource - should pass without any CONTAINERREGISTRY_ID set
- go test ./... (unit tests) still passes

Closes #104

Generated with Claude Code
