### PR TITLE
test: make TestAccDatabasebackupDataSource self-contained

### DIFF
--- a/internal/provider/databasebackup_data_source_test.go
+++ b/internal/provider/databasebackup_data_source_test.go
@@ -13,9 +13,8 @@ import (
 
 func TestAccDatabasebackupDataSource(t *testing.T) {
 	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
-	backupID := os.Getenv("ARUBACLOUD_DATABASE_BACKUP_ID")
-	if projectID == "" || backupID == "" {
-		t.Skip("ARUBACLOUD_PROJECT_ID and ARUBACLOUD_DATABASE_BACKUP_ID must be set for acceptance tests")
+	if projectID == "" {
+		t.Skip("ARUBACLOUD_PROJECT_ID must be set for acceptance tests")
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -23,7 +22,7 @@ func TestAccDatabasebackupDataSource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatabasebackupDataSourceConfig(projectID, backupID),
+				Config: testAccDatabasebackupDataSourceConfig(projectID),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"data.arubacloud_databasebackup.test",
@@ -51,11 +50,69 @@ func TestAccDatabasebackupDataSource(t *testing.T) {
 	})
 }
 
-func testAccDatabasebackupDataSourceConfig(projectID, backupID string) string {
+func testAccDatabasebackupDataSourceConfig(projectID string) string {
 	return fmt.Sprintf(`
-data "arubacloud_databasebackup" "test" {
-  id         = %[1]q
-  project_id = %[2]q
+resource "arubacloud_vpc" "test" {
+  name       = "test-ds-dbbackup-vpc"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
 }
-`, backupID, projectID)
+
+resource "arubacloud_subnet" "test" {
+  name       = "test-ds-dbbackup-subnet"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+  vpc_id     = arubacloud_vpc.test.id
+  type       = "Basic"
+}
+
+resource "arubacloud_securitygroup" "test" {
+  name       = "test-ds-dbbackup-sg"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+  vpc_id     = arubacloud_vpc.test.id
+}
+
+resource "arubacloud_dbaas" "test" {
+  name       = "test-ds-dbbackup-dbaas"
+  location   = "ITBG-Bergamo"
+  zone       = "ITBG-1"
+  project_id = %[1]q
+  engine_id  = "mysql-8.0"
+  flavor     = "DBO2A4"
+  tags       = ["acceptance-test"]
+
+  storage = {
+    size_gb = 20
+  }
+
+  network = {
+    vpc_uri_ref            = arubacloud_vpc.test.uri
+    subnet_uri_ref         = arubacloud_subnet.test.uri
+    security_group_uri_ref = arubacloud_securitygroup.test.uri
+  }
+}
+
+resource "arubacloud_database" "test" {
+  name       = "testdb"
+  project_id = %[1]q
+  dbaas_id   = arubacloud_dbaas.test.id
+}
+
+resource "arubacloud_databasebackup" "test" {
+  name           = "test-ds-databasebackup"
+  project_id     = %[1]q
+  location       = "ITBG-Bergamo"
+  zone           = "ITBG-1"
+  dbaas_id       = arubacloud_dbaas.test.id
+  database       = arubacloud_database.test.name
+  billing_period = "Hour"
+  tags           = ["acceptance-test"]
+}
+
+data "arubacloud_databasebackup" "test" {
+  id         = arubacloud_databasebackup.test.id
+  project_id = %[1]q
+}
+`, projectID)
 }


### PR DESCRIPTION
﻿## Summary

- TestAccDatabasebackupDataSource now creates its own VPC, Subnet, SecurityGroup, DBaaS cluster, Database, and DatabaseBackup resources inline.
- Eliminated ARUBACLOUD_DATABASE_BACKUP_ID env-var dependency.
- Only ARUBACLOUD_PROJECT_ID and API credentials are required.

## Test plan

- Run TF_ACC=1 go test ./... -run TestAccDatabasebackupDataSource - should pass without any DATABASE_BACKUP_ID set
- go test ./... (unit tests) still passes

Closes #107

Generated with Claude Code
