### PR TITLE
test: increase unit test coverage from 68% to 75%

### DIFF
--- a/internal/provider/coverage_simple_unit_test.go
+++ b/internal/provider/coverage_simple_unit_test.go
@@ -1,0 +1,33 @@
+package provider
+
+import (
+	"context"
+	"testing"
+)
+
+// TestPtrToString verifies the ptrToString helper (defined in kaas_data_source.go)
+// with both a non-nil and a nil pointer, covering the two branches of the function.
+func TestPtrToString(t *testing.T) {
+	s := "hello"
+	if got := ptrToString(&s); got != "hello" {
+		t.Errorf("ptrToString(&s): got %q, want %q", got, "hello")
+	}
+	if got := ptrToString(nil); got != "" {
+		t.Errorf("ptrToString(nil): got %q, want %q", got, "")
+	}
+}
+
+// TestProtocolNormalizePlanModifier_Descriptions verifies that the
+// Description() and MarkdownDescription() methods on
+// protocolNormalizePlanModifier return non-empty strings.
+func TestProtocolNormalizePlanModifier_Descriptions(t *testing.T) {
+	ctx := context.Background()
+	m := protocolNormalizePlanModifier{}
+
+	if got := m.Description(ctx); got == "" {
+		t.Error("Description() returned empty string")
+	}
+	if got := m.MarkdownDescription(ctx); got == "" {
+		t.Error("MarkdownDescription() returned empty string")
+	}
+}

--- a/internal/provider/datasource_read_rich_test.go
+++ b/internal/provider/datasource_read_rich_test.go
@@ -1,0 +1,91 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+)
+
+// dbaasRichPropertiesJSON is a DBaaS API response that includes optional
+// property fields (engine, flavor, billingPlan, storage) that minimalActiveJSON
+// leaves absent.  Using this JSON covers the `!= nil` branches for each field
+// in DBaaSResource.Read() and the `else` (preserve-from-state) branches when
+// Storage.SizeGB is present.
+const dbaasRichPropertiesJSON = `{` +
+	`"metadata":{` +
+	`"id":"test-id","name":"test-name",` +
+	`"location":{"value":"test-location","code":"test-code","name":"test-region"},` +
+	`"project":{"id":"test-project-id"}` +
+	`},` +
+	`"status":{"state":"Active"},` +
+	`"properties":{` +
+	`"engine":{"id":"postgres-14"},` +
+	`"flavor":{"name":"m1"},` +
+	`"billingPlan":{"billingPeriod":"Hour"},` +
+	`"storage":{"sizeGb":20}` +
+	`}` +
+	`}`
+
+// TestDBaaSResource_Read_WithProperties verifies that DBaaSResource.Read()
+// correctly maps engine, flavor, billingPlan and storage from the API response
+// into Terraform state.  resourceReadReqFull provides non-null storage and
+// network in state so the autoscaling-preserve-from-state branches are also
+// exercised.
+func TestDBaaSResource_Read_WithProperties(t *testing.T) {
+	ctx := context.Background()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(dbaasRichPropertiesJSON)) //nolint:errcheck
+	}
+
+	_, mockClient := newMockArubaClient(t, handler)
+
+	res := NewDBaaSResource()
+	configureResource(ctx, t, res, mockClient)
+
+	req, resp := resourceReadReqFull(ctx, t, res)
+	res.Read(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("DBaaSResource Read() with properties reported error: %v", resp.Diagnostics)
+	}
+	if resp.State.Raw.IsNull() {
+		t.Fatal("DBaaSResource Read() removed resource from state unexpectedly")
+	}
+}
+
+// TestSubnetDataSource_Read_WithDHCP exercises SubnetDataSource.Read() with a
+// response that includes a full DHCP block (range, routes, DNS), covering the
+// DHCP-mapping branches that are skipped by minimalActiveJSON / richMetadataJSON.
+//
+// The JSON matches the SubnetPropertiesResponse SDK struct field tags.
+func TestSubnetDataSource_Read_WithDHCP(t *testing.T) {
+	ctx := context.Background()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(subnetAdvancedJSON)) //nolint:errcheck
+	}
+
+	_, mockClient := newMockArubaClient(t, handler)
+
+	ds := NewSubnetDataSource()
+	configureDatasource(ctx, t, ds, mockClient)
+
+	schemaResp := &datasource.SchemaResponse{}
+	ds.Schema(ctx, datasource.SchemaRequest{}, schemaResp)
+
+	req := dsReadReq(ctx, t, ds, nil)
+	resp := &datasource.ReadResponse{State: tfsdk.State{Schema: schemaResp.Schema}}
+	ds.Read(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("SubnetDataSource Read() with DHCP reported error: %v", resp.Diagnostics)
+	}
+}

--- a/internal/provider/kaas_properties_test.go
+++ b/internal/provider/kaas_properties_test.go
@@ -1,0 +1,106 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+)
+
+// kaasFullPropertiesJSON is a KaaS API response that includes all optional
+// properties blocks: vpc, subnet, securityGroup, nodecidr, podcidr,
+// billingPlan, ha, managementIp, kubernetesVersion, and nodesPool.
+//
+// The JSON key "nodesPool" (not "nodePools") matches the SDK field tag
+// `json:"nodesPool,omitempty"` in NodePoolPropertiesResponse, so the pool
+// array is actually deserialized and ptrToString() is exercised for the
+// pool Name field.
+const kaasFullPropertiesJSON = `{` +
+	`"metadata":{"id":"test-id","name":"test-name"},` +
+	`"status":{"state":"Active"},` +
+	`"properties":{` +
+	`"managementIp":"10.0.0.1",` +
+	`"kubernetesVersion":{"value":"1.29"},` +
+	`"ha":true,` +
+	`"billingPlan":{"billingPeriod":"Hour"},` +
+	`"vpc":{"uri":"test-vpc-uri"},` +
+	`"subnet":{"uri":"test-subnet-uri"},` +
+	`"securityGroup":{"name":"test-sg-name"},` +
+	`"nodecidr":{"address":"10.0.1.0/24","name":"test-cidr"},` +
+	`"podcidr":{"address":"10.1.0.0/16"},` +
+	`"nodesPool":[{` +
+	`"name":"test-pool",` +
+	`"nodes":2,` +
+	`"instance":{"name":"test-instance"},` +
+	`"dataCenter":{"code":"test-zone"},` +
+	`"autoscaling":true,` +
+	`"minCount":1,` +
+	`"maxCount":5` +
+	`}]` +
+	`}}`
+
+// kaasFullPropertiesHandler returns kaasFullPropertiesJSON for every GET and
+// 500 for any write operation (none expected during Read).
+func kaasFullPropertiesHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(kaasFullPropertiesJSON)) //nolint:errcheck
+}
+
+// TestKaaSDataSource_FullProperties exercises the KaaS data source Read() with
+// a response that populates all optional property branches:
+//   - VPC URI, Subnet URI, SecurityGroup.Name, NodeCIDR address+name, PodCIDR
+//   - BillingPlan.BillingPeriod, HA, ManagementIP
+//   - nodesPool loop (exercises ptrToString() on Name, Instance.Name,
+//     DataCenter.Code, MinCount, MaxCount)
+//   - kubeconfig download attempt (managementIp is set; mock returns full JSON
+//     which has no "content" field, so kubeconfig falls through to StringNull)
+func TestKaaSDataSource_FullProperties(t *testing.T) {
+	ctx := context.Background()
+
+	_, mockClient := newMockArubaClient(t, kaasFullPropertiesHandler)
+
+	ds := NewKaaSDataSource()
+	configureDatasource(ctx, t, ds, mockClient)
+
+	schemaResp := &datasource.SchemaResponse{}
+	ds.Schema(ctx, datasource.SchemaRequest{}, schemaResp)
+
+	req := dsReadReq(ctx, t, ds, nil)
+	resp := &datasource.ReadResponse{State: tfsdk.State{Schema: schemaResp.Schema}}
+	ds.Read(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("KaaS datasource Read() reported error with full properties: %v", resp.Diagnostics)
+	}
+}
+
+// TestKaaSResource_Read_FullProperties exercises the KaaS resource Read() with
+// a response that populates all optional property branches.  resourceReadReqFull
+// provides non-null nested state objects so that the network/settings
+// object-building code inside Read() is reached.
+func TestKaaSResource_Read_FullProperties(t *testing.T) {
+	oldActivePoll := waitForActivePollInterval
+	waitForActivePollInterval = 1 * time.Millisecond
+	t.Cleanup(func() { waitForActivePollInterval = oldActivePoll })
+
+	ctx := context.Background()
+
+	_, mockClient := newMockArubaClient(t, kaasFullPropertiesHandler)
+
+	res := NewKaaSResource()
+	configureResource(ctx, t, res, mockClient)
+
+	req, resp := resourceReadReqFull(ctx, t, res)
+	res.Read(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("KaaS resource Read() reported error with full properties: %v", resp.Diagnostics)
+	}
+	if resp.State.Raw.IsNull() {
+		t.Fatal("KaaS resource Read() removed resource from state unexpectedly")
+	}
+}

--- a/internal/provider/project_create_rich_test.go
+++ b/internal/provider/project_create_rich_test.go
@@ -1,0 +1,95 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+// projectCreateRichJSON is the API response for a successful project Create that
+// includes a description in Properties and tags in Metadata.  This exercises the
+// branches inside ProjectResource.Create() that map the response description and
+// tags back into Terraform state (lines that are skipped by minimalActiveJSON).
+const projectCreateRichJSON = `{` +
+	`"metadata":{` +
+	`"id":"test-project-id",` +
+	`"name":"test-name",` +
+	`"tags":["env:test","team:platform"]` +
+	`},` +
+	`"status":{"state":"Active"},` +
+	`"properties":{` +
+	`"description":"test description"` +
+	`}` +
+	`}`
+
+// TestProjectCreate_WithTagsAndDescription verifies that ProjectResource.Create()
+// correctly maps tags and description from the API response into Terraform state.
+// This covers the `if len(response.Data.Metadata.Tags) > 0` branch and the
+// `if response.Data.Properties.Description != nil` branch that minimalActiveJSON
+// leaves uncovered.
+func TestProjectCreate_WithTagsAndDescription(t *testing.T) {
+	ctx := context.Background()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusCreated)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+		w.Write([]byte(projectCreateRichJSON)) //nolint:errcheck
+	}
+
+	_, mockClient := newMockArubaClient(t, handler)
+
+	res := NewProjectResource()
+	configureResource(ctx, t, res, mockClient)
+
+	req, resp := resourceCreateReq(ctx, t, res)
+	res.Create(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("ProjectResource Create() with description+tags reported error: %v", resp.Diagnostics)
+	}
+}
+
+// TestProjectCreate_WithEmptyTagsList verifies that ProjectResource.Create()
+// correctly handles a response where Tags is empty but the plan had a non-null
+// (empty) tags list.  This covers the `else { emptyList }` branch in the Create
+// function's tags-response section.
+const projectCreateNoTagsJSON = `{` +
+	`"metadata":{` +
+	`"id":"test-project-id",` +
+	`"name":"test-name"` +
+	`},` +
+	`"status":{"state":"Active"},` +
+	`"properties":{}` +
+	`}`
+
+func TestProjectCreate_WithEmptyTagsList(t *testing.T) {
+	ctx := context.Background()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusCreated)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+		w.Write([]byte(projectCreateNoTagsJSON)) //nolint:errcheck
+	}
+
+	_, mockClient := newMockArubaClient(t, handler)
+
+	res := NewProjectResource()
+	configureResource(ctx, t, res, mockClient)
+
+	// resourceCreateReq sets tags to null (non-string attribute).
+	// This hits the `data.Tags.IsNull()` true branch.
+	req, resp := resourceCreateReq(ctx, t, res)
+	res.Create(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("ProjectResource Create() with no-tags response reported error: %v", resp.Diagnostics)
+	}
+}

--- a/internal/provider/resource_create_rich_test.go
+++ b/internal/provider/resource_create_rich_test.go
@@ -1,0 +1,108 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+// createRichJSON is a create-response that includes all optional metadata
+// fields returned by the API (id, uri, tags).  Using this handler covers the
+// "URI non-nil" and "len(Tags) > 0" branches in Create() functions that are
+// skipped when the handler returns minimalActiveJSON.
+const createRichJSON = `{` +
+	`"metadata":{` +
+	`"id":"test-id",` +
+	`"name":"test-name",` +
+	`"uri":"/test/resource/test-id",` +
+	`"tags":["env:test","team:platform"]` +
+	`},"status":{"state":"Active"}}`
+
+// createSuccessRichHandler returns createRichJSON for both POST and GET
+// requests.  POST (the actual create) receives 201; GET receives 200.  This
+// is used by TestResourceCreate_RichResponse to cover the URI / tags response
+// branches in Create() for a batch of resources.
+func createSuccessRichHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if r.Method == http.MethodPost {
+		w.WriteHeader(http.StatusCreated)
+	} else {
+		w.WriteHeader(http.StatusOK)
+	}
+	w.Write([]byte(createRichJSON)) //nolint:errcheck
+}
+
+// createSuccessRichWithURIHandler is like createSuccessRichHandler but uses
+// a response that contains metadata.uri (required by backup/restore Create()
+// which perform a GET to resolve the source volume URI before the POST).
+const createRichWithSourceURI = `{` +
+	`"metadata":{` +
+	`"id":"test-id",` +
+	`"name":"test-name",` +
+	`"uri":"/projects/p/providers/Aruba.Storage/volumes/test-vol-id",` +
+	`"tags":["env:test"]` +
+	`},"status":{"state":"Active"}}`
+
+func createSuccessRichWithURIHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if r.Method == http.MethodPost {
+		w.WriteHeader(http.StatusCreated)
+	} else {
+		w.WriteHeader(http.StatusOK)
+	}
+	w.Write([]byte(createRichWithSourceURI)) //nolint:errcheck
+}
+
+// TestResourceCreate_RichResponse repeats TestResourceCreate_Success with a
+// handler that returns uri and tags in the response body.  This covers the
+// "metadata.URI non-nil → data.Uri = ..." and "len(Tags) > 0 → data.Tags = ..."
+// branches that minimalActiveJSON leaves as uncovered "false" paths in the
+// Create() functions below.
+func TestResourceCreate_RichResponse(t *testing.T) {
+	oldActivePoll := waitForActivePollInterval
+	waitForActivePollInterval = 1 * time.Millisecond
+	t.Cleanup(func() { waitForActivePollInterval = oldActivePoll })
+
+	ctx := context.Background()
+
+	cases := []struct {
+		name    string
+		newR    func() resource.Resource
+		handler http.HandlerFunc
+	}{
+		{"vpc", NewVPCResource, createSuccessRichHandler},
+		{"subnet", NewSubnetResource, createSuccessRichHandler},
+		{"securitygroup", NewSecurityGroupResource, createSuccessRichHandler},
+		{"elasticip", NewElasticIPResource, createSuccessRichHandler},
+		{"keypair", NewKeypairResource, createSuccessRichHandler},
+		{"blockstorage", NewBlockStorageResource, createSuccessRichHandler},
+		{"snapshot", NewSnapshotResource, createSuccessRichHandler},
+		{"kms", NewKMSResource, createSuccessRichHandler},
+		{"vpcpeering", NewVpcPeeringResource, createSuccessRichHandler},
+		{"vpcpeeringroute", NewVpcPeeringRouteResource, createSuccessRichHandler},
+		{"vpntunnel", NewVPNTunnelResource, createSuccessRichHandler},
+		{"databasegrant", NewDatabaseGrantResource, createSuccessRichHandler},
+		// backup / restore pre-fetch a source volume URI before the actual POST.
+		{"backup", NewBackupResource, createSuccessRichWithURIHandler},
+		{"restore", NewRestoreResource, createSuccessRichWithURIHandler},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, mockClient := newMockArubaClient(t, tc.handler)
+
+			res := tc.newR()
+			configureResource(ctx, t, res, mockClient)
+
+			req, resp := resourceCreateReq(ctx, t, res)
+			res.Create(ctx, req, resp)
+
+			if resp.Diagnostics.HasError() {
+				t.Errorf("%s: Create() with rich response reported error: %v", tc.name, resp.Diagnostics)
+			}
+		})
+	}
+}

--- a/internal/provider/resource_read_error_extra_test.go
+++ b/internal/provider/resource_read_error_extra_test.go
@@ -1,0 +1,82 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+// resourcesForExtraErrorTests lists resources that are missing from the
+// existing TestResourceRead_API404 / TestResourceRead_API500 test lists in
+// resource_read_mock_test.go. Adding them here covers their error-handling
+// branches (404 → state removal, 500 → error diagnostic) without modifying
+// the original table-driven tests.
+var resourcesForExtraErrorTests = []struct {
+	name string
+	newR func() resource.Resource
+}{
+	{"databasegrant", NewDatabaseGrantResource},
+	{"vpcpeeringroute", NewVpcPeeringRouteResource},
+	{"dbaasuser", NewDBaaSUserResource},
+	{"database", NewDatabaseResource},
+	{"databasebackup", NewDatabaseBackupResource},
+	{"securityrule", NewSecurityRuleResource},
+	{"schedulejob", NewScheduleJobResource},
+	{"cloudserver", NewCloudServerResource},
+}
+
+// TestResourceRead_API404_Extra verifies that the extra resources (missing from
+// the original TestResourceRead_API404) correctly remove themselves from state
+// (no error diagnostic) when the API returns 404.
+func TestResourceRead_API404_Extra(t *testing.T) {
+	ctx := context.Background()
+
+	for _, tc := range resourcesForExtraErrorTests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, mockClient := newMockArubaClient(t, func(w http.ResponseWriter, r *http.Request) {
+				apiError(w, http.StatusNotFound)
+			})
+
+			res := tc.newR()
+			configureResource(ctx, t, res, mockClient)
+
+			req, resp := resourceReadReq(ctx, t, res)
+			res.Read(ctx, req, resp)
+
+			if resp.Diagnostics.HasError() {
+				t.Errorf("%s: Read() added error diagnostic on 404 (expected state removal only): %v",
+					tc.name, resp.Diagnostics)
+			}
+			if !resp.State.Raw.IsNull() {
+				t.Errorf("%s: Read() did not remove resource from state on 404", tc.name)
+			}
+		})
+	}
+}
+
+// TestResourceRead_API500_Extra verifies that the extra resources (missing from
+// the original TestResourceRead_API500) add an error diagnostic when the API
+// returns 500.
+func TestResourceRead_API500_Extra(t *testing.T) {
+	ctx := context.Background()
+
+	for _, tc := range resourcesForExtraErrorTests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, mockClient := newMockArubaClient(t, func(w http.ResponseWriter, r *http.Request) {
+				apiError(w, http.StatusInternalServerError)
+			})
+
+			res := tc.newR()
+			configureResource(ctx, t, res, mockClient)
+
+			req, resp := resourceReadReq(ctx, t, res)
+			res.Read(ctx, req, resp)
+
+			if !resp.Diagnostics.HasError() {
+				t.Errorf("%s: Read() returned no error diagnostic for HTTP 500 response", tc.name)
+			}
+		})
+	}
+}

--- a/internal/provider/resource_read_state_extra_test.go
+++ b/internal/provider/resource_read_state_extra_test.go
@@ -1,0 +1,168 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+// cloudserverFailedJSON is a CloudServer API response with state=Failed that
+// also includes a full properties block.  This allows cloudserver's Read()
+// to add only the warning (not additional errors from nil-property access) when
+// the resource is in a terminal failure state.
+const cloudserverFailedJSON = `{` +
+	`"metadata":{"id":"test-id","name":"test-name",` +
+	`"location":{"value":"test-location","code":"test-code","name":"test-region"},` +
+	`"project":{"id":"test-project-id"}},` +
+	`"status":{"state":"Failed"},` +
+	`"properties":{` +
+	`"vpc":{"uri":"test-vpc-uri"},` +
+	`"bootVolume":{"uri":"test-boot-uri"},` +
+	`"flavor":{"name":"test-flavor"},` +
+	`"keyPair":{"uri":""},` +
+	`"zone":"test-zone"` +
+	`}}`
+
+// dbaasFailedJSON is a DBaaS API response with state=Failed that includes
+// the properties block so Read() can continue past the properties-mapping
+// section without nil-pointer errors.
+const dbaasFailedJSON = `{` +
+	`"metadata":{"id":"test-id","name":"test-name",` +
+	`"location":{"value":"test-location","code":"test-code","name":"test-region"},` +
+	`"project":{"id":"test-project-id"}},` +
+	`"status":{"state":"Failed"},` +
+	`"properties":{` +
+	`"engine":{"id":"postgres-14"},` +
+	`"billingPlan":{"billingPeriod":"Hour"}` +
+	`}}`
+
+// TestResourceRead_FailedState_Extra verifies that complex resources (missing
+// from the original TestResourceRead_FailedStateWarning because they require
+// a full state or rich response JSON) correctly emit a Warning diagnostic and
+// keep the resource in state when they encounter a terminal failure status.
+func TestResourceRead_FailedState_Extra(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		name    string
+		newR    func() resource.Resource
+		json    string
+		useFull bool
+	}{
+		// kaas: the minimal failedJSON is safe because the properties-mapping
+		// code inside kaas Read is nil-guarded throughout.
+		{"kaas", NewKaaSResource, `{"metadata":{"id":"test-id","name":"test-name"},"status":{"state":"Failed"}}`, true},
+		// cloudserver: needs full state (CloudServerNetworkModel can't hold null)
+		// and a properties block so the post-warning mapping doesn't nil-panic.
+		{"cloudserver", NewCloudServerResource, cloudserverFailedJSON, true},
+		// dbaas: needs full state and a properties block.
+		{"dbaas", NewDBaaSResource, dbaasFailedJSON, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := tc.json
+			handler := func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodGet {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(body)) //nolint:errcheck
+					return
+				}
+				apiError(w, http.StatusInternalServerError)
+			}
+
+			_, mockClient := newMockArubaClient(t, handler)
+
+			res := tc.newR()
+			configureResource(ctx, t, res, mockClient)
+
+			var req resource.ReadRequest
+			var resp *resource.ReadResponse
+			if tc.useFull {
+				req, resp = resourceReadReqFull(ctx, t, res)
+			} else {
+				req, resp = resourceReadReq(ctx, t, res)
+			}
+			res.Read(ctx, req, resp)
+
+			if resp.Diagnostics.HasError() {
+				t.Errorf("%s: Read() added error diagnostic for Failed state (expected warning only): %v",
+					tc.name, resp.Diagnostics)
+			}
+
+			var hasWarning bool
+			for _, d := range resp.Diagnostics {
+				if d.Severity() == 2 {
+					hasWarning = true
+					break
+				}
+			}
+			if !hasWarning {
+				t.Errorf("%s: Read() did not add warning diagnostic for resource in Failed state", tc.name)
+			}
+		})
+	}
+}
+
+// TestResourceRead_Provisioning_Extra verifies that extra resources (missing
+// from TestResourceRead_RecoveryFromProvisioning) correctly transition from
+// InCreation to Active during Read().
+func TestResourceRead_Provisioning_Extra(t *testing.T) {
+	oldActivePoll := waitForActivePollInterval
+	waitForActivePollInterval = 1 * time.Millisecond
+	t.Cleanup(func() { waitForActivePollInterval = oldActivePoll })
+
+	ctx := context.Background()
+
+	cases := []struct {
+		name string
+		newR func() resource.Resource
+	}{
+		{"securityrule", NewSecurityRuleResource},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var callCount int32
+			firstJSON := `{"metadata":{"id":"test-id","name":"test-name"},"status":{"state":"InCreation"}}`
+			// Return securityruleFullJSON for the second call so properties mapping succeeds.
+			secondJSON := securityruleFullJSON
+
+			handler := func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					apiError(w, http.StatusInternalServerError)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				if atomic.AddInt32(&callCount, 1) <= 1 {
+					w.Write([]byte(firstJSON)) //nolint:errcheck
+				} else {
+					w.Write([]byte(secondJSON)) //nolint:errcheck
+				}
+			}
+
+			_, mockClient := newMockArubaClient(t, handler)
+
+			res := tc.newR()
+			configureResource(ctx, t, res, mockClient)
+
+			req, resp := resourceReadReq(ctx, t, res)
+			res.Read(ctx, req, resp)
+
+			if resp.Diagnostics.HasError() {
+				t.Errorf("%s: Read() reported error during provisioning recovery: %v",
+					tc.name, resp.Diagnostics)
+			}
+			if resp.State.Raw.IsNull() {
+				t.Errorf("%s: Read() removed resource from state unexpectedly after provisioning recovery",
+					tc.name)
+			}
+		})
+	}
+}

--- a/internal/provider/resource_update_edge_cases_test.go
+++ b/internal/provider/resource_update_edge_cases_test.go
@@ -1,0 +1,291 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// blockstorageActiveJSON is a BlockStorage API response with status=Active.
+// When BlockStorageResource.Update() receives this status, it returns an error
+// (cannot update an attached/active volume) without making a PATCH call.
+// This covers the `status != "Used" && status != "NotUsed"` branch.
+// Note: BlockStorage SDK uses "sizeGb" and "dataCenter" as JSON field names.
+const blockstorageActiveJSON = `{` +
+	`"metadata":{` +
+	`"id":"test-id","name":"test-name",` +
+	`"location":{"value":"test-location","code":"test-code","name":"test-region"},` +
+	`"project":{"id":"test-project-id"}},` +
+	`"status":{"state":"Active"},` +
+	`"properties":{"sizeGb":10,"billingPeriod":"Hour","type":"Standard","dataCenter":""}}`
+
+// blockstorageNotUsedWithZoneJSON is like blockstorageNotUsedJSON but includes
+// a non-empty dataCenter (zone).  This covers the `current.Properties.Zone != ""`
+// true branch inside BlockStorageResource.Update().
+const blockstorageNotUsedWithZoneJSON = `{` +
+	`"metadata":{` +
+	`"id":"test-id","name":"test-name",` +
+	`"location":{"value":"test-location","code":"test-code","name":"test-region"},` +
+	`"project":{"id":"test-project-id"}},` +
+	`"status":{"state":"NotUsed"},` +
+	`"properties":{"sizeGb":10,"billingPeriod":"Hour","type":"Standard","dataCenter":"test-zone"}}`
+
+// TestBlockStorageUpdate_ActiveStatus verifies that BlockStorageResource.Update()
+// adds an error diagnostic (and makes no PATCH request) when the resource is in
+// "Active" state.  This covers the `status != "Used" && status != "NotUsed"`
+// branch that the existing blockstorageUpdateSuccessHandler misses.
+func TestBlockStorageUpdate_ActiveStatus(t *testing.T) {
+	ctx := context.Background()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if r.Method == http.MethodGet {
+			w.Write([]byte(blockstorageActiveJSON)) //nolint:errcheck
+		} else {
+			// PATCH should never be reached when status is Active.
+			w.Write([]byte(minimalActiveJSON)) //nolint:errcheck
+		}
+	}
+
+	_, mockClient := newMockArubaClient(t, handler)
+
+	res := NewBlockStorageResource()
+	configureResource(ctx, t, res, mockClient)
+
+	req, resp := resourceUpdateReq(ctx, t, res)
+	res.Update(ctx, req, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Error("BlockStorageResource Update() with 'Active' status should have returned an error diagnostic")
+	}
+}
+
+// TestBlockStorageUpdate_WithZone verifies that BlockStorageResource.Update()
+// sets a non-nil zone pointer when the current GET response contains a non-empty
+// zone value.  This covers the `current.Properties.Zone != ""` true branch.
+func TestBlockStorageUpdate_WithZone(t *testing.T) {
+	oldActivePoll := waitForActivePollInterval
+	waitForActivePollInterval = 1 * time.Millisecond
+	t.Cleanup(func() { waitForActivePollInterval = oldActivePoll })
+
+	ctx := context.Background()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if r.Method == http.MethodGet {
+			w.Write([]byte(blockstorageNotUsedWithZoneJSON)) //nolint:errcheck
+		} else {
+			w.Write([]byte(blockstorageNotUsedWithZoneJSON)) //nolint:errcheck
+		}
+	}
+
+	_, mockClient := newMockArubaClient(t, handler)
+
+	res := NewBlockStorageResource()
+	configureResource(ctx, t, res, mockClient)
+
+	req, resp := resourceUpdateReq(ctx, t, res)
+	res.Update(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Errorf("BlockStorageResource Update() with zone reported error: %v", resp.Diagnostics)
+	}
+}
+
+// TestBlockStorageUpdate_MissingRegion verifies that BlockStorageResource.Update()
+// adds an error when the GET response has no location (regionValue == "").
+// This covers the `regionValue == ""` error branch that the standard handlers miss.
+const blockstorageNoLocationJSON = `{` +
+	`"metadata":{"id":"test-id","name":"test-name"},` +
+	`"status":{"state":"NotUsed"},` +
+	`"properties":{"sizeGb":10,"billingPeriod":"Hour","type":"Standard","dataCenter":""}}`
+
+func TestBlockStorageUpdate_MissingRegion(t *testing.T) {
+	ctx := context.Background()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(blockstorageNoLocationJSON)) //nolint:errcheck
+	}
+
+	_, mockClient := newMockArubaClient(t, handler)
+
+	res := NewBlockStorageResource()
+	configureResource(ctx, t, res, mockClient)
+
+	req, resp := resourceUpdateReq(ctx, t, res)
+	res.Update(ctx, req, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Error("BlockStorageResource Update() with missing region should have returned an error diagnostic")
+	}
+}
+
+// elasticipInCreationJSON is an ElasticIP API response with status=InCreation.
+// ElasticIPResource.Update() returns an error when the resource is still being
+// created.  This covers the `*current.Status.State == "InCreation"` branch.
+const elasticipInCreationJSON = `{` +
+	`"metadata":{` +
+	`"id":"test-id","name":"test-name",` +
+	`"location":{"value":"test-location","code":"test-code","name":"test-region"}},` +
+	`"status":{"state":"InCreation"},` +
+	`"properties":{}}`
+
+// TestElasticIPUpdate_InCreationStatus verifies that ElasticIPResource.Update()
+// adds an error diagnostic (and makes no PATCH request) when the resource is
+// in "InCreation" state.
+func TestElasticIPUpdate_InCreationStatus(t *testing.T) {
+	ctx := context.Background()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(elasticipInCreationJSON)) //nolint:errcheck
+	}
+
+	_, mockClient := newMockArubaClient(t, handler)
+
+	res := NewElasticIPResource()
+	configureResource(ctx, t, res, mockClient)
+
+	req, resp := resourceUpdateReq(ctx, t, res)
+	res.Update(ctx, req, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Error("ElasticIPResource Update() with 'InCreation' status should have returned an error diagnostic")
+	}
+}
+
+// TestElasticIPUpdate_MissingRegion verifies that ElasticIPResource.Update()
+// adds an error when the GET response has no location (regionValue == "").
+const elasticipNoLocationJSON = `{` +
+	`"metadata":{"id":"test-id","name":"test-name"},` +
+	`"status":{"state":"Active"},` +
+	`"properties":{}}`
+
+func TestElasticIPUpdate_MissingRegion(t *testing.T) {
+	ctx := context.Background()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(elasticipNoLocationJSON)) //nolint:errcheck
+	}
+
+	_, mockClient := newMockArubaClient(t, handler)
+
+	res := NewElasticIPResource()
+	configureResource(ctx, t, res, mockClient)
+
+	req, resp := resourceUpdateReq(ctx, t, res)
+	res.Update(ctx, req, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Error("ElasticIPResource Update() with missing region should have returned an error diagnostic")
+	}
+}
+
+// vpcNoLocationJSON is a VPC API response without a location block.
+// VPCResource.Update() returns an error when regionValue cannot be determined.
+const vpcNoLocationJSON = `{` +
+	`"metadata":{"id":"test-id","name":"test-name"},` +
+	`"status":{"state":"Active"},` +
+	`"properties":{}}`
+
+// TestVPCUpdate_MissingRegion verifies that VPCResource.Update() adds an error
+// when the GET response has no location (covers the `regionValue == ""` branch).
+func TestVPCUpdate_MissingRegion(t *testing.T) {
+	ctx := context.Background()
+
+	_, mockClient := newMockArubaClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(vpcNoLocationJSON)) //nolint:errcheck
+	})
+
+	res := NewVPCResource()
+	configureResource(ctx, t, res, mockClient)
+
+	req, resp := resourceUpdateReq(ctx, t, res)
+	res.Update(ctx, req, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Error("VPCResource Update() with missing region should have returned an error diagnostic")
+	}
+}
+
+// backupNoLocationJSON is a Backup API response without a location block.
+const backupNoLocationJSON = `{` +
+	`"metadata":{"id":"test-id","name":"test-name"},` +
+	`"status":{"state":"Active"},` +
+	`"properties":{}}`
+
+// TestBackupUpdate_MissingRegion verifies that BackupResource.Update() adds an
+// error when the GET response has no location.
+func TestBackupUpdate_MissingRegion(t *testing.T) {
+	ctx := context.Background()
+
+	_, mockClient := newMockArubaClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(backupNoLocationJSON)) //nolint:errcheck
+	})
+
+	res := NewBackupResource()
+	configureResource(ctx, t, res, mockClient)
+
+	req, resp := resourceUpdateReq(ctx, t, res)
+	res.Update(ctx, req, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Error("BackupResource Update() with missing region should have returned an error diagnostic")
+	}
+}
+
+// TestRestoreUpdate_MissingRegion verifies that RestoreResource.Update() adds
+// an error when the GET response has no location.
+func TestRestoreUpdate_MissingRegion(t *testing.T) {
+	ctx := context.Background()
+
+	_, mockClient := newMockArubaClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"metadata":{"id":"test-id","name":"test-name"},"status":{"state":"Active"},"properties":{}}`)) //nolint:errcheck
+	})
+
+	res := NewRestoreResource()
+	configureResource(ctx, t, res, mockClient)
+
+	req, resp := resourceUpdateReq(ctx, t, res)
+	res.Update(ctx, req, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Error("RestoreResource Update() with missing region should have returned an error diagnostic")
+	}
+}
+
+// TestSnapshotUpdate_MissingRegion verifies that SnapshotResource.Update() adds
+// an error when the GET response has no location.
+func TestSnapshotUpdate_MissingRegion(t *testing.T) {
+	ctx := context.Background()
+
+	_, mockClient := newMockArubaClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"metadata":{"id":"test-id","name":"test-name"},"status":{"state":"Active"},"properties":{}}`)) //nolint:errcheck
+	})
+
+	res := NewSnapshotResource()
+	configureResource(ctx, t, res, mockClient)
+
+	req, resp := resourceUpdateReq(ctx, t, res)
+	res.Update(ctx, req, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Error("SnapshotResource Update() with missing region should have returned an error diagnostic")
+	}
+}

--- a/internal/provider/securityrule_any_protocol_test.go
+++ b/internal/provider/securityrule_any_protocol_test.go
@@ -1,0 +1,143 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// buildSecurityRuleCreatePlanWithProtocol creates a CreateRequest for the
+// SecurityRuleResource where properties.protocol is set to the given value
+// and properties.port is null (omitted).  All other string attributes use the
+// "test-<name>" default from resourceCreateReq.
+//
+// This is used to exercise the port-clearing and JSON-manipulation code path
+// that runs when protocol is "Any" or "ICMP".
+func buildSecurityRuleCreatePlanWithProtocol(ctx context.Context, t *testing.T, protocol string) (resource.CreateRequest, *resource.CreateResponse) {
+	t.Helper()
+
+	r := NewSecurityRuleResource()
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+
+	objType, ok := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	if !ok {
+		t.Fatal("buildSecurityRuleCreatePlanWithProtocol: schema root is not an object type")
+	}
+
+	// Get the tftypes for the nested properties and target objects.
+	propsTFType, ok := objType.AttributeTypes["properties"].(tftypes.Object)
+	if !ok {
+		t.Fatal("buildSecurityRuleCreatePlanWithProtocol: properties attribute is not an object type")
+	}
+	targetTFType, ok := propsTFType.AttributeTypes["target"].(tftypes.Object)
+	if !ok {
+		t.Fatal("buildSecurityRuleCreatePlanWithProtocol: target attribute is not an object type")
+	}
+
+	// Build target: kind = "IP", value = "0.0.0.0/0"
+	targetVal := tftypes.NewValue(targetTFType, map[string]tftypes.Value{
+		"kind":  tftypes.NewValue(tftypes.String, "IP"),
+		"value": tftypes.NewValue(tftypes.String, "0.0.0.0/0"),
+	})
+
+	// Build properties: protocol = caller-provided, port = null
+	propsVal := tftypes.NewValue(propsTFType, map[string]tftypes.Value{
+		"direction": tftypes.NewValue(tftypes.String, "Ingress"),
+		"protocol":  tftypes.NewValue(tftypes.String, protocol),
+		"port":      tftypes.NewValue(tftypes.String, nil), // null → port == "" in Create()
+		"target":    targetVal,
+	})
+
+	// Build root: set all string attributes to "test-<name>",
+	// override properties with the custom value, leave non-strings null.
+	attrs := make(map[string]tftypes.Value, len(objType.AttributeTypes))
+	for name, ty := range objType.AttributeTypes {
+		switch name {
+		case "properties":
+			attrs[name] = propsVal
+		default:
+			if ty.Is(tftypes.String) {
+				attrs[name] = tftypes.NewValue(tftypes.String, "test-"+name)
+			} else {
+				attrs[name] = tftypes.NewValue(ty, nil)
+			}
+		}
+	}
+
+	plan := tfsdk.Plan{
+		Raw:    tftypes.NewValue(objType, attrs),
+		Schema: schemaResp.Schema,
+	}
+	req := resource.CreateRequest{Plan: plan}
+	resp := &resource.CreateResponse{State: tfsdk.State{Schema: schemaResp.Schema}}
+	return req, resp
+}
+
+// TestSecurityRuleCreate_AnyProtocol verifies that Create() succeeds when
+// protocol is "Any" (no port required).  This exercises the port-clearing
+// branch (strings.EqualFold(protocol, "Any")), the JSON-marshalling path that
+// omits the port field, and the CRITICAL rebuild guard.
+func TestSecurityRuleCreate_AnyProtocol(t *testing.T) {
+	oldActivePoll := waitForActivePollInterval
+	waitForActivePollInterval = 1 * time.Millisecond
+	t.Cleanup(func() { waitForActivePollInterval = oldActivePoll })
+
+	ctx := context.Background()
+
+	_, mockClient := newMockArubaClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusCreated)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+		w.Write([]byte(minimalActiveJSON)) //nolint:errcheck
+	})
+
+	res := NewSecurityRuleResource()
+	configureResource(ctx, t, res, mockClient)
+
+	req, resp := buildSecurityRuleCreatePlanWithProtocol(ctx, t, "Any")
+	res.Create(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("SecurityRuleResource Create() with 'Any' protocol reported error: %v", resp.Diagnostics)
+	}
+}
+
+// TestSecurityRuleCreate_ICMPProtocol verifies that Create() succeeds when
+// protocol is "ICMP".  This exercises the same port-clearing branch as the
+// "Any" test but via the ICMP condition.
+func TestSecurityRuleCreate_ICMPProtocol(t *testing.T) {
+	oldActivePoll := waitForActivePollInterval
+	waitForActivePollInterval = 1 * time.Millisecond
+	t.Cleanup(func() { waitForActivePollInterval = oldActivePoll })
+
+	ctx := context.Background()
+
+	_, mockClient := newMockArubaClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusCreated)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+		w.Write([]byte(minimalActiveJSON)) //nolint:errcheck
+	})
+
+	res := NewSecurityRuleResource()
+	configureResource(ctx, t, res, mockClient)
+
+	req, resp := buildSecurityRuleCreatePlanWithProtocol(ctx, t, "ICMP")
+	res.Create(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("SecurityRuleResource Create() with 'ICMP' protocol reported error: %v", resp.Diagnostics)
+	}
+}

--- a/internal/provider/subnet_read_rich_test.go
+++ b/internal/provider/subnet_read_rich_test.go
@@ -1,0 +1,100 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// subnetAdvancedJSON is a Subnet API response with a full properties block
+// including type=Advanced, a network address, DHCP enabled with a range,
+// routes, and DNS entries.  This exercises the DHCP-mapping code paths in
+// SubnetResource.Read() that are skipped by minimalActiveJSON.
+const subnetAdvancedJSON = `{` +
+	`"metadata":{` +
+	`"id":"test-id","name":"test-name",` +
+	`"uri":"/subnets/test-id",` +
+	`"location":{"value":"test-location"},` +
+	`"tags":["env:test"]` +
+	`},` +
+	`"status":{"state":"Active"},` +
+	`"properties":{` +
+	`"type":"Advanced",` +
+	`"network":{"address":"10.0.0.0/24"},` +
+	`"dhcp":{` +
+	`"enabled":true,` +
+	`"range":{"start":"10.0.0.100","count":50},` +
+	`"routes":[{"address":"10.0.0.0/24","gateway":"10.0.0.1"}],` +
+	`"dns":["8.8.8.8","8.8.4.4"]` +
+	`}` +
+	`}` +
+	`}`
+
+// subnetBasicJSON is a Basic Subnet response with no network block.  This
+// exercises the shouldSetNetwork=false branch (type != "Advanced" and no
+// network in state) which sets the entire network block to null.
+const subnetBasicNoNetworkJSON = `{` +
+	`"metadata":{"id":"test-id","name":"test-name"},` +
+	`"status":{"state":"Active"},` +
+	`"properties":{"type":"Basic"}` +
+	`}`
+
+// TestSubnetResource_Read_WithDHCP verifies that SubnetResource.Read() correctly
+// maps a response that includes a full DHCP block (range, routes, DNS).  Using
+// resourceReadReqFull provides non-null network in state so shouldSetNetwork is
+// true and the DHCP-mapping section is exercised.
+func TestSubnetResource_Read_WithDHCP(t *testing.T) {
+	oldActivePoll := waitForActivePollInterval
+	waitForActivePollInterval = 1 * time.Millisecond
+	t.Cleanup(func() { waitForActivePollInterval = oldActivePoll })
+
+	ctx := context.Background()
+
+	_, mockClient := newMockArubaClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(subnetAdvancedJSON)) //nolint:errcheck
+	})
+
+	res := NewSubnetResource()
+	configureResource(ctx, t, res, mockClient)
+
+	req, resp := resourceReadReqFull(ctx, t, res)
+	res.Read(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("SubnetResource Read() reported error with DHCP response: %v", resp.Diagnostics)
+	}
+	if resp.State.Raw.IsNull() {
+		t.Fatal("SubnetResource Read() removed resource from state unexpectedly")
+	}
+}
+
+// TestSubnetResource_Read_BasicNoNetwork verifies that SubnetResource.Read() with
+// a Basic subnet response and null network in state correctly sets
+// data.Network to null (the shouldSetNetwork=false / else branch).
+func TestSubnetResource_Read_BasicNoNetwork(t *testing.T) {
+	oldActivePoll := waitForActivePollInterval
+	waitForActivePollInterval = 1 * time.Millisecond
+	t.Cleanup(func() { waitForActivePollInterval = oldActivePoll })
+
+	ctx := context.Background()
+
+	_, mockClient := newMockArubaClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(subnetBasicNoNetworkJSON)) //nolint:errcheck
+	})
+
+	res := NewSubnetResource()
+	configureResource(ctx, t, res, mockClient)
+
+	// Use minimal Read request (network is null in state) with a Basic subnet type.
+	req, resp := resourceReadReq(ctx, t, res)
+	res.Read(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("SubnetResource Read() reported error for Basic subnet: %v", resp.Diagnostics)
+	}
+}

--- a/internal/provider/subnet_validator_routes_test.go
+++ b/internal/provider/subnet_validator_routes_test.go
@@ -1,0 +1,206 @@
+package provider
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// buildSubnetAdvancedWithRoutes creates a tfsdk.Config for SubnetResource with
+// type = "Advanced", a network CIDR of subnetCIDR, and the given DHCP routes.
+// Each route element is a map{"address": CIDR, "gateway": IP}.
+//
+// The tftypes.Object hierarchy is derived from the resource schema so it
+// remains correct even if the schema changes field types.
+func buildSubnetAdvancedWithRoutes(t *testing.T, subnetCIDR string, routes []map[string]string) tfsdk.Config {
+	t.Helper()
+	ctx := context.Background()
+
+	r := NewSubnetResource()
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+
+	objType, ok := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	if !ok {
+		t.Fatal("buildSubnetAdvancedWithRoutes: schema root is not an object type")
+	}
+
+	// Extract nested attribute types from the schema-derived tftypes hierarchy.
+	networkTFType, ok := objType.AttributeTypes["network"].(tftypes.Object)
+	if !ok {
+		t.Fatal("network attribute is not an object type")
+	}
+	dhcpTFType, ok := networkTFType.AttributeTypes["dhcp"].(tftypes.Object)
+	if !ok {
+		t.Fatal("dhcp attribute is not an object type")
+	}
+	routesListType, ok := dhcpTFType.AttributeTypes["routes"].(tftypes.List)
+	if !ok {
+		t.Fatal("routes attribute is not a list type")
+	}
+	routeObjType, ok := routesListType.ElementType.(tftypes.Object)
+	if !ok {
+		t.Fatal("routes element type is not an object type")
+	}
+	rangeTFType, ok := dhcpTFType.AttributeTypes["range"].(tftypes.Object)
+	if !ok {
+		t.Fatal("range attribute is not an object type")
+	}
+	dnsListType, ok := dhcpTFType.AttributeTypes["dns"].(tftypes.List)
+	if !ok {
+		t.Fatal("dns attribute is not a list type")
+	}
+
+	// Build route tftypes.Values.
+	routeVals := make([]tftypes.Value, len(routes))
+	for i, r := range routes {
+		routeVals[i] = tftypes.NewValue(routeObjType, map[string]tftypes.Value{
+			"address": tftypes.NewValue(tftypes.String, r["address"]),
+			"gateway": tftypes.NewValue(tftypes.String, r["gateway"]),
+		})
+	}
+
+	// Build range object.
+	rangeVal := tftypes.NewValue(rangeTFType, map[string]tftypes.Value{
+		"start": tftypes.NewValue(tftypes.String, "10.0.0.100"),
+		"count": tftypes.NewValue(tftypes.Number, new(big.Float).SetFloat64(50)),
+	})
+
+	// Build DHCP object.
+	dhcpVal := tftypes.NewValue(dhcpTFType, map[string]tftypes.Value{
+		"enabled": tftypes.NewValue(tftypes.Bool, true),
+		"range":   rangeVal,
+		"routes":  tftypes.NewValue(routesListType, routeVals),
+		"dns":     tftypes.NewValue(dnsListType, []tftypes.Value{}),
+	})
+
+	// Build network object.
+	networkVal := tftypes.NewValue(networkTFType, map[string]tftypes.Value{
+		"address": tftypes.NewValue(tftypes.String, subnetCIDR),
+		"dhcp":    dhcpVal,
+	})
+
+	// Build root object: use "Advanced" for type, the custom network value,
+	// and "test-<name>" for all other string attributes.
+	attrs := make(map[string]tftypes.Value, len(objType.AttributeTypes))
+	for name, ty := range objType.AttributeTypes {
+		switch name {
+		case "type":
+			attrs[name] = tftypes.NewValue(tftypes.String, "Advanced")
+		case "network":
+			attrs[name] = networkVal
+		default:
+			if ty.Is(tftypes.String) {
+				attrs[name] = tftypes.NewValue(tftypes.String, "test-"+name)
+			} else {
+				attrs[name] = tftypes.NewValue(ty, nil)
+			}
+		}
+	}
+
+	return tfsdk.Config{
+		Raw:    tftypes.NewValue(objType, attrs),
+		Schema: schemaResp.Schema,
+	}
+}
+
+// TestSubnetRouteAddressValidator_ValidRoute verifies that ValidateResource
+// produces no diagnostics when the route address is within the subnet CIDR.
+// This covers the full validator path through network.As → DHCP.As → routes
+// loop → cidrContains (returning true).
+func TestSubnetRouteAddressValidator_ValidRoute(t *testing.T) {
+	ctx := context.Background()
+	v := subnetRouteAddressValidator{}
+
+	config := buildSubnetAdvancedWithRoutes(t, "10.0.0.0/24",
+		[]map[string]string{{"address": "10.0.0.0/25", "gateway": "10.0.0.1"}})
+
+	req := resource.ValidateConfigRequest{Config: config}
+	resp := &resource.ValidateConfigResponse{}
+	v.ValidateResource(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Errorf("ValidateResource with valid route reported error: %v", resp.Diagnostics)
+	}
+}
+
+// TestSubnetRouteAddressValidator_RouteOutsideCIDR verifies that
+// ValidateResource adds an attribute error when the route address is outside
+// the subnet CIDR.  This covers the `!cidrContains(subnetNet, routeNet)` branch.
+func TestSubnetRouteAddressValidator_RouteOutsideCIDR(t *testing.T) {
+	ctx := context.Background()
+	v := subnetRouteAddressValidator{}
+
+	config := buildSubnetAdvancedWithRoutes(t, "192.168.0.0/24",
+		[]map[string]string{{"address": "10.0.0.0/8", "gateway": "192.168.0.1"}})
+
+	req := resource.ValidateConfigRequest{Config: config}
+	resp := &resource.ValidateConfigResponse{}
+	v.ValidateResource(ctx, req, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Error("ValidateResource with route outside subnet CIDR should have reported an error")
+	}
+}
+
+// TestSubnetRouteAddressValidator_InvalidRouteCIDR verifies that
+// ValidateResource adds an attribute error when the route address is not valid
+// CIDR notation.  This covers the `err != nil` branch inside the routes loop.
+func TestSubnetRouteAddressValidator_InvalidRouteCIDR(t *testing.T) {
+	ctx := context.Background()
+	v := subnetRouteAddressValidator{}
+
+	config := buildSubnetAdvancedWithRoutes(t, "10.0.0.0/24",
+		[]map[string]string{{"address": "not-a-cidr", "gateway": "10.0.0.1"}})
+
+	req := resource.ValidateConfigRequest{Config: config}
+	resp := &resource.ValidateConfigResponse{}
+	v.ValidateResource(ctx, req, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Error("ValidateResource with invalid route CIDR should have reported an error")
+	}
+}
+
+// TestSubnetRouteAddressValidator_EmptyRouteAddress verifies that
+// ValidateResource skips routes whose address is an empty string.
+func TestSubnetRouteAddressValidator_EmptyRouteAddress(t *testing.T) {
+	ctx := context.Background()
+	v := subnetRouteAddressValidator{}
+
+	config := buildSubnetAdvancedWithRoutes(t, "10.0.0.0/24",
+		[]map[string]string{{"address": "", "gateway": "10.0.0.1"}})
+
+	req := resource.ValidateConfigRequest{Config: config}
+	resp := &resource.ValidateConfigResponse{}
+	v.ValidateResource(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Errorf("ValidateResource with empty route address should not report error: %v", resp.Diagnostics)
+	}
+}
+
+// TestSubnetRouteAddressValidator_MultipleRoutes verifies that all routes in a
+// list are validated (both valid and invalid routes in the same list).
+func TestSubnetRouteAddressValidator_MultipleRoutes(t *testing.T) {
+	ctx := context.Background()
+	v := subnetRouteAddressValidator{}
+
+	config := buildSubnetAdvancedWithRoutes(t, "10.0.0.0/24",
+		[]map[string]string{
+			{"address": "10.0.0.0/25", "gateway": "10.0.0.1"},    // valid
+			{"address": "192.168.1.0/24", "gateway": "10.0.0.1"}, // outside CIDR
+		})
+
+	req := resource.ValidateConfigRequest{Config: config}
+	resp := &resource.ValidateConfigResponse{}
+	v.ValidateResource(ctx, req, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Error("ValidateResource with mixed routes should report error for out-of-CIDR route")
+	}
+}


### PR DESCRIPTION
﻿## Summary

- Add 11 new test files covering previously untested branches across 24+ resources
- Coverage increased from 68% to **75.0%** (6309/8411 statements)
- All tests pass, lint is clean (0 issues from golangci-lint v2)

## What was covered

- `coverage_simple_unit_test.go`: ptrToString, protocolNormalizePlanModifier.Description/MarkdownDescription
- `resource_read_error_extra_test.go`: API 404/500 error paths for 8 resources missing from original error test lists
- `kaas_properties_test.go`: KaaS data source + resource Read with full properties JSON (fixes nodesPool JSON key)
- `subnet_read_rich_test.go`: Subnet Read with DHCP range/routes/DNS response
- `subnet_validator_routes_test.go`: subnetRouteAddressValidator.ValidateResource with valid, outside-CIDR, invalid-CIDR, empty, multiple routes
- `securityrule_any_protocol_test.go`: SecurityRule Create with Any/ICMP protocol covering port-clearing + JSON manipulation
- `project_create_rich_test.go`: Project Create with tags+description and empty-tags response branches
- `resource_create_rich_test.go`: Batch Create with URI+tags response for 14 resources
- `datasource_read_rich_test.go`: DBaaS Read with engine/flavor/storage; Subnet data source Read with DHCP
- `resource_read_state_extra_test.go`: Failed-state warning + provisioning recovery for cloudserver, kaas, dbaas, securityrule
- `resource_update_edge_cases_test.go`: BlockStorage/ElasticIP/VPC/Backup/Snapshot/Restore Update edge cases (Active-status, InCreation, missing-region, non-empty-zone)

## Test plan

- go test ./... -count=1 passes (75.0% coverage)
- golangci-lint run passes (0 issues)
- go vet ./... passes

Generated with Claude Code
