### PR TITLE
refactor: replace CheckResponse[T] with CheckResponseErr for aruba.HTTPError (sdk-go v1.0.4)

### DIFF
--- a/docs/guides/sdk-v1-compile-error-inventory.md
+++ b/docs/guides/sdk-v1-compile-error-inventory.md
@@ -1,0 +1,124 @@
+# sdk-go v1.0.4 Compile Error Inventory
+
+Generated after bumping `go.mod` from `sdk-go v0.1.24` → `v1.0.4` and running `go build -gcflags=all='-e' ./...`.
+
+## Summary
+
+| Category | Count | Scope | Fix strategy |
+|---|---|---|---|
+| `.Data undefined` | 660 | All 50 files | Replace `response.Data.*` access with wrapper promoted accessors (`wrapper.ID()`, `wrapper.URI()`, `wrapper.Name()`, `wrapper.State()`, `wrapper.Raw().Properties.*`) |
+| `string→CallOption` (trailing `nil`) | 399 | All 50 files | Remove trailing `nil` argument — v1.0.4 CRUD methods no longer accept a trailing options parameter via the old `nil` pattern |
+| `string→Ref` (parent ID params) | 214 | All 50 files | Replace explicit string parent IDs with builder-embedded `aruba.URI(...)` Refs; Create no longer takes separate `projectID` argument |
+| `CheckResponse` type mismatch | 130 | All files using `CheckResponse` | Replace `CheckResponse[T](*sdktypes.Response[T])` with `CheckResponseErr(op, res, error)` (see issue #135) |
+| `sdktypes.*` undefined | 107 | 25 resource files | Replace struct-literal request construction with fluent builder chains (see issues #136–#142) |
+| `.IsError()` undefined | 15 | Files using `.IsError()` | Remove — errors surface via `(wrapper, error)` return; check `err != nil` instead |
+| **Total** | **~1,525** | **50 files** | |
+
+## Files affected
+
+All 25 resource files and all 25 data source files in `internal/provider/`.
+
+## Error category detail
+
+### 1. `.Data undefined` (660 errors) — highest volume
+
+Every `response.Data.Metadata.ID`, `response.Data.Metadata.URI`, `response.Data.Properties.*`, `response.Data.Status.State` access.
+
+**Before**:
+```go
+data.Id  = types.StringValue(*response.Data.Metadata.ID)
+data.Uri = types.StringValue(*response.Data.Metadata.URI)
+state    := *response.Data.Status.State
+```
+
+**After**:
+```go
+data.Id  = types.StringValue(wrapper.ID())
+data.Uri = types.StringValue(wrapper.URI())
+state    := string(wrapper.State())
+// Resource-specific properties:
+raw := wrapper.Raw()
+data.SizeGB = types.Int64Value(int64(*raw.Properties.SizeGB))
+```
+
+### 2. `string→CallOption` (399 errors) — trailing `nil` parameter
+
+Every CRUD call ends with `..., nil)` which was the options parameter. v1.0.4 removes it from these positions.
+
+**Before**:
+```go
+r.client.Client.FromNetwork().VPCs().Get(ctx, projectID, vpcID, nil)
+```
+
+**After**:
+```go
+r.client.Client.FromNetwork().VPCs().Get(ctx, aruba.URI(data.Uri.ValueString()))
+```
+
+### 3. `string→Ref` (214 errors) — CRUD signature change
+
+Parent IDs passed as explicit string parameters are no longer accepted. The builder embeds them.
+
+**Before**:
+```go
+r.client.Client.FromNetwork().VPCs().Create(ctx, projectID, createRequest, nil)
+```
+
+**After**:
+```go
+r.client.Client.FromNetwork().VPCs().Create(ctx, aruba.NewVPC().Named(...).InProject(aruba.URI(...)))
+```
+
+### 4. `CheckResponse` type mismatch (130 errors)
+
+`CheckResponse[T any](op, res string, resp *sdktypes.Response[T])` is called with the new wrapper types which don't implement `*sdktypes.Response[T]`.
+
+Fix: Replace with `CheckResponseErr(op, res string, err error) *ProviderError` — see issue #135.
+
+### 5. `sdktypes.*` undefined (107 errors)
+
+Request struct types from `pkg/types` that were used for literal construction. All replaced by builder methods.
+
+Examples:
+- `sdktypes.CloudServerRequest{...}` → `aruba.NewCloudServer().Named(...)`
+- `sdktypes.BlockStorageRequest{...}` → `aruba.NewBlockStorage().Named(...)`
+- `sdktypes.SubnetDHCP{...}` → `aruba.NewSubnetDHCP().Enabled()...`
+- `sdktypes.NodePoolProperties{...}` → `aruba.NewNodePool().Named()...`
+
+### 6. `.IsError()` undefined (15 errors)
+
+`response.IsError()` no longer exists on wrappers. Errors surface via the `error` return value of CRUD methods.
+
+**Before**:
+```go
+if response.IsError() { ... }
+```
+
+**After**:
+```go
+if err != nil { ... }
+```
+
+## Confirmed architectural decisions (from this analysis)
+
+1. **Module path unchanged**: `github.com/Arubacloud/sdk-go` (no v2 suffix) ✅
+2. **All 50 files affected**: Every resource and data source needs updating
+3. **Dominant change is `.Data` access**: 660 errors — the wrapper pattern replaces the `Response[T].Data` envelope entirely
+4. **CRUD signature changes**: Confirmed across all 214 parent-ID usage sites
+5. **`pkg/types` request types**: 107 undefined errors confirm complete elimination is required
+6. **`provider_error.go`**: The 130 `CheckResponse` mismatches are all in resource files; fixing `provider_error.go` (issue #135) first eliminates them all
+7. **`go mod tidy` succeeds**: No dependency conflicts; v1.0.4 is compatible with the rest of the dependency tree
+
+## Implementation order
+
+Based on this analysis, the fix order is:
+
+```
+#134 (auth rename — independent)
+#135 (CheckResponse → CheckResponseErr — prerequisite for all resource files)
+    ↓
+#136 (compute)  #137 (networking)  #138 (ext-network)
+#139 (storage)  #140 (database)    #141 (container)   #142 (security+schedule)
+    ↓ (can parallelise)
+#143 (cleanup)  #144 (tests)  #145 (docs+release)
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,8 +23,8 @@ terraform {
 }
 
 provider "arubacloud" {
-  api_key    = "YOUR_API_KEY"
-  api_secret = "YOUR_API_SECRET"
+  client_id     = "YOUR_CLIENT_ID"
+  client_secret = "YOUR_CLIENT_SECRET"
 }
 ```
 
@@ -47,8 +47,8 @@ terraform {
 }
 
 provider "arubacloud" {
-  api_key    = var.api_key
-  api_secret = var.api_secret
+  client_id     = var.client_id
+  client_secret = var.client_secret
 }
 
 variable "api_key" {
@@ -209,8 +209,8 @@ output "cloudserver_id" {
 
 The following arguments are supported:
 
-- `api_key` - (Required, string) ArubaCloud API key. Can also be specified with the `ARUBACLOUD_API_KEY` environment variable.
-- `api_secret` - (Required, string) ArubaCloud API secret. Can also be specified with the `ARUBACLOUD_API_SECRET` environment variable.
+- `client_id` - (Required, string) ArubaCloud API key. Can also be specified with the `ARUBACLOUD_CLIENT_ID` environment variable.
+- `client_secret` - (Required, string) ArubaCloud API secret. Can also be specified with the `ARUBACLOUD_CLIENT_SECRET` environment variable.
 - `resource_timeout` - (Optional, string) Timeout for waiting for resources to become active after creation (e.g. `"5m"`, `"10m"`). Default: `"10m"`.
 - `base_url` - (Optional, string) Override the ArubaCloud API base URL. Advanced use only.
 - `token_issuer_url` - (Optional, string) Override the ArubaCloud token issuer URL. Advanced use only.
@@ -231,8 +231,8 @@ A message is visible only when **both** filters permit it. SDK messages are tagg
 
 ```hcl
 provider "arubacloud" {
-  api_key    = var.api_key
-  api_secret = var.api_secret
+  client_id     = var.client_id
+  client_secret = var.client_secret
   log_level  = "DEBUG"
 }
 ```

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -8,6 +8,6 @@ terraform {
 }
 
 provider "arubacloud" {
-  api_key    = "YOUR_API_KEY"
-  api_secret = "YOUR_API_SECRET"
+  client_id     = "YOUR_CLIENT_ID"
+  client_secret = "YOUR_CLIENT_SECRET"
 }

--- a/examples/provider/quick-start.tf
+++ b/examples/provider/quick-start.tf
@@ -12,18 +12,18 @@ terraform {
 }
 
 provider "arubacloud" {
-  api_key    = var.api_key
-  api_secret = var.api_secret
+  client_id     = var.client_id
+  client_secret = var.client_secret
 }
 
-variable "api_key" {
-  description = "ArubaCloud API key"
+variable "client_id" {
+  description = "ArubaCloud OAuth2 client ID"
   type        = string
   sensitive   = true
 }
 
-variable "api_secret" {
-  description = "ArubaCloud API secret"
+variable "client_secret" {
+  description = "ArubaCloud OAuth2 client secret"
   type        = string
   sensitive   = true
 }
@@ -117,7 +117,7 @@ resource "arubacloud_blockstorage" "quickstart_boot" {
   name           = "quickstart-boot-disk"
   project_id     = arubacloud_project.quickstart.id
   location       = "ITBG-Bergamo"
-  zone           = "ITBG-1" # Zone (datacenter) — must match the CloudServer zone below
+  zone           = "ITBG-1" # Zone (datacenter) ï¿½ must match the CloudServer zone below
   size_gb        = 50
   billing_period = "Hour"
   type           = "Performance" # Performance type recommended for boot volumes
@@ -133,7 +133,7 @@ resource "arubacloud_cloudserver" "quickstart" {
   name       = "quickstart-server"
   location   = "ITBG-Bergamo"
   project_id = arubacloud_project.quickstart.id
-  zone       = "ITBG-1" # Zone (datacenter) — must match the boot-volume zone above
+  zone       = "ITBG-1" # Zone (datacenter) ï¿½ must match the boot-volume zone above
   tags       = ["quickstart", "compute"]
 
   network = {

--- a/examples/test/compute/00-variables.tf
+++ b/examples/test/compute/00-variables.tf
@@ -1,11 +1,11 @@
-variable "arubacloud_api_key" {
-  description = "ArubaCloud API Key"
+variable "arubacloud_client_id" {
+  description = "ArubaCloud OAuth2 Client ID"
   type        = string
   sensitive   = true
 }
 
-variable "arubacloud_api_secret" {
-  description = "ArubaCloud API Secret"
+variable "arubacloud_client_secret" {
+  description = "ArubaCloud OAuth2 Client Secret"
   type        = string
   sensitive   = true
 }

--- a/examples/test/compute/01-provider.tf
+++ b/examples/test/compute/01-provider.tf
@@ -9,8 +9,8 @@ terraform {
 
 
 provider "arubacloud" {
-  api_key    = var.arubacloud_api_key
-  api_secret = var.arubacloud_api_secret
+  client_id     = var.arubacloud_client_id
+  client_secret = var.arubacloud_client_secret
   
   log_level = "DEBUG" # Accepted: OFF, ERROR, WARN, INFO, DEBUG, TRACE. Default: OFF. Requires TF_LOG=DEBUG to surface.
 

--- a/examples/test/container/00-variables.tf
+++ b/examples/test/container/00-variables.tf
@@ -1,11 +1,11 @@
-variable "arubacloud_api_key" {
-  description = "ArubaCloud API Key"
+variable "arubacloud_client_id" {
+  description = "ArubaCloud OAuth2 Client ID"
   type        = string
   sensitive   = true
 }
 
-variable "arubacloud_api_secret" {
-  description = "ArubaCloud API Secret"
+variable "arubacloud_client_secret" {
+  description = "ArubaCloud OAuth2 Client Secret"
   type        = string
   sensitive   = true
 }

--- a/examples/test/container/01-provider.tf
+++ b/examples/test/container/01-provider.tf
@@ -8,6 +8,6 @@ terraform {
 }
 
 provider "arubacloud" {
-  api_key    = var.arubacloud_api_key
-  api_secret = var.arubacloud_api_secret
+  client_id     = var.arubacloud_client_id
+  client_secret = var.arubacloud_client_secret
 }

--- a/examples/test/database/00-variables.tf
+++ b/examples/test/database/00-variables.tf
@@ -1,11 +1,11 @@
-variable "arubacloud_api_key" {
-  description = "ArubaCloud API Key"
+variable "arubacloud_client_id" {
+  description = "ArubaCloud OAuth2 Client ID"
   type        = string
   sensitive   = true
 }
 
-variable "arubacloud_api_secret" {
-  description = "ArubaCloud API Secret"
+variable "arubacloud_client_secret" {
+  description = "ArubaCloud OAuth2 Client Secret"
   type        = string
   sensitive   = true
 }

--- a/examples/test/database/01-provider.tf
+++ b/examples/test/database/01-provider.tf
@@ -8,6 +8,6 @@ terraform {
 }
 
 provider "arubacloud" {
-  api_key    = var.arubacloud_api_key
-  api_secret = var.arubacloud_api_secret
+  client_id     = var.arubacloud_client_id
+  client_secret = var.arubacloud_client_secret
 }

--- a/examples/test/datasources/00-input-variables.tf
+++ b/examples/test/datasources/00-input-variables.tf
@@ -2,14 +2,14 @@
 # Fill these with actual resource IDs from your account to test datasources
 
 # Provider Credentials
-variable "arubacloud_api_key" {
-  description = "ArubaCloud API Key"
+variable "arubacloud_client_id" {
+  description = "ArubaCloud OAuth2 Client ID"
   type        = string
   sensitive   = true
 }
 
-variable "arubacloud_api_secret" {
-  description = "ArubaCloud API Secret"
+variable "arubacloud_client_secret" {
+  description = "ArubaCloud OAuth2 Client Secret"
   type        = string
   sensitive   = true
 }

--- a/examples/test/datasources/01-provider.tf
+++ b/examples/test/datasources/01-provider.tf
@@ -8,6 +8,6 @@ terraform {
 }
 
 provider "arubacloud" {
-  api_key    = var.arubacloud_api_key
-  api_secret = var.arubacloud_api_secret
+  client_id     = var.arubacloud_client_id
+  client_secret = var.arubacloud_client_secret
 }

--- a/examples/test/schedule/00-variables.tf
+++ b/examples/test/schedule/00-variables.tf
@@ -1,11 +1,11 @@
-variable "arubacloud_api_key" {
-  description = "ArubaCloud API Key"
+variable "arubacloud_client_id" {
+  description = "ArubaCloud OAuth2 Client ID"
   type        = string
   sensitive   = true
 }
 
-variable "arubacloud_api_secret" {
-  description = "ArubaCloud API Secret"
+variable "arubacloud_client_secret" {
+  description = "ArubaCloud OAuth2 Client Secret"
   type        = string
   sensitive   = true
 }

--- a/examples/test/schedule/01-provider.tf
+++ b/examples/test/schedule/01-provider.tf
@@ -8,6 +8,6 @@ terraform {
 }
 
 provider "arubacloud" {
-  api_key    = var.arubacloud_api_key
-  api_secret = var.arubacloud_api_secret
+  client_id     = var.arubacloud_client_id
+  client_secret = var.arubacloud_client_secret
 }

--- a/examples/test/security/00-variables.tf
+++ b/examples/test/security/00-variables.tf
@@ -1,11 +1,11 @@
-variable "arubacloud_api_key" {
-  description = "ArubaCloud API Key"
+variable "arubacloud_client_id" {
+  description = "ArubaCloud OAuth2 Client ID"
   type        = string
   sensitive   = true
 }
 
-variable "arubacloud_api_secret" {
-  description = "ArubaCloud API Secret"
+variable "arubacloud_client_secret" {
+  description = "ArubaCloud OAuth2 Client Secret"
   type        = string
   sensitive   = true
 }

--- a/examples/test/security/01-provider.tf
+++ b/examples/test/security/01-provider.tf
@@ -8,6 +8,6 @@ terraform {
 }
 
 provider "arubacloud" {
-  api_key    = var.arubacloud_api_key
-  api_secret = var.arubacloud_api_secret
+  client_id     = var.arubacloud_client_id
+  client_secret = var.arubacloud_client_secret
 }

--- a/examples/test/wordpress/00-variables.tf
+++ b/examples/test/wordpress/00-variables.tf
@@ -1,11 +1,11 @@
-variable "arubacloud_api_key" {
-  description = "ArubaCloud API Key"
+variable "arubacloud_client_id" {
+  description = "ArubaCloud OAuth2 Client ID"
   type        = string
   sensitive   = true
 }
 
-variable "arubacloud_api_secret" {
-  description = "ArubaCloud API Secret"
+variable "arubacloud_client_secret" {
+  description = "ArubaCloud OAuth2 Client Secret"
   type        = string
   sensitive   = true
 }

--- a/examples/test/wordpress/01-provider.tf
+++ b/examples/test/wordpress/01-provider.tf
@@ -8,8 +8,8 @@ terraform {
 }
 
 provider "arubacloud" {
-  api_key    = var.arubacloud_api_key
-  api_secret = var.arubacloud_api_secret
+  client_id     = var.arubacloud_client_id
+  client_secret = var.arubacloud_client_secret
 
   resource_timeout = "20m"
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Arubacloud/terraform-provider-arubacloud
 go 1.24.0
 
 require (
-	github.com/Arubacloud/sdk-go v0.1.24
+	github.com/Arubacloud/sdk-go v1.0.4
 	github.com/hashicorp/terraform-plugin-framework v1.16.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.29.0
@@ -78,4 +78,6 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250707201910-8d1bb00bc6a7 // indirect
 	google.golang.org/grpc v1.75.1 // indirect
 	google.golang.org/protobuf v1.36.9 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/utils v0.0.0-20260507154919-ff6756f316d2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/Arubacloud/sdk-go v0.1.24 h1:4mu7TzoLhkZCq1lHlzQgymf7Q4FzWDplyK9iszM6PE0=
-github.com/Arubacloud/sdk-go v0.1.24/go.mod h1:4lXc0Dte8HqeKag8eMo0/TClwsgMqXW0KbKaQ2BYlXA=
+github.com/Arubacloud/sdk-go v1.0.4 h1:RUmmvojnIyHFAY0gE/jujfbbs7qY+ecpgv9fxEcp87w=
+github.com/Arubacloud/sdk-go v1.0.4/go.mod h1:OD2PSOa9uAxrhFwDcYcw+LE7eyZ+OQVaTA2tlHxVE4U=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.1.6 h1:ZcV+Ropw6Qn0AX9brlQLAUXfqLBc7Bl+f/DmNxpLfdw=
@@ -283,3 +283,5 @@ gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+k8s.io/utils v0.0.0-20260507154919-ff6756f316d2 h1:wU4tMEhLGgIbLvXQb1cfN+EcM0wf7zC6CPF+C79jroc=
+k8s.io/utils v0.0.0-20260507154919-ff6756f316d2/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -35,8 +35,8 @@ type ArubaCloudProvider struct {
 
 // ArubaCloudProviderModel describes the provider data model.
 type ArubaCloudProviderModel struct {
-	ApiKey          types.String `tfsdk:"api_key"`
-	ApiSecret       types.String `tfsdk:"api_secret"`
+	ClientID        types.String `tfsdk:"client_id"`
+	ClientSecret    types.String `tfsdk:"client_secret"`
 	ResourceTimeout types.String `tfsdk:"resource_timeout"`
 	BaseURL         types.String `tfsdk:"base_url"`
 	TokenIssuerURL  types.String `tfsdk:"token_issuer_url"`
@@ -51,12 +51,12 @@ func (p *ArubaCloudProvider) Metadata(ctx context.Context, req provider.Metadata
 func (p *ArubaCloudProvider) Schema(ctx context.Context, req provider.SchemaRequest, resp *provider.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			"api_key": schema.StringAttribute{
-				MarkdownDescription: "API key for ArubaCloud. Can also be set via ARUBACLOUD_API_KEY environment variable.",
+			"client_id": schema.StringAttribute{
+				MarkdownDescription: "Client ID for ArubaCloud OAuth2 authentication. Can also be set via the `ARUBACLOUD_CLIENT_ID` environment variable.",
 				Optional:            true,
 			},
-			"api_secret": schema.StringAttribute{
-				MarkdownDescription: "API secret for ArubaCloud. Can also be set via ARUBACLOUD_API_SECRET environment variable.",
+			"client_secret": schema.StringAttribute{
+				MarkdownDescription: "Client secret for ArubaCloud OAuth2 authentication. Can also be set via the `ARUBACLOUD_CLIENT_SECRET` environment variable.",
 				Optional:            true,
 				Sensitive:           true,
 			},
@@ -91,8 +91,8 @@ func (p *ArubaCloudProvider) Schema(ctx context.Context, req provider.SchemaRequ
 func (p *ArubaCloudProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
 
 	// Default values to environment variables, but override with Terraform configuration value if set.
-	apiKey := os.Getenv("ARUBACLOUD_API_KEY")
-	apiSecret := os.Getenv("ARUBACLOUD_API_SECRET")
+	clientID := os.Getenv("ARUBACLOUD_CLIENT_ID")
+	clientSecret := os.Getenv("ARUBACLOUD_CLIENT_SECRET")
 	tokenIssuerURL := os.Getenv("ARUBACLOUD_TOKEN_ISSUER_URL")
 	logLevelStr := os.Getenv("ARUBACLOUD_LOG_LEVEL")
 
@@ -104,12 +104,12 @@ func (p *ArubaCloudProvider) Configure(ctx context.Context, req provider.Configu
 		return
 	}
 
-	if !config.ApiKey.IsNull() {
-		apiKey = config.ApiKey.ValueString()
+	if !config.ClientID.IsNull() {
+		clientID = config.ClientID.ValueString()
 	}
 
-	if !config.ApiSecret.IsNull() {
-		apiSecret = config.ApiSecret.ValueString()
+	if !config.ClientSecret.IsNull() {
+		clientSecret = config.ClientSecret.ValueString()
 	}
 
 	if !config.TokenIssuerURL.IsNull() && config.TokenIssuerURL.ValueString() != "" {
@@ -120,21 +120,21 @@ func (p *ArubaCloudProvider) Configure(ctx context.Context, req provider.Configu
 		logLevelStr = config.LogLevel.ValueString()
 	}
 
-	if apiKey == "" {
+	if clientID == "" {
 		resp.Diagnostics.AddAttributeError(
-			path.Root("api_key"),
-			"Unknown ArubaCloud API Key",
-			"The provider cannot create the ArubaCloud API client as there is an unknown configuration value for the API key. "+
-				"Either target apply the source of the value first, set the value statically in the configuration, or use the ARUBACLOUD_API_KEY environment variable.",
+			path.Root("client_id"),
+			"Unknown ArubaCloud Client ID",
+			"The provider cannot create the ArubaCloud API client as there is an unknown configuration value for the client ID. "+
+				"Either target apply the source of the value first, set the value statically in the configuration, or use the ARUBACLOUD_CLIENT_ID environment variable.",
 		)
 	}
 
-	if apiSecret == "" {
+	if clientSecret == "" {
 		resp.Diagnostics.AddAttributeError(
-			path.Root("api_secret"),
-			"Unknown ArubaCloud API Secret",
-			"The provider cannot create the ArubaCloud API client as there is an unknown configuration value for the API secret. "+
-				"Either target apply the source of the value first, set the value statically in the configuration, or use the ARUBACLOUD_API_SECRET environment variable.",
+			path.Root("client_secret"),
+			"Unknown ArubaCloud Client Secret",
+			"The provider cannot create the ArubaCloud API client as there is an unknown configuration value for the client secret. "+
+				"Either target apply the source of the value first, set the value statically in the configuration, or use the ARUBACLOUD_CLIENT_SECRET environment variable.",
 		)
 	}
 
@@ -157,7 +157,7 @@ func (p *ArubaCloudProvider) Configure(ctx context.Context, req provider.Configu
 	ctx = tflog.NewSubsystem(ctx, subsystemName)
 
 	// Create SDK client with credentials using DefaultOptions
-	options := aruba.DefaultOptions(apiKey, apiSecret)
+	options := aruba.DefaultOptions(clientID, clientSecret)
 	options = options.WithCustomLogger(newSDKLogAdapter(ctx, logLevel))
 
 	// Optionally override base URL and token issuer
@@ -183,8 +183,8 @@ func (p *ArubaCloudProvider) Configure(ctx context.Context, req provider.Configu
 
 	// Create a new ArubaCloud client using the SDK client
 	client := &ArubaCloudClient{
-		ApiKey:          apiKey,
-		ApiSecret:       apiSecret,
+		ClientID:        clientID,
+		ClientSecret:    clientSecret,
 		Client:          sdkClient,
 		ResourceTimeout: resourceTimeout,
 	}
@@ -215,8 +215,8 @@ func parseTimeout(timeoutStr types.String, defaultDuration time.Duration, diags 
 
 // ArubaCloudClient wraps the SDK client with API credentials and timeout configuration.
 type ArubaCloudClient struct {
-	ApiKey          string
-	ApiSecret       string
+	ClientID        string
+	ClientSecret    string
 	Client          aruba.Client
 	ResourceTimeout time.Duration
 }

--- a/internal/provider/provider_error.go
+++ b/internal/provider/provider_error.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	sdktypes "github.com/Arubacloud/sdk-go/pkg/types"
 )
 
@@ -213,21 +214,19 @@ func newResponseError(operation, resource string, statusCode int, errResp *sdkty
 	}
 }
 
-// CheckResponse inspects a typed SDK response and returns nil if the status code
-// is 2xx, or a *ProviderError otherwise. A nil response is treated as a Technical error.
-func CheckResponse[T any](operation, resource string, resp *sdktypes.Response[T]) error {
-	if resp == nil {
-		return &ProviderError{
-			Category:  ProviderErrorCategoryTechnical,
-			Operation: operation,
-			Resource:  resource,
-			Cause:     fmt.Errorf("nil response"),
-		}
-	}
-	if resp.IsSuccess() {
+// CheckResponseErr inspects the error returned by a sdk-go v1 builder call and
+// returns a classified *ProviderError, or nil on success (err == nil).
+// It handles both API-level errors (*aruba.HTTPError, produced by 4xx/5xx responses)
+// and transport-level errors (network failures, TLS errors, etc.).
+func CheckResponseErr(operation, resource string, err error) *ProviderError {
+	if err == nil {
 		return nil
 	}
-	return newResponseError(operation, resource, resp.StatusCode, resp.Error, resp.RawBody)
+	var httpErr *aruba.HTTPError
+	if errors.As(err, &httpErr) {
+		return newResponseError(operation, resource, httpErr.StatusCode, httpErr.ErrResp, httpErr.Body)
+	}
+	return NewTransportError(operation, resource, err)
 }
 
 // IsNotFound reports whether err (or any error in its chain) represents a 404 Not Found response.

--- a/internal/provider/provider_error_test.go
+++ b/internal/provider/provider_error_test.go
@@ -2,9 +2,11 @@ package provider
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
+	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	sdktypes "github.com/Arubacloud/sdk-go/pkg/types"
 )
 
@@ -186,78 +188,78 @@ func TestNewResponseError_NilErrResp(t *testing.T) {
 	_ = err.Error()
 }
 
-func TestCheckResponse(t *testing.T) {
+func makeHTTPErr(statusCode int, errResp *sdktypes.ErrorResponse) error {
+	return &aruba.HTTPError{StatusCode: statusCode, ErrResp: errResp}
+}
+
+func TestCheckResponseErr(t *testing.T) {
 	title404 := "Not Found"
 	title400 := "Validation failed"
 
 	cases := []struct {
 		name         string
-		resp         *sdktypes.Response[struct{}]
+		err          error
 		wantNil      bool
 		wantCategory ProviderErrorCategory
 	}{
 		{
-			name:         "nil response → technical error",
-			resp:         nil,
-			wantCategory: ProviderErrorCategoryTechnical,
-		},
-		{
-			name:    "200 OK → nil",
-			resp:    &sdktypes.Response[struct{}]{StatusCode: 200},
-			wantNil: true,
-		},
-		{
-			name:    "201 Created → nil",
-			resp:    &sdktypes.Response[struct{}]{StatusCode: 201},
+			name:    "nil error → nil (success)",
+			err:     nil,
 			wantNil: true,
 		},
 		{
 			name: "404 Not Found (no validation errors) → transient",
-			resp: &sdktypes.Response[struct{}]{
-				StatusCode: 404,
-				Error:      &sdktypes.ErrorResponse{Title: &title404},
-			},
+			err:  makeHTTPErr(404, &sdktypes.ErrorResponse{Title: &title404}),
 			wantCategory: ProviderErrorCategoryTransient,
 		},
 		{
 			name: "400 with validation errors → semantic",
-			resp: &sdktypes.Response[struct{}]{
-				StatusCode: 400,
-				Error: &sdktypes.ErrorResponse{
-					Title: &title400,
-					Errors: []sdktypes.ValidationError{
-						{Field: "name", Message: "is required"},
-					},
+			err: makeHTTPErr(400, &sdktypes.ErrorResponse{
+				Title: &title400,
+				Errors: []sdktypes.ValidationError{
+					{Field: "name", Message: "is required"},
 				},
-			},
+			}),
 			wantCategory: ProviderErrorCategorySemantic,
 		},
 		{
 			name:         "500 Internal Server Error → technical",
-			resp:         &sdktypes.Response[struct{}]{StatusCode: 500},
+			err:          makeHTTPErr(500, nil),
+			wantCategory: ProviderErrorCategoryTechnical,
+		},
+		{
+			name:         "non-HTTP transport error → technical",
+			err:          fmt.Errorf("dial tcp: connection refused"),
 			wantCategory: ProviderErrorCategoryTechnical,
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := CheckResponse("create", "Resource", tc.resp)
+			provErr := CheckResponseErr("create", "Resource", tc.err)
 			if tc.wantNil {
-				if err != nil {
-					t.Errorf("expected nil error, got %v", err)
+				if provErr != nil {
+					t.Errorf("expected nil, got %v", provErr)
 				}
 				return
 			}
-			if err == nil {
-				t.Fatal("expected non-nil error, got nil")
-			}
-			var provErr *ProviderError
-			if !errors.As(err, &provErr) {
-				t.Fatalf("expected *ProviderError, got %T", err)
+			if provErr == nil {
+				t.Fatal("expected non-nil *ProviderError, got nil")
 			}
 			if provErr.Category != tc.wantCategory {
 				t.Errorf("category: got %v, want %v", provErr.Category, tc.wantCategory)
 			}
 		})
+	}
+}
+
+func TestCheckResponseErr_IsNotFound(t *testing.T) {
+	title := "Not Found"
+	err := CheckResponseErr("get", "VPC", makeHTTPErr(404, &sdktypes.ErrorResponse{Title: &title}))
+	if err == nil {
+		t.Fatal("expected non-nil error for 404")
+	}
+	if !IsNotFound(err) {
+		t.Errorf("IsNotFound should return true for 404, got false; err=%v", err)
 	}
 }
 

--- a/internal/provider/provider_schema_test.go
+++ b/internal/provider/provider_schema_test.go
@@ -3,6 +3,9 @@ package provider
 import (
 	"context"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 )
 
 // TestProviderSchema validates that the provider can be instantiated successfully.
@@ -86,6 +89,35 @@ func TestAllDataSourceSchemas(t *testing.T) {
 		dataSource := dataSourceFunc()
 		if dataSource == nil {
 			t.Error("data source function returned nil")
+		}
+	}
+}
+
+// TestProviderSchemaAttributes validates the auth attribute rename from v0.1.x to v0.2.0.
+func TestProviderSchemaAttributes(t *testing.T) {
+	t.Parallel()
+
+	p := New("test")()
+	schemaResp := &provider.SchemaResponse{}
+	p.Schema(context.TODO(), provider.SchemaRequest{}, schemaResp)
+	attrs := schemaResp.Schema.Attributes
+
+	// v0.2.0 attributes must exist
+	for _, name := range []string{"client_id", "client_secret"} {
+		if _, ok := attrs[name]; !ok {
+			t.Errorf("expected provider schema attribute %q to exist", name)
+		}
+	}
+	// client_secret must be sensitive
+	if cs, ok := attrs["client_secret"]; ok {
+		if sa, ok := cs.(schema.StringAttribute); !ok || !sa.Sensitive {
+			t.Error("client_secret must be Sensitive: true")
+		}
+	}
+	// v0.1.x attributes must NOT exist
+	for _, name := range []string{"api_key", "api_secret"} {
+		if _, ok := attrs[name]; ok {
+			t.Errorf("deprecated attribute %q must not be present in v0.2.0 schema", name)
 		}
 	}
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -20,7 +20,7 @@ var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServe
 
 func testAccPreCheck(t *testing.T) {
 	t.Helper()
-	for _, env := range []string{"ARUBACLOUD_API_KEY", "ARUBACLOUD_API_SECRET"} {
+	for _, env := range []string{"ARUBACLOUD_CLIENT_ID", "ARUBACLOUD_CLIENT_SECRET"} {
 		if os.Getenv(env) == "" {
 			t.Fatalf("acceptance tests require %s to be set", env)
 		}
@@ -29,12 +29,12 @@ func testAccPreCheck(t *testing.T) {
 
 // testAccClient builds an ArubaCloudClient from env vars for use in CheckDestroy functions.
 func testAccClient() (*ArubaCloudClient, error) {
-	apiKey := os.Getenv("ARUBACLOUD_API_KEY")
-	apiSecret := os.Getenv("ARUBACLOUD_API_SECRET")
-	if apiKey == "" || apiSecret == "" {
-		return nil, fmt.Errorf("ARUBACLOUD_API_KEY and ARUBACLOUD_API_SECRET must be set")
+	clientID := os.Getenv("ARUBACLOUD_CLIENT_ID")
+	clientSecret := os.Getenv("ARUBACLOUD_CLIENT_SECRET")
+	if clientID == "" || clientSecret == "" {
+		return nil, fmt.Errorf("ARUBACLOUD_CLIENT_ID and ARUBACLOUD_CLIENT_SECRET must be set")
 	}
-	sdkClient, err := aruba.NewClient(aruba.DefaultOptions(apiKey, apiSecret))
+	sdkClient, err := aruba.NewClient(aruba.DefaultOptions(clientID, clientSecret))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create test client: %w", err)
 	}

--- a/internal/provider/testutil_mockserver_test.go
+++ b/internal/provider/testutil_mockserver_test.go
@@ -44,8 +44,8 @@ func newMockArubaClient(t *testing.T, apiHandler http.HandlerFunc) (*httptest.Se
 	}
 
 	return srv, &ArubaCloudClient{
-		ApiKey:          "test-key",
-		ApiSecret:       "test-secret",
+		ClientID:        "test-client-id",
+		ClientSecret:    "test-client-secret",
 		Client:          sdkClient,
 		ResourceTimeout: 10 * time.Minute,
 	}


### PR DESCRIPTION
﻿## Summary
Replaces the generic `CheckResponse[T any](*sdktypes.Response[T])` gate with `CheckResponseErr(operation, resource string, err error) *ProviderError`, which handles the error return from sdk-go v1.0.4 builder calls.

This is a **prerequisite for all resource migration PRs** (#136–#142) — every resource CRUD path calls it.

## Background

| | Before (v0.1.24) | After (v1.0.4) |
|---|---|---|
| SDK call returns | `(*sdktypes.Response[T], error)` | `(WrapperType, error)` |
| Error type | `*sdktypes.Response[T]` with `.IsError()` / `.StatusCode` / `.Error` | `*aruba.HTTPError` with `.StatusCode` / `.ErrResp` / `.Body` |
| Error classification | `CheckResponse[T]` on the response | `CheckResponseErr` on the `error` return |

## Changes

**`internal/provider/provider_error.go`**
- Add `"github.com/Arubacloud/sdk-go/pkg/aruba"` import
- Add `CheckResponseErr(operation, resource string, err error) *ProviderError`
  — handles `*aruba.HTTPError` (API) and plain errors (transport) in one function
- Remove `CheckResponse[T any](operation, resource string, resp *sdktypes.Response[T]) error`
- Retain `newResponseError(...)` unchanged — `aruba.HTTPError.ErrResp` is `*types.ErrorResponse` carrying the same `Errors[]{Field, Message}` array; Semantic/Transient/Technical classification is fully preserved

**`internal/provider/provider_error_test.go`**
- Add `aruba "github.com/Arubacloud/sdk-go/pkg/aruba"` import
- Replace `TestCheckResponse` with `TestCheckResponseErr` using `*aruba.HTTPError` fixtures
- Add `TestCheckResponseErr_IsNotFound` — verifies 404 → `IsNotFound`
- All `TestNewResponseError_*` tests unchanged (they test internal `newResponseError` directly)

## Test plan
- [ ] `TestCheckResponseErr` passes (nil→nil, 404→transient, 400+errors→semantic, 500→technical, transport→technical)
- [ ] `TestCheckResponseErr_IsNotFound` passes
- [ ] All existing `TestNewResponseError_*` tests pass
- [ ] `TestIsNotFound`, `TestErrorCategoryHelpers` pass

Closes #135
