### PR TITLE
test: improve unit test coverage for helper functions

### DIFF
--- a/internal/provider/provider_error_test.go
+++ b/internal/provider/provider_error_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	sdktypes "github.com/Arubacloud/sdk-go/pkg/types"
@@ -293,5 +294,138 @@ func TestErrorCategoryHelpers(t *testing.T) {
 	}
 	if ErrorIsTechnical(nil) {
 		t.Error("nil should not be technical")
+	}
+}
+
+// ── sanitizeAPIString ─────────────────────────────────────────────────────────
+
+func TestSanitizeAPIString(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"hello", "hello"},
+		{"tab\there", "tab here"},
+		{"new\nline", "new line"},
+		{"multiple  spaces", "multiple spaces"},
+		{"\t\n  \t", ""},
+		{"  leading and trailing  ", "leading and trailing"},
+		{"multiple   spaces   here", "multiple spaces here"},
+	}
+	for _, tc := range cases {
+		if got := sanitizeAPIString(tc.in); got != tc.want {
+			t.Errorf("sanitizeAPIString(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// ── ProviderErrorCategory.String ─────────────────────────────────────────────
+
+func TestProviderErrorCategory_String(t *testing.T) {
+	cases := []struct {
+		cat  ProviderErrorCategory
+		want string
+	}{
+		{ProviderErrorCategorySemantic, "semantic"},
+		{ProviderErrorCategoryTransient, "transient"},
+		{ProviderErrorCategoryTechnical, "technical"},
+		{ProviderErrorCategory(99), "unknown"},
+	}
+	for _, tc := range cases {
+		if got := tc.cat.String(); got != tc.want {
+			t.Errorf("ProviderErrorCategory(%d).String() = %q, want %q", tc.cat, got, tc.want)
+		}
+	}
+}
+
+// ── ProviderError.Error ───────────────────────────────────────────────────────
+
+func TestProviderError_Error(t *testing.T) {
+	// With Cause: message should mention operation, resource, and cause text.
+	cause := errors.New("network failure")
+	e1 := &ProviderError{
+		Category:  ProviderErrorCategoryTechnical,
+		Operation: "create",
+		Resource:  "vpc",
+		Cause:     cause,
+	}
+	msg1 := e1.Error()
+	for _, sub := range []string{"create", "vpc", "network failure"} {
+		if !strings.Contains(msg1, sub) {
+			t.Errorf("ProviderError.Error() with Cause = %q, missing %q", msg1, sub)
+		}
+	}
+
+	// Without Cause, full fields: message should contain status code, category,
+	// title, detail, and instance.
+	e2 := &ProviderError{
+		Category:   ProviderErrorCategorySemantic,
+		StatusCode: 400,
+		Title:      "Bad Request",
+		Detail:     "name is required",
+		Instance:   "/api/v1/vpc",
+		Operation:  "create",
+		Resource:   "vpc",
+	}
+	msg2 := e2.Error()
+	for _, sub := range []string{"400", "Bad Request", "name is required", "/api/v1/vpc"} {
+		if !strings.Contains(msg2, sub) {
+			t.Errorf("ProviderError.Error() without Cause = %q, missing %q", msg2, sub)
+		}
+	}
+
+	// Without Cause, empty optional fields: no panic.
+	e3 := &ProviderError{
+		Category:   ProviderErrorCategoryTechnical,
+		StatusCode: 500,
+		Operation:  "delete",
+		Resource:   "vpc",
+	}
+	msg3 := e3.Error()
+	if !strings.Contains(msg3, "500") || !strings.Contains(msg3, "delete") {
+		t.Errorf("ProviderError.Error() minimal = %q, expected status+operation", msg3)
+	}
+}
+
+// ── ProviderError.Unwrap ──────────────────────────────────────────────────────
+
+func TestProviderError_Unwrap(t *testing.T) {
+	cause := errors.New("root cause")
+	e := &ProviderError{Cause: cause, Operation: "create", Resource: "vpc"}
+	if !errors.Is(e, cause) {
+		t.Error("errors.Is should find cause via Unwrap")
+	}
+
+	// No Cause → Unwrap returns nil.
+	e2 := &ProviderError{StatusCode: 400, Operation: "create", Resource: "vpc"}
+	if errors.Unwrap(e2) != nil {
+		t.Error("Unwrap should return nil when Cause is not set")
+	}
+}
+
+// ── NewTransportError ─────────────────────────────────────────────────────────
+
+func TestNewTransportError(t *testing.T) {
+	cause := errors.New("dial error")
+	err := NewTransportError("create", "vpc", cause)
+
+	if err.Category != ProviderErrorCategoryTechnical {
+		t.Errorf("expected Technical category, got %v", err.Category)
+	}
+	if err.Operation != "create" {
+		t.Errorf("expected operation 'create', got %q", err.Operation)
+	}
+	if err.Resource != "vpc" {
+		t.Errorf("expected resource 'vpc', got %q", err.Resource)
+	}
+	if !errors.Is(err, cause) {
+		t.Error("expected errors.Is to find cause via Unwrap")
+	}
+	if !ErrorIsTechnical(err) {
+		t.Error("ErrorIsTechnical should return true for transport error")
+	}
+	if ErrorIsTransient(err) || ErrorIsSemantic(err) {
+		t.Error("transport error should not be transient or semantic")
 	}
 }

--- a/internal/provider/provider_errorcases_test.go
+++ b/internal/provider/provider_errorcases_test.go
@@ -341,3 +341,141 @@ resource "arubacloud_containerregistry" "test" {
 		},
 	})
 }
+
+// --- Compute (additional) ---
+
+func TestUnitCloudserverResource_MissingProjectID(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "arubacloud_cloudserver" "test" {
+  name     = "test-cs"
+  location = "ITBG-Bergamo"
+  zone     = "ITBG-1"
+}
+`,
+				ExpectError: regexp.MustCompile(`project_id`),
+			},
+		},
+	})
+}
+
+// --- Security (additional) ---
+
+func TestUnitSecurityruleResource_MissingSecurityGroupID(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "arubacloud_securityrule" "test" {
+  name       = "test-rule"
+  location   = "ITBG-Bergamo"
+  project_id = "test-project"
+  vpc_id     = "test-vpc"
+}
+`,
+				ExpectError: regexp.MustCompile(`security_group_id`),
+			},
+		},
+	})
+}
+
+// --- Network (additional) ---
+
+func TestUnitVpcpeeringResource_MissingVpcID(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "arubacloud_vpcpeering" "test" {
+  name       = "test-peering"
+  location   = "ITBG-Bergamo"
+  project_id = "test-project"
+  peer_vpc   = "peer-vpc-id"
+}
+`,
+				ExpectError: regexp.MustCompile(`vpc_id`),
+			},
+		},
+	})
+}
+
+func TestUnitVpcpeeringrouteResource_MissingVpcPeeringID(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "arubacloud_vpcpeeringroute" "test" {
+  name       = "test-route"
+  project_id = "test-project"
+  vpc_id     = "test-vpc"
+}
+`,
+				ExpectError: regexp.MustCompile(`vpc_peering_id`),
+			},
+		},
+	})
+}
+
+func TestUnitVpnrouteResource_MissingVpnTunnelID(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "arubacloud_vpnroute" "test" {
+  name       = "test-vpnroute"
+  location   = "ITBG-Bergamo"
+  project_id = "test-project"
+}
+`,
+				ExpectError: regexp.MustCompile(`vpn_tunnel_id`),
+			},
+		},
+	})
+}
+
+// --- Database (additional) ---
+
+func TestUnitDatabasegrantResource_MissingDbaasID(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "arubacloud_databasegrant" "test" {
+  project_id = "test-project"
+  database   = "testdb"
+  user_id    = "testuser"
+}
+`,
+				ExpectError: regexp.MustCompile(`dbaas_id`),
+			},
+		},
+	})
+}
+
+func TestUnitDatabasebackupResource_MissingDbaasID(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "arubacloud_databasebackup" "test" {
+  project_id = "test-project"
+  name       = "test-dbbackup"
+  location   = "ITBG-Bergamo"
+  zone       = "ITBG-1"
+  database   = "testdb"
+}
+`,
+				ExpectError: regexp.MustCompile(`dbaas_id`),
+			},
+		},
+	})
+}

--- a/internal/provider/resource_wait_test.go
+++ b/internal/provider/resource_wait_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	sdktypes "github.com/Arubacloud/sdk-go/pkg/types"
 	tfdiag "github.com/hashicorp/terraform-plugin-framework/diag"
 )
 
@@ -481,5 +483,146 @@ func TestWaitForResourceDeleted_RecognisesNotFoundPattern(t *testing.T) {
 
 	if err := WaitForResourceDeleted(context.Background(), checker, "kaas", "abc", time.Second); err != nil {
 		t.Fatalf("expected deletion to be detected via IsNotFound, got %v", err)
+	}
+}
+
+// ── isReadyState ─────────────────────────────────────────────────────────────
+
+func TestIsReadyState(t *testing.T) {
+	transitional := []string{
+		"InCreation", "Creating", "Updating", "Deleting", "Pending", "Provisioning",
+	}
+	for _, s := range transitional {
+		if isReadyState(s) {
+			t.Errorf("isReadyState(%q) = true, want false", s)
+		}
+	}
+	ready := []string{"Active", "NotUsed", "InUse", "Used", "Stopped", "Running", "Unknown"}
+	for _, s := range ready {
+		if !isReadyState(s) {
+			t.Errorf("isReadyState(%q) = false, want true", s)
+		}
+	}
+}
+
+// ── ErrWaitTimeout.Error ──────────────────────────────────────────────────────
+
+func TestErrWaitTimeout_Error(t *testing.T) {
+	te := &ErrWaitTimeout{
+		ResourceType: "vpc",
+		ResourceID:   "abc",
+		Timeout:      time.Minute,
+		Operation:    "become active",
+	}
+	msg := te.Error()
+	for _, substr := range []string{"vpc", "abc", "1m0s", "become active"} {
+		if !strings.Contains(msg, substr) {
+			t.Errorf("ErrWaitTimeout.Error() = %q, missing %q", msg, substr)
+		}
+	}
+
+	// Empty Operation defaults to "become active".
+	te2 := &ErrWaitTimeout{ResourceType: "kaas", ResourceID: "xyz", Timeout: 5 * time.Minute}
+	msg2 := te2.Error()
+	if !strings.Contains(msg2, "become active") {
+		t.Errorf("ErrWaitTimeout.Error() with empty Operation = %q, missing 'become active'", msg2)
+	}
+}
+
+// ── ReportWaitResult ─────────────────────────────────────────────────────────
+
+func TestReportWaitResult_TimeoutProducesWarning(t *testing.T) {
+	var d tfdiag.Diagnostics
+	ReportWaitResult(&d, &ErrWaitTimeout{ResourceType: "vpc", ResourceID: "abc", Timeout: time.Minute}, "vpc", "abc")
+	if d.HasError() {
+		t.Error("expected no error diagnostic for timeout, got error")
+	}
+	if len(d) == 0 {
+		t.Error("expected at least one warning diagnostic, got none")
+	}
+}
+
+func TestReportWaitResult_NonTimeoutProducesError(t *testing.T) {
+	var d tfdiag.Diagnostics
+	ReportWaitResult(&d, errors.New("something broke"), "vpc", "abc")
+	if !d.HasError() {
+		t.Error("expected error diagnostic for non-timeout error, got none")
+	}
+}
+
+// ── remainingTimeout ─────────────────────────────────────────────────────────
+
+func TestRemainingTimeout(t *testing.T) {
+	total := 10 * time.Minute
+
+	// Recent start: nearly the full budget remains.
+	got := remainingTimeout(time.Now(), total)
+	if got <= 0 || got > total {
+		t.Errorf("remainingTimeout for fresh start = %v, expected (0, %v]", got, total)
+	}
+
+	// Start was 20 minutes ago, total is 10 minutes: budget exhausted → 0.
+	old := time.Now().Add(-20 * time.Minute)
+	got2 := remainingTimeout(old, total)
+	if got2 != 0 {
+		t.Errorf("remainingTimeout for exhausted budget = %v, expected 0", got2)
+	}
+}
+
+// ── CreateWithTransientRetry ─────────────────────────────────────────────────
+
+func TestCreateWithTransientRetry_SucceedsImmediately(t *testing.T) {
+	var calls int32
+	createFunc := func() error {
+		atomic.AddInt32(&calls, 1)
+		return nil
+	}
+	err := CreateWithTransientRetry(context.Background(), createFunc, "vpc", "abc", time.Minute)
+	if err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if n := atomic.LoadInt32(&calls); n != 1 {
+		t.Fatalf("expected 1 call, got %d", n)
+	}
+}
+
+func TestCreateWithTransientRetry_NonTransientErrorReturnedImmediately(t *testing.T) {
+	semantic := newResponseError("create", "vpc", 400, &sdktypes.ErrorResponse{
+		Errors: []sdktypes.ValidationError{{Field: "name", Message: "required"}},
+	}, nil)
+	var calls int32
+	createFunc := func() error {
+		atomic.AddInt32(&calls, 1)
+		return semantic
+	}
+	err := CreateWithTransientRetry(context.Background(), createFunc, "vpc", "abc", time.Minute)
+	if err == nil {
+		t.Fatal("expected non-nil error, got nil")
+	}
+	if n := atomic.LoadInt32(&calls); n != 1 {
+		t.Fatalf("expected exactly 1 call for semantic error, got %d", n)
+	}
+}
+
+func TestCreateWithTransientRetry_TransientErrorTimesOut(t *testing.T) {
+	transient := newResponseError("create", "vpc", 400, nil, nil)
+	if !ErrorIsTransient(transient) {
+		t.Fatal("test setup: expected 400 with no validation errors to be transient")
+	}
+
+	var calls int32
+	createFunc := func() error {
+		atomic.AddInt32(&calls, 1)
+		return transient
+	}
+
+	// A negative timeout means the deadline is already in the past: the function
+	// detects the timeout immediately after the first transient error.
+	err := CreateWithTransientRetry(context.Background(), createFunc, "vpc", "abc", -time.Second)
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if n := atomic.LoadInt32(&calls); n < 1 {
+		t.Fatal("expected createFunc to be called at least once")
 	}
 }

--- a/internal/provider/subnet_resource_test.go
+++ b/internal/provider/subnet_resource_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -105,4 +106,43 @@ resource "arubacloud_subnet" "test" {
   }
 }
 `, name)
+}
+
+// ── cidrContains ──────────────────────────────────────────────────────────────
+
+func TestCidrContains(t *testing.T) {
+	parseCIDR := func(s string) *net.IPNet {
+		t.Helper()
+		_, n, err := net.ParseCIDR(s)
+		if err != nil {
+			t.Fatalf("ParseCIDR(%q): %v", s, err)
+		}
+		return n
+	}
+
+	cases := []struct {
+		parent string
+		child  string
+		want   bool
+	}{
+		// Subnet is contained in the parent.
+		{"10.0.0.0/8", "10.1.2.0/24", true},
+		// Equal networks are considered contained.
+		{"10.0.0.0/24", "10.0.0.0/24", true},
+		// Child prefix longer than parent — still a subset.
+		{"192.168.0.0/16", "192.168.1.0/24", true},
+		// Child has a different network address — not contained.
+		{"10.0.0.0/24", "10.0.1.0/24", false},
+		// Parent is a subnet of child (narrower mask) — not contained.
+		{"10.0.0.0/24", "10.0.0.0/16", false},
+		// IPv4 vs IPv6 — different bit widths, never contained.
+		{"10.0.0.0/8", "::1/128", false},
+	}
+
+	for _, tc := range cases {
+		parent, child := parseCIDR(tc.parent), parseCIDR(tc.child)
+		if got := cidrContains(parent, child); got != tc.want {
+			t.Errorf("cidrContains(%q, %q) = %v, want %v", tc.parent, tc.child, got, tc.want)
+		}
+	}
 }


### PR DESCRIPTION
## Summary  
- Add unit tests
- Add  for the subnet CIDR containment helper 
- Add 8 new  schema-validation error-case tests for resources that were missing coverage: ,
-  All tests are table-driven and run without  or live API credentials.

-  Closes #97.  

## Test plan  
- [ ]  passes (all ~198 unit tests green) 
- [ ] No acceptance tests are modified or broken 
- [ ] Coverage is measurably higher than before this PR  
