### PR TITLE
refactor: migrate compute resources (CloudServer, KeyPair) to sdk-go v1.0.4 builder API

### DIFF
--- a/docs/guides/sdk-v1-compile-error-inventory.md
+++ b/docs/guides/sdk-v1-compile-error-inventory.md
@@ -1,0 +1,124 @@
+# sdk-go v1.0.4 Compile Error Inventory
+
+Generated after bumping `go.mod` from `sdk-go v0.1.24` → `v1.0.4` and running `go build -gcflags=all='-e' ./...`.
+
+## Summary
+
+| Category | Count | Scope | Fix strategy |
+|---|---|---|---|
+| `.Data undefined` | 660 | All 50 files | Replace `response.Data.*` access with wrapper promoted accessors (`wrapper.ID()`, `wrapper.URI()`, `wrapper.Name()`, `wrapper.State()`, `wrapper.Raw().Properties.*`) |
+| `string→CallOption` (trailing `nil`) | 399 | All 50 files | Remove trailing `nil` argument — v1.0.4 CRUD methods no longer accept a trailing options parameter via the old `nil` pattern |
+| `string→Ref` (parent ID params) | 214 | All 50 files | Replace explicit string parent IDs with builder-embedded `aruba.URI(...)` Refs; Create no longer takes separate `projectID` argument |
+| `CheckResponse` type mismatch | 130 | All files using `CheckResponse` | Replace `CheckResponse[T](*sdktypes.Response[T])` with `CheckResponseErr(op, res, error)` (see issue #135) |
+| `sdktypes.*` undefined | 107 | 25 resource files | Replace struct-literal request construction with fluent builder chains (see issues #136–#142) |
+| `.IsError()` undefined | 15 | Files using `.IsError()` | Remove — errors surface via `(wrapper, error)` return; check `err != nil` instead |
+| **Total** | **~1,525** | **50 files** | |
+
+## Files affected
+
+All 25 resource files and all 25 data source files in `internal/provider/`.
+
+## Error category detail
+
+### 1. `.Data undefined` (660 errors) — highest volume
+
+Every `response.Data.Metadata.ID`, `response.Data.Metadata.URI`, `response.Data.Properties.*`, `response.Data.Status.State` access.
+
+**Before**:
+```go
+data.Id  = types.StringValue(*response.Data.Metadata.ID)
+data.Uri = types.StringValue(*response.Data.Metadata.URI)
+state    := *response.Data.Status.State
+```
+
+**After**:
+```go
+data.Id  = types.StringValue(wrapper.ID())
+data.Uri = types.StringValue(wrapper.URI())
+state    := string(wrapper.State())
+// Resource-specific properties:
+raw := wrapper.Raw()
+data.SizeGB = types.Int64Value(int64(*raw.Properties.SizeGB))
+```
+
+### 2. `string→CallOption` (399 errors) — trailing `nil` parameter
+
+Every CRUD call ends with `..., nil)` which was the options parameter. v1.0.4 removes it from these positions.
+
+**Before**:
+```go
+r.client.Client.FromNetwork().VPCs().Get(ctx, projectID, vpcID, nil)
+```
+
+**After**:
+```go
+r.client.Client.FromNetwork().VPCs().Get(ctx, aruba.URI(data.Uri.ValueString()))
+```
+
+### 3. `string→Ref` (214 errors) — CRUD signature change
+
+Parent IDs passed as explicit string parameters are no longer accepted. The builder embeds them.
+
+**Before**:
+```go
+r.client.Client.FromNetwork().VPCs().Create(ctx, projectID, createRequest, nil)
+```
+
+**After**:
+```go
+r.client.Client.FromNetwork().VPCs().Create(ctx, aruba.NewVPC().Named(...).InProject(aruba.URI(...)))
+```
+
+### 4. `CheckResponse` type mismatch (130 errors)
+
+`CheckResponse[T any](op, res string, resp *sdktypes.Response[T])` is called with the new wrapper types which don't implement `*sdktypes.Response[T]`.
+
+Fix: Replace with `CheckResponseErr(op, res string, err error) *ProviderError` — see issue #135.
+
+### 5. `sdktypes.*` undefined (107 errors)
+
+Request struct types from `pkg/types` that were used for literal construction. All replaced by builder methods.
+
+Examples:
+- `sdktypes.CloudServerRequest{...}` → `aruba.NewCloudServer().Named(...)`
+- `sdktypes.BlockStorageRequest{...}` → `aruba.NewBlockStorage().Named(...)`
+- `sdktypes.SubnetDHCP{...}` → `aruba.NewSubnetDHCP().Enabled()...`
+- `sdktypes.NodePoolProperties{...}` → `aruba.NewNodePool().Named()...`
+
+### 6. `.IsError()` undefined (15 errors)
+
+`response.IsError()` no longer exists on wrappers. Errors surface via the `error` return value of CRUD methods.
+
+**Before**:
+```go
+if response.IsError() { ... }
+```
+
+**After**:
+```go
+if err != nil { ... }
+```
+
+## Confirmed architectural decisions (from this analysis)
+
+1. **Module path unchanged**: `github.com/Arubacloud/sdk-go` (no v2 suffix) ✅
+2. **All 50 files affected**: Every resource and data source needs updating
+3. **Dominant change is `.Data` access**: 660 errors — the wrapper pattern replaces the `Response[T].Data` envelope entirely
+4. **CRUD signature changes**: Confirmed across all 214 parent-ID usage sites
+5. **`pkg/types` request types**: 107 undefined errors confirm complete elimination is required
+6. **`provider_error.go`**: The 130 `CheckResponse` mismatches are all in resource files; fixing `provider_error.go` (issue #135) first eliminates them all
+7. **`go mod tidy` succeeds**: No dependency conflicts; v1.0.4 is compatible with the rest of the dependency tree
+
+## Implementation order
+
+Based on this analysis, the fix order is:
+
+```
+#134 (auth rename — independent)
+#135 (CheckResponse → CheckResponseErr — prerequisite for all resource files)
+    ↓
+#136 (compute)  #137 (networking)  #138 (ext-network)
+#139 (storage)  #140 (database)    #141 (container)   #142 (security+schedule)
+    ↓ (can parallelise)
+#143 (cleanup)  #144 (tests)  #145 (docs+release)
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,8 +23,8 @@ terraform {
 }
 
 provider "arubacloud" {
-  api_key    = "YOUR_API_KEY"
-  api_secret = "YOUR_API_SECRET"
+  client_id     = "YOUR_CLIENT_ID"
+  client_secret = "YOUR_CLIENT_SECRET"
 }
 ```
 
@@ -47,8 +47,8 @@ terraform {
 }
 
 provider "arubacloud" {
-  api_key    = var.api_key
-  api_secret = var.api_secret
+  client_id     = var.client_id
+  client_secret = var.client_secret
 }
 
 variable "api_key" {
@@ -209,8 +209,8 @@ output "cloudserver_id" {
 
 The following arguments are supported:
 
-- `api_key` - (Required, string) ArubaCloud API key. Can also be specified with the `ARUBACLOUD_API_KEY` environment variable.
-- `api_secret` - (Required, string) ArubaCloud API secret. Can also be specified with the `ARUBACLOUD_API_SECRET` environment variable.
+- `client_id` - (Required, string) ArubaCloud API key. Can also be specified with the `ARUBACLOUD_CLIENT_ID` environment variable.
+- `client_secret` - (Required, string) ArubaCloud API secret. Can also be specified with the `ARUBACLOUD_CLIENT_SECRET` environment variable.
 - `resource_timeout` - (Optional, string) Timeout for waiting for resources to become active after creation (e.g. `"5m"`, `"10m"`). Default: `"10m"`.
 - `base_url` - (Optional, string) Override the ArubaCloud API base URL. Advanced use only.
 - `token_issuer_url` - (Optional, string) Override the ArubaCloud token issuer URL. Advanced use only.
@@ -231,8 +231,8 @@ A message is visible only when **both** filters permit it. SDK messages are tagg
 
 ```hcl
 provider "arubacloud" {
-  api_key    = var.api_key
-  api_secret = var.api_secret
+  client_id     = var.client_id
+  client_secret = var.client_secret
   log_level  = "DEBUG"
 }
 ```

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -8,6 +8,6 @@ terraform {
 }
 
 provider "arubacloud" {
-  api_key    = "YOUR_API_KEY"
-  api_secret = "YOUR_API_SECRET"
+  client_id     = "YOUR_CLIENT_ID"
+  client_secret = "YOUR_CLIENT_SECRET"
 }

--- a/examples/provider/quick-start.tf
+++ b/examples/provider/quick-start.tf
@@ -12,18 +12,18 @@ terraform {
 }
 
 provider "arubacloud" {
-  api_key    = var.api_key
-  api_secret = var.api_secret
+  client_id     = var.client_id
+  client_secret = var.client_secret
 }
 
-variable "api_key" {
-  description = "ArubaCloud API key"
+variable "client_id" {
+  description = "ArubaCloud OAuth2 client ID"
   type        = string
   sensitive   = true
 }
 
-variable "api_secret" {
-  description = "ArubaCloud API secret"
+variable "client_secret" {
+  description = "ArubaCloud OAuth2 client secret"
   type        = string
   sensitive   = true
 }
@@ -117,7 +117,7 @@ resource "arubacloud_blockstorage" "quickstart_boot" {
   name           = "quickstart-boot-disk"
   project_id     = arubacloud_project.quickstart.id
   location       = "ITBG-Bergamo"
-  zone           = "ITBG-1" # Zone (datacenter) — must match the CloudServer zone below
+  zone           = "ITBG-1" # Zone (datacenter) ï¿½ must match the CloudServer zone below
   size_gb        = 50
   billing_period = "Hour"
   type           = "Performance" # Performance type recommended for boot volumes
@@ -133,7 +133,7 @@ resource "arubacloud_cloudserver" "quickstart" {
   name       = "quickstart-server"
   location   = "ITBG-Bergamo"
   project_id = arubacloud_project.quickstart.id
-  zone       = "ITBG-1" # Zone (datacenter) — must match the boot-volume zone above
+  zone       = "ITBG-1" # Zone (datacenter) ï¿½ must match the boot-volume zone above
   tags       = ["quickstart", "compute"]
 
   network = {

--- a/examples/test/compute/00-variables.tf
+++ b/examples/test/compute/00-variables.tf
@@ -1,11 +1,11 @@
-variable "arubacloud_api_key" {
-  description = "ArubaCloud API Key"
+variable "arubacloud_client_id" {
+  description = "ArubaCloud OAuth2 Client ID"
   type        = string
   sensitive   = true
 }
 
-variable "arubacloud_api_secret" {
-  description = "ArubaCloud API Secret"
+variable "arubacloud_client_secret" {
+  description = "ArubaCloud OAuth2 Client Secret"
   type        = string
   sensitive   = true
 }

--- a/examples/test/compute/01-provider.tf
+++ b/examples/test/compute/01-provider.tf
@@ -9,8 +9,8 @@ terraform {
 
 
 provider "arubacloud" {
-  api_key    = var.arubacloud_api_key
-  api_secret = var.arubacloud_api_secret
+  client_id     = var.arubacloud_client_id
+  client_secret = var.arubacloud_client_secret
   
   log_level = "DEBUG" # Accepted: OFF, ERROR, WARN, INFO, DEBUG, TRACE. Default: OFF. Requires TF_LOG=DEBUG to surface.
 

--- a/examples/test/container/00-variables.tf
+++ b/examples/test/container/00-variables.tf
@@ -1,11 +1,11 @@
-variable "arubacloud_api_key" {
-  description = "ArubaCloud API Key"
+variable "arubacloud_client_id" {
+  description = "ArubaCloud OAuth2 Client ID"
   type        = string
   sensitive   = true
 }
 
-variable "arubacloud_api_secret" {
-  description = "ArubaCloud API Secret"
+variable "arubacloud_client_secret" {
+  description = "ArubaCloud OAuth2 Client Secret"
   type        = string
   sensitive   = true
 }

--- a/examples/test/container/01-provider.tf
+++ b/examples/test/container/01-provider.tf
@@ -8,6 +8,6 @@ terraform {
 }
 
 provider "arubacloud" {
-  api_key    = var.arubacloud_api_key
-  api_secret = var.arubacloud_api_secret
+  client_id     = var.arubacloud_client_id
+  client_secret = var.arubacloud_client_secret
 }

--- a/examples/test/database/00-variables.tf
+++ b/examples/test/database/00-variables.tf
@@ -1,11 +1,11 @@
-variable "arubacloud_api_key" {
-  description = "ArubaCloud API Key"
+variable "arubacloud_client_id" {
+  description = "ArubaCloud OAuth2 Client ID"
   type        = string
   sensitive   = true
 }
 
-variable "arubacloud_api_secret" {
-  description = "ArubaCloud API Secret"
+variable "arubacloud_client_secret" {
+  description = "ArubaCloud OAuth2 Client Secret"
   type        = string
   sensitive   = true
 }

--- a/examples/test/database/01-provider.tf
+++ b/examples/test/database/01-provider.tf
@@ -8,6 +8,6 @@ terraform {
 }
 
 provider "arubacloud" {
-  api_key    = var.arubacloud_api_key
-  api_secret = var.arubacloud_api_secret
+  client_id     = var.arubacloud_client_id
+  client_secret = var.arubacloud_client_secret
 }

--- a/examples/test/datasources/00-input-variables.tf
+++ b/examples/test/datasources/00-input-variables.tf
@@ -2,14 +2,14 @@
 # Fill these with actual resource IDs from your account to test datasources
 
 # Provider Credentials
-variable "arubacloud_api_key" {
-  description = "ArubaCloud API Key"
+variable "arubacloud_client_id" {
+  description = "ArubaCloud OAuth2 Client ID"
   type        = string
   sensitive   = true
 }
 
-variable "arubacloud_api_secret" {
-  description = "ArubaCloud API Secret"
+variable "arubacloud_client_secret" {
+  description = "ArubaCloud OAuth2 Client Secret"
   type        = string
   sensitive   = true
 }

--- a/examples/test/datasources/01-provider.tf
+++ b/examples/test/datasources/01-provider.tf
@@ -8,6 +8,6 @@ terraform {
 }
 
 provider "arubacloud" {
-  api_key    = var.arubacloud_api_key
-  api_secret = var.arubacloud_api_secret
+  client_id     = var.arubacloud_client_id
+  client_secret = var.arubacloud_client_secret
 }

--- a/examples/test/schedule/00-variables.tf
+++ b/examples/test/schedule/00-variables.tf
@@ -1,11 +1,11 @@
-variable "arubacloud_api_key" {
-  description = "ArubaCloud API Key"
+variable "arubacloud_client_id" {
+  description = "ArubaCloud OAuth2 Client ID"
   type        = string
   sensitive   = true
 }
 
-variable "arubacloud_api_secret" {
-  description = "ArubaCloud API Secret"
+variable "arubacloud_client_secret" {
+  description = "ArubaCloud OAuth2 Client Secret"
   type        = string
   sensitive   = true
 }

--- a/examples/test/schedule/01-provider.tf
+++ b/examples/test/schedule/01-provider.tf
@@ -8,6 +8,6 @@ terraform {
 }
 
 provider "arubacloud" {
-  api_key    = var.arubacloud_api_key
-  api_secret = var.arubacloud_api_secret
+  client_id     = var.arubacloud_client_id
+  client_secret = var.arubacloud_client_secret
 }

--- a/examples/test/security/00-variables.tf
+++ b/examples/test/security/00-variables.tf
@@ -1,11 +1,11 @@
-variable "arubacloud_api_key" {
-  description = "ArubaCloud API Key"
+variable "arubacloud_client_id" {
+  description = "ArubaCloud OAuth2 Client ID"
   type        = string
   sensitive   = true
 }
 
-variable "arubacloud_api_secret" {
-  description = "ArubaCloud API Secret"
+variable "arubacloud_client_secret" {
+  description = "ArubaCloud OAuth2 Client Secret"
   type        = string
   sensitive   = true
 }

--- a/examples/test/security/01-provider.tf
+++ b/examples/test/security/01-provider.tf
@@ -8,6 +8,6 @@ terraform {
 }
 
 provider "arubacloud" {
-  api_key    = var.arubacloud_api_key
-  api_secret = var.arubacloud_api_secret
+  client_id     = var.arubacloud_client_id
+  client_secret = var.arubacloud_client_secret
 }

--- a/examples/test/wordpress/00-variables.tf
+++ b/examples/test/wordpress/00-variables.tf
@@ -1,11 +1,11 @@
-variable "arubacloud_api_key" {
-  description = "ArubaCloud API Key"
+variable "arubacloud_client_id" {
+  description = "ArubaCloud OAuth2 Client ID"
   type        = string
   sensitive   = true
 }
 
-variable "arubacloud_api_secret" {
-  description = "ArubaCloud API Secret"
+variable "arubacloud_client_secret" {
+  description = "ArubaCloud OAuth2 Client Secret"
   type        = string
   sensitive   = true
 }

--- a/examples/test/wordpress/01-provider.tf
+++ b/examples/test/wordpress/01-provider.tf
@@ -8,8 +8,8 @@ terraform {
 }
 
 provider "arubacloud" {
-  api_key    = var.arubacloud_api_key
-  api_secret = var.arubacloud_api_secret
+  client_id     = var.arubacloud_client_id
+  client_secret = var.arubacloud_client_secret
 
   resource_timeout = "20m"
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Arubacloud/terraform-provider-arubacloud
 go 1.24.0
 
 require (
-	github.com/Arubacloud/sdk-go v0.1.24
+	github.com/Arubacloud/sdk-go v1.0.4
 	github.com/hashicorp/terraform-plugin-framework v1.16.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.29.0
@@ -78,4 +78,6 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250707201910-8d1bb00bc6a7 // indirect
 	google.golang.org/grpc v1.75.1 // indirect
 	google.golang.org/protobuf v1.36.9 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/utils v0.0.0-20260507154919-ff6756f316d2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/Arubacloud/sdk-go v0.1.24 h1:4mu7TzoLhkZCq1lHlzQgymf7Q4FzWDplyK9iszM6PE0=
-github.com/Arubacloud/sdk-go v0.1.24/go.mod h1:4lXc0Dte8HqeKag8eMo0/TClwsgMqXW0KbKaQ2BYlXA=
+github.com/Arubacloud/sdk-go v1.0.4 h1:RUmmvojnIyHFAY0gE/jujfbbs7qY+ecpgv9fxEcp87w=
+github.com/Arubacloud/sdk-go v1.0.4/go.mod h1:OD2PSOa9uAxrhFwDcYcw+LE7eyZ+OQVaTA2tlHxVE4U=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.1.6 h1:ZcV+Ropw6Qn0AX9brlQLAUXfqLBc7Bl+f/DmNxpLfdw=
@@ -283,3 +283,5 @@ gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+k8s.io/utils v0.0.0-20260507154919-ff6756f316d2 h1:wU4tMEhLGgIbLvXQb1cfN+EcM0wf7zC6CPF+C79jroc=
+k8s.io/utils v0.0.0-20260507154919-ff6756f316d2/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=

--- a/internal/provider/cloudserver_data_source.go
+++ b/internal/provider/cloudserver_data_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -55,7 +56,7 @@ func (d *CloudServerDataSource) Schema(ctx context.Context, req datasource.Schem
 				Required:            true,
 			},
 			"uri": schema.StringAttribute{
-				MarkdownDescription: "Computed by the API. Full resource URI used as a reference value in other resources (e.g., as a `*_uri_ref` attribute).",
+				MarkdownDescription: "Computed by the API. Full resource URI.",
 				Computed:            true,
 			},
 			"name": schema.StringAttribute{
@@ -63,7 +64,7 @@ func (d *CloudServerDataSource) Schema(ctx context.Context, req datasource.Schem
 				Computed:            true,
 			},
 			"location": schema.StringAttribute{
-				MarkdownDescription: "Region identifier for the resource (e.g., `ITBG-Bergamo`). See the [available locations and zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center).",
+				MarkdownDescription: "Region identifier for the resource (e.g., `ITBG-Bergamo`).",
 				Computed:            true,
 			},
 			"project_id": schema.StringAttribute{
@@ -71,7 +72,7 @@ func (d *CloudServerDataSource) Schema(ctx context.Context, req datasource.Schem
 				Required:            true,
 			},
 			"zone": schema.StringAttribute{
-				MarkdownDescription: "Availability zone within the region (e.g., `ITBG-1`). See [available zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center).",
+				MarkdownDescription: "Availability zone within the region (e.g., `ITBG-1`).",
 				Computed:            true,
 			},
 			"tags": schema.ListAttribute{
@@ -98,7 +99,7 @@ func (d *CloudServerDataSource) Schema(ctx context.Context, req datasource.Schem
 				Computed:            true,
 			},
 			"flavor_name": schema.StringAttribute{
-				MarkdownDescription: "Compute flavour name (e.g., `CSO4A8` for 4 vCPU / 8 GB RAM). See [available flavours](https://api.arubacloud.com/docs/metadata/#cloudserver-flavors).",
+				MarkdownDescription: "Compute flavour name (e.g., `CSO4A8` for 4 vCPU / 8 GB RAM).",
 				Computed:            true,
 			},
 			"key_pair_uri_ref": schema.StringAttribute{
@@ -146,52 +147,42 @@ func (d *CloudServerDataSource) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
-	response, err := d.client.Client.FromCompute().CloudServers().Get(ctx, projectID, serverID, nil)
-	if err != nil {
-		resp.Diagnostics.AddError("Error reading cloud server", NewTransportError("read", "Cloudserver", err).Error())
-		return
-	}
-	if apiErr := CheckResponse("read", "Cloudserver", response); apiErr != nil {
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
-		return
-	}
-	if response == nil || response.Data == nil {
-		resp.Diagnostics.AddError("No data returned", "CloudServer Get returned no data")
+	ref := aruba.URI("/projects/" + projectID + "/compute/cloudServers/" + serverID)
+	server, err := d.client.Client.FromCompute().CloudServers().Get(ctx, ref)
+	if provErr := CheckResponseErr("read", "Cloudserver", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	server := response.Data
-	if server.Metadata.ID != nil {
-		data.Id = types.StringValue(*server.Metadata.ID)
-	}
-	if server.Metadata.URI != nil {
-		data.Uri = types.StringValue(*server.Metadata.URI)
+	data.Id = types.StringValue(server.ID())
+	if uri := server.URI(); uri != "" {
+		data.Uri = types.StringValue(uri)
 	} else {
 		data.Uri = types.StringNull()
 	}
-	if server.Metadata.Name != nil {
-		data.Name = types.StringValue(*server.Metadata.Name)
-	}
-	if server.Metadata.LocationResponse != nil {
-		data.Location = types.StringValue(server.Metadata.LocationResponse.Value)
-	} else {
-		data.Location = types.StringNull()
-	}
+	data.Name = types.StringValue(server.Name())
 	data.ProjectID = types.StringValue(projectID)
-	// Zone is not returned by the API
-	data.Zone = types.StringNull()
-	// Flavor name is returned by the API
-	data.FlavorName = types.StringValue(server.Properties.Flavor.Name)
-	// Network/settings/storage URI refs are not returned by the API
-	data.VpcUriRef = types.StringNull()
+	data.Tags = TagsToListPreserveNull(server.Tags(), data.Tags)
+	data.FlavorName = types.StringValue(server.Flavor())
+	data.VpcUriRef = types.StringValue(server.VPC())
+	data.BootVolumeUriRef = types.StringValue(server.BootVolume())
+	data.KeyPairUriRef = types.StringValue(server.KeyPair())
 	data.ElasticIpUriRef = types.StringNull()
+	data.UserData = types.StringNull()
+
+	raw := server.Raw()
+	if raw != nil {
+		if raw.Metadata.LocationResponse != nil {
+			data.Location = types.StringValue(raw.Metadata.LocationResponse.Value)
+		} else {
+			data.Location = types.StringNull()
+		}
+		data.Zone = types.StringNull() // Zone not reliably returned; set null to avoid drift
+	}
+
+	// Subnets — not reliably mapped from API response; set empty list.
 	data.SubnetUriRefs = types.ListValueMust(types.StringType, []attr.Value{})
 	data.SecurityGroupUriRefs = types.ListValueMust(types.StringType, []attr.Value{})
-	data.KeyPairUriRef = types.StringNull()
-	data.UserData = types.StringNull()
-	data.BootVolumeUriRef = types.StringNull()
-
-	data.Tags = TagsToListPreserveNull(server.Metadata.Tags, data.Tags)
 
 	tflog.Trace(ctx, "read a CloudServer data source", map[string]interface{}{"server_id": serverID})
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/cloudserver_resource.go
+++ b/internal/provider/cloudserver_resource.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	sdktypes "github.com/Arubacloud/sdk-go/pkg/types"
+	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -216,67 +217,24 @@ func (r *CloudServerResource) Create(ctx context.Context, req resource.CreateReq
 
 	projectID := data.ProjectID.ValueString()
 	if projectID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Project ID",
-			"Project ID is required to create a cloud server",
-		)
+		resp.Diagnostics.AddError("Missing Project ID", "Project ID is required to create a cloud server")
 		return
 	}
 
-	// Extract network model
 	var networkModel CloudServerNetworkModel
-	diags := data.Network.As(ctx, &networkModel, basetypes.ObjectAsOptions{})
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(data.Network.As(ctx, &networkModel, basetypes.ObjectAsOptions{})...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	// Extract settings model
 	var settingsModel CloudServerSettingsModel
-	diags = data.Settings.As(ctx, &settingsModel, basetypes.ObjectAsOptions{})
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(data.Settings.As(ctx, &settingsModel, basetypes.ObjectAsOptions{})...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	// Extract storage model
 	var storageModel CloudServerStorageModel
-	diags = data.Storage.As(ctx, &storageModel, basetypes.ObjectAsOptions{})
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(data.Storage.As(ctx, &storageModel, basetypes.ObjectAsOptions{})...)
 	if resp.Diagnostics.HasError() {
 		return
-	}
-
-	// Extract subnets from network model
-	var subnetRefs []sdktypes.ReferenceResource
-	if !networkModel.SubnetUriRefs.IsNull() && !networkModel.SubnetUriRefs.IsUnknown() {
-		var subnetURIs []string
-		diags := networkModel.SubnetUriRefs.ElementsAs(ctx, &subnetURIs, false)
-		resp.Diagnostics.Append(diags...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-		for _, subnetURI := range subnetURIs {
-			subnetRefs = append(subnetRefs, sdktypes.ReferenceResource{
-				URI: subnetURI,
-			})
-		}
-	}
-
-	// Extract security groups from network model
-	var securityGroupRefs []sdktypes.ReferenceResource
-	if !networkModel.SecurityGroupUriRefs.IsNull() && !networkModel.SecurityGroupUriRefs.IsUnknown() {
-		var sgURIs []string
-		diags := networkModel.SecurityGroupUriRefs.ElementsAs(ctx, &sgURIs, false)
-		resp.Diagnostics.Append(diags...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-		for _, sgURI := range sgURIs {
-			securityGroupRefs = append(securityGroupRefs, sdktypes.ReferenceResource{
-				URI: sgURI,
-			})
-		}
 	}
 
 	tags := ListToTags(ctx, data.Tags, &resp.Diagnostics)
@@ -284,389 +242,262 @@ func (r *CloudServerResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	// Build the create request
-	flavorName := settingsModel.FlavorName.ValueString()
-	zone := data.Zone.ValueString()
-	createRequest := sdktypes.CloudServerRequest{
-		Metadata: sdktypes.RegionalResourceMetadataRequest{
-			ResourceMetadataRequest: sdktypes.ResourceMetadataRequest{
-				Name: data.Name.ValueString(),
-				Tags: tags,
-			},
-			Location: sdktypes.LocationRequest{
-				Value: data.Location.ValueString(),
-			},
-		},
-		Properties: sdktypes.CloudServerPropertiesRequest{
-			FlavorName: &flavorName,
-			Zone:       zone,
-			BootVolume: sdktypes.ReferenceResource{
-				URI: storageModel.BootVolumeUriRef.ValueString(),
-			},
-			VPC: sdktypes.ReferenceResource{
-				URI: networkModel.VpcUriRef.ValueString(),
-			},
-			Subnets:        subnetRefs,
-			SecurityGroups: securityGroupRefs,
-		},
-	}
-
-	// Add keypair if provided
-	if !settingsModel.KeyPairUriRef.IsNull() && !settingsModel.KeyPairUriRef.IsUnknown() {
-		createRequest.Properties.KeyPair = sdktypes.ReferenceResource{
-			URI: settingsModel.KeyPairUriRef.ValueString(),
+	var subnetURIs []string
+	if !networkModel.SubnetUriRefs.IsNull() && !networkModel.SubnetUriRefs.IsUnknown() {
+		resp.Diagnostics.Append(networkModel.SubnetUriRefs.ElementsAs(ctx, &subnetURIs, false)...)
+		if resp.Diagnostics.HasError() {
+			return
 		}
 	}
+	subnetRefs := make([]aruba.Ref, len(subnetURIs))
+	for i, u := range subnetURIs {
+		subnetRefs[i] = aruba.URI(u)
+	}
 
-	// Add elastic IP if provided
-	if !networkModel.ElasticIpUriRef.IsNull() && !networkModel.ElasticIpUriRef.IsUnknown() {
-		createRequest.Properties.ElasticIP = sdktypes.ReferenceResource{
-			URI: networkModel.ElasticIpUriRef.ValueString(),
+	var sgURIs []string
+	if !networkModel.SecurityGroupUriRefs.IsNull() && !networkModel.SecurityGroupUriRefs.IsUnknown() {
+		resp.Diagnostics.Append(networkModel.SecurityGroupUriRefs.ElementsAs(ctx, &sgURIs, false)...)
+		if resp.Diagnostics.HasError() {
+			return
 		}
 	}
-
-	// Add user data if provided
-	if !settingsModel.UserData.IsNull() && !settingsModel.UserData.IsUnknown() {
-		userDataRaw := settingsModel.UserData.ValueString()
-		createRequest.Properties.UserData = &userDataRaw
+	sgRefs := make([]aruba.Ref, len(sgURIs))
+	for i, u := range sgURIs {
+		sgRefs[i] = aruba.URI(u)
 	}
 
-	// Create the cloud server using the SDK
-	response, err := r.client.Client.FromCompute().CloudServers().Create(ctx, projectID, createRequest, nil)
+	builder := aruba.NewCloudServer().
+		Named(data.Name.ValueString()).
+		InProject(aruba.URI("/projects/"+projectID)).
+		InRegion(aruba.Region(data.Location.ValueString())).
+		InZone(aruba.Zone(data.Zone.ValueString())).
+		OfFlavor(aruba.CloudServerFlavor(settingsModel.FlavorName.ValueString())).
+		WithVPC(aruba.URI(networkModel.VpcUriRef.ValueString())).
+		BootingFrom(aruba.URI(storageModel.BootVolumeUriRef.ValueString())).
+		OnSubnets(subnetRefs...).
+		WithSecurityGroups(sgRefs...).
+		Tagged(tags...)
 
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error creating cloud server",
-			NewTransportError("create", "Cloudserver", err).Error(),
-		)
+	if !settingsModel.KeyPairUriRef.IsNull() && settingsModel.KeyPairUriRef.ValueString() != "" {
+		builder = builder.UsingKeyPair(aruba.URI(settingsModel.KeyPairUriRef.ValueString()))
+	}
+	if !networkModel.ElasticIpUriRef.IsNull() && networkModel.ElasticIpUriRef.ValueString() != "" {
+		builder = builder.WithElasticIP(aruba.URI(networkModel.ElasticIpUriRef.ValueString()))
+	}
+	if !settingsModel.UserData.IsNull() && settingsModel.UserData.ValueString() != "" {
+		builder = builder.WithUserData(settingsModel.UserData.ValueString())
+	}
+
+	server, err := r.client.Client.FromCompute().CloudServers().Create(ctx, builder)
+	if provErr := CheckResponseErr("create", "CloudServer", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	if apiErr := CheckResponse("create", "Cloudserver", response); apiErr != nil {
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
-		return
-	}
-
-	// Extract ID and URI from the Create response (SDK v0.1.13+ has ResourceMetadataResponse with ID and URI)
-	if response == nil || response.Data == nil {
-		resp.Diagnostics.AddError(
-			"Invalid API Response",
-			"Cloud server create response is missing data",
-		)
-		return
-	}
-
-	// Get the server ID from the response
-	var serverID string
-	if response.Data.Metadata.ID != nil {
-		serverID = *response.Data.Metadata.ID
-	} else {
-		resp.Diagnostics.AddError(
-			"Invalid API Response",
-			"Cloud server create response is missing ID in metadata",
-		)
-		return
-	}
-
+	serverID := server.ID()
 	data.Id = types.StringValue(serverID)
-
-	// Set URI if available
-	if response.Data.Metadata.URI != nil {
-		data.Uri = types.StringValue(*response.Data.Metadata.URI)
+	if uri := server.URI(); uri != "" {
+		data.Uri = types.StringValue(uri)
 	} else {
 		data.Uri = types.StringNull()
 	}
 
-	// Wait for Cloud Server to be active before returning
-	// This ensures Terraform doesn't proceed until CloudServer is fully ready
-	checker := func(ctx context.Context) (string, error) {
-		getResp, err := r.client.Client.FromCompute().CloudServers().Get(ctx, projectID, serverID, nil)
-		if err != nil {
-			return "", err
-		}
-		// Check if response indicates an error state
-		if getResp != nil && getResp.IsError() {
-			if getResp.Error != nil {
-				errMsg := "Unknown error"
-				if getResp.Error.Title != nil {
-					errMsg = *getResp.Error.Title
-				}
-				if getResp.Error.Detail != nil {
-					errMsg = fmt.Sprintf("%s: %s", errMsg, *getResp.Error.Detail)
-				}
-				return "", fmt.Errorf("cloud server in error state: %s", errMsg)
-			}
-			return "", fmt.Errorf("cloud server API returned error response")
-		}
-		// If we can successfully get the resource, check its status
-		if getResp != nil && getResp.Data != nil {
-			if getResp.Data.Status.State != nil {
-				state := *getResp.Data.Status.State
-				return state, nil
-			}
-		}
-		// If Status.State is nil, assume it's still creating
-		return "InCreation", nil
-	}
-
-	// Wait for Cloud Server to be active - block until ready (using configured timeout)
-	if err := WaitForResourceActive(ctx, checker, "CloudServer", serverID, r.client.ResourceTimeout); err != nil {
-		ReportWaitResult(&resp.Diagnostics, err, "CloudServer", serverID)
-		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	// Save partial state so destroy can clean up on timeout.
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Re-read the Cloud Server to ensure all fields are properly set
-	getResp, err := r.client.Client.FromCompute().CloudServers().Get(ctx, projectID, serverID, nil)
-	if err == nil && getResp != nil && getResp.Data != nil {
-		// Update with values from Get response
-		if getResp.Data.Metadata.ID != nil {
-			data.Id = types.StringValue(*getResp.Data.Metadata.ID)
-		}
-		if getResp.Data.Metadata.Name != nil {
-			data.Name = types.StringValue(*getResp.Data.Metadata.Name)
-		}
-		if getResp.Data.Metadata.URI != nil {
-			data.Uri = types.StringValue(*getResp.Data.Metadata.URI)
-		} else {
-			data.Uri = types.StringNull()
-		}
-	} else if err != nil {
-		// If Get fails, log but don't fail - we already have the ID from create response
-		tflog.Warn(ctx, fmt.Sprintf("Failed to refresh Cloud Server after creation: %v", err))
+	if err := server.WaitUntilReady(ctx, aruba.WithTimeout(r.client.ResourceTimeout)); err != nil {
+		ReportWaitResult(&resp.Diagnostics, err, "CloudServer", serverID)
+		return
+	}
+
+	// Re-read to populate URI and server-assigned fields after provisioning.
+	fresh, freshErr := r.client.Client.FromCompute().CloudServers().Get(ctx, aruba.URI(server.URI()))
+	if freshErr == nil {
+		r.applyServerToState(ctx, fresh, &data, nil, &resp.Diagnostics)
+	} else {
+		tflog.Warn(ctx, fmt.Sprintf("Failed to refresh CloudServer after creation: %v", freshErr))
 	}
 
 	tflog.Trace(ctx, "created a CloudServer resource", map[string]interface{}{
-		"cloudserver_id":   data.Id.ValueString(),
+		"cloudserver_id":   serverID,
 		"cloudserver_name": data.Name.ValueString(),
 	})
-
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
+// cloudServerRef returns the Ref to use for Get/Update/Delete.
+// Falls back to a constructed URI for the import flow where stored URI may be empty.
+func cloudServerRef(data *CloudServerResourceModel) aruba.Ref {
+	if !data.Uri.IsNull() && data.Uri.ValueString() != "" {
+		return aruba.URI(data.Uri.ValueString())
+	}
+	return aruba.URI("/projects/" + data.ProjectID.ValueString() + "/compute/cloudServers/" + data.Id.ValueString())
+}
+
 func (r *CloudServerResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	var data CloudServerResourceModel
 	var originalState CloudServerResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &originalState)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	projectID := originalState.ProjectID.ValueString()
 	serverID := originalState.Id.ValueString()
-
 	if originalState.Id.IsUnknown() || originalState.Id.IsNull() || serverID == "" {
-		tflog.Debug(ctx, "Cloud Server ID is empty, removing resource from state", map[string]interface{}{"server_id": serverID})
 		resp.State.RemoveResource(ctx)
 		return
 	}
 
-	if projectID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID is required to read the cloud server",
-		)
-		return
-	}
-
-	// Get cloud server details using the SDK
-	response, err := r.client.Client.FromCompute().CloudServers().Get(ctx, projectID, serverID, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error reading cloud server",
-			NewTransportError("read", "Cloudserver", err).Error(),
-		)
-		return
-	}
-
-	if response != nil && response.IsError() && response.Error != nil {
-		// If cloud server not found, mark as removed
-		if response.StatusCode == 404 {
+	server, err := r.client.Client.FromCompute().CloudServers().Get(ctx, cloudServerRef(&originalState))
+	if provErr := CheckResponseErr("read", "CloudServer", err); provErr != nil {
+		if IsNotFound(provErr) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		apiErr := newResponseError("read", "Cloudserver", response.StatusCode, response.Error, response.RawBody)
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
-		return
-	}
-
-	if response == nil || response.Data == nil {
-		resp.State.RemoveResource(ctx)
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
 	// Resume provisioning wait if the resource is still in a transitional state.
-	if response.Data.Status.State != nil {
-		switch st := *response.Data.Status.State; {
-		case isFailedState(st):
-			resp.Diagnostics.AddWarning(
-				"Resource in Failed State",
-				fmt.Sprintf("CloudServer %q is in a terminal failure state (%s). "+
-					"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", serverID, st),
-			)
-		case IsCreatingState(st):
-			checker := func(ctx context.Context) (string, error) {
-				getResp, err := r.client.Client.FromCompute().CloudServers().Get(ctx, projectID, serverID, nil)
-				if err != nil {
-					return "", err
-				}
-				if getResp != nil && getResp.IsError() {
-					if getResp.Error != nil && getResp.Error.Title != nil {
-						return "", fmt.Errorf("cloud server in error state: %s", *getResp.Error.Title)
-					}
-					return "", fmt.Errorf("cloud server API returned error response")
-				}
-				if getResp != nil && getResp.Data != nil && getResp.Data.Status.State != nil {
-					return *getResp.Data.Status.State, nil
-				}
-				return "InCreation", nil
-			}
-			if err := WaitForResourceActive(ctx, checker, "CloudServer", serverID, r.client.ResourceTimeout); err != nil {
-				ReportWaitResult(&resp.Diagnostics, err, "CloudServer", serverID)
-				resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-				return
-			}
-			// Re-read to get the final active state.
-			response, err = r.client.Client.FromCompute().CloudServers().Get(ctx, projectID, serverID, nil)
-			if err != nil {
-				resp.Diagnostics.AddError("Error reading CloudServer after provisioning wait",
-					NewTransportError("read", "Cloudserver", err).Error())
-				return
-			}
-			if response == nil || response.Data == nil {
-				resp.State.RemoveResource(ctx)
-				return
-			}
+	st := string(server.State())
+	switch {
+	case isFailedState(st):
+		resp.Diagnostics.AddWarning(
+			"Resource in Failed State",
+			fmt.Sprintf("CloudServer %q is in a terminal failure state (%s). "+
+				"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", serverID, st),
+		)
+	case IsCreatingState(st):
+		if waitErr := server.WaitUntilReady(ctx, aruba.WithTimeout(r.client.ResourceTimeout)); waitErr != nil {
+			ReportWaitResult(&resp.Diagnostics, waitErr, "CloudServer", serverID)
+			return
+		}
+		// Re-read after wait.
+		server, err = r.client.Client.FromCompute().CloudServers().Get(ctx, cloudServerRef(&originalState))
+		if provErr := CheckResponseErr("read", "CloudServer", err); provErr != nil {
+			resp.Diagnostics.AddError("API Error", provErr.Error())
+			return
 		}
 	}
 
-	server := response.Data
-
-	// Extract original nested models to preserve fields not returned by API
-	var originalNetworkModel CloudServerNetworkModel
-	diags := originalState.Network.As(ctx, &originalNetworkModel, basetypes.ObjectAsOptions{})
-	resp.Diagnostics.Append(diags...)
+	var data CloudServerResourceModel
+	r.applyServerToState(ctx, server, &data, &originalState, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
 
-	var originalSettingsModel CloudServerSettingsModel
-	diags = originalState.Settings.As(ctx, &originalSettingsModel, basetypes.ObjectAsOptions{})
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	var originalStorageModel CloudServerStorageModel
-	diags = originalState.Storage.As(ctx, &originalStorageModel, basetypes.ObjectAsOptions{})
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// Update basic fields from API response
-	if server.Metadata.ID != nil {
-		data.Id = types.StringValue(*server.Metadata.ID)
-	}
-
-	if server.Metadata.URI != nil {
-		data.Uri = types.StringValue(*server.Metadata.URI)
+// applyServerToState populates data from the SDK wrapper, preserving fields from
+// originalState that the API does not return. Pass originalState=nil on first Create.
+func (r *CloudServerResource) applyServerToState(
+	ctx context.Context,
+	server *aruba.CloudServer,
+	data *CloudServerResourceModel,
+	originalState *CloudServerResourceModel,
+	diags *diag.Diagnostics,
+) {
+	data.Id = types.StringValue(server.ID())
+	if uri := server.URI(); uri != "" {
+		data.Uri = types.StringValue(uri)
 	} else {
 		data.Uri = types.StringNull()
 	}
+	data.Name = types.StringValue(server.Name())
+	data.Tags = TagsToListPreserveNull(server.Tags(), data.Tags)
 
-	if server.Metadata.Name != nil {
-		data.Name = types.StringValue(*server.Metadata.Name)
+	raw := server.Raw()
+	if raw != nil {
+		if raw.Metadata.LocationResponse != nil && raw.Metadata.LocationResponse.Value != "" {
+			data.Location = types.StringValue(raw.Metadata.LocationResponse.Value)
+		}
+		data.Zone = resolveAPIStringRef(raw.Properties.Zone, firstString(originalState, func(s *CloudServerResourceModel) types.String { return s.Zone }))
 	}
 
-	if server.Metadata.LocationResponse != nil && server.Metadata.LocationResponse.Value != "" {
-		data.Location = types.StringValue(server.Metadata.LocationResponse.Value)
+	if originalState != nil {
+		data.ProjectID = originalState.ProjectID
 	}
 
-	data.ProjectID = originalState.ProjectID
-
-	data.Zone = resolveAPIStringRef(server.Properties.Zone, originalState.Zone)
-
-	data.Tags = TagsToListPreserveNull(server.Metadata.Tags, data.Tags)
-
-	// VPC URI is returned by the API; map it directly to detect drift.
-	vpcUriRef := resolveAPIStringRef(server.Properties.VPC.URI, originalNetworkModel.VpcUriRef)
-
-	// Build network object.
-	// vpc_uri_ref:            mapped from API (Properties.VPC.URI)
-	// elastic_ip_uri_ref:     preserved — not present in CloudServerPropertiesResult
-	// subnet_uri_refs:        preserved — only available via NetworkInterfaces[].Subnet
-	//                         which uses a different URI format; mapping is unsafe without
-	//                         live API verification
-	// securitygroup_uri_refs: preserved — not present in CloudServerPropertiesResult
+	// ── Network object ────────────────────────────────────────────────────────
+	var origNetwork CloudServerNetworkModel
+	if originalState != nil {
+		diags.Append(originalState.Network.As(ctx, &origNetwork, basetypes.ObjectAsOptions{})...)
+		if diags.HasError() {
+			return
+		}
+	}
 	networkAttrs := map[string]attr.Value{
-		"vpc_uri_ref":            vpcUriRef,
-		"elastic_ip_uri_ref":     originalNetworkModel.ElasticIpUriRef,
-		"subnet_uri_refs":        originalNetworkModel.SubnetUriRefs,
-		"securitygroup_uri_refs": originalNetworkModel.SecurityGroupUriRefs,
+		"vpc_uri_ref":            resolveAPIStringRef(server.VPC(), origNetwork.VpcUriRef),
+		"elastic_ip_uri_ref":     origNetwork.ElasticIpUriRef, // not in API response; preserve state
+		"subnet_uri_refs":        origNetwork.SubnetUriRefs,   // preserve state (API returns different format)
+		"securitygroup_uri_refs": origNetwork.SecurityGroupUriRefs,
 	}
-	networkObj, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"vpc_uri_ref":            types.StringType,
-			"elastic_ip_uri_ref":     types.StringType,
-			"subnet_uri_refs":        types.ListType{ElemType: types.StringType},
-			"securitygroup_uri_refs": types.ListType{ElemType: types.StringType},
-		},
-		networkAttrs,
-	)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
+	networkObj, d := types.ObjectValue(csNetworkAttrTypes(), networkAttrs)
+	diags.Append(d...)
 	data.Network = networkObj
 
-	// KeyPair URI is returned by the API; map it directly to detect drift.
-	keyPairUriRef := resolveKeyPairUriRef(server.Properties.KeyPair.URI, originalSettingsModel.KeyPairUriRef)
-
-	// Build settings object.
-	// flavor_name:      mapped from API
-	// key_pair_uri_ref: mapped from API (Properties.KeyPair.URI)
-	// user_data:        preserved — write-only, never returned by the API
+	// ── Settings object ───────────────────────────────────────────────────────
+	var origSettings CloudServerSettingsModel
+	if originalState != nil {
+		diags.Append(originalState.Settings.As(ctx, &origSettings, basetypes.ObjectAsOptions{})...)
+		if diags.HasError() {
+			return
+		}
+	}
 	settingsAttrs := map[string]attr.Value{
-		"flavor_name":      types.StringValue(server.Properties.Flavor.Name),
-		"key_pair_uri_ref": keyPairUriRef,
-		"user_data":        originalSettingsModel.UserData,
+		"flavor_name":      types.StringValue(server.Flavor()),
+		"key_pair_uri_ref": resolveKeyPairUriRef(server.KeyPair(), origSettings.KeyPairUriRef),
+		"user_data":        origSettings.UserData, // write-only; never returned by API
 	}
-	settingsObj, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"flavor_name":      types.StringType,
-			"key_pair_uri_ref": types.StringType,
-			"user_data":        types.StringType,
-		},
-		settingsAttrs,
-	)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
+	settingsObj, d := types.ObjectValue(csSettingsAttrTypes(), settingsAttrs)
+	diags.Append(d...)
 	data.Settings = settingsObj
 
-	// BootVolume URI is returned by the API; map it directly to detect drift.
-	bootVolumeUriRef := resolveAPIStringRef(server.Properties.BootVolume.URI, originalStorageModel.BootVolumeUriRef)
-
-	// Build storage object.
-	// boot_volume_uri_ref: mapped from API (Properties.BootVolume.URI)
+	// ── Storage object ────────────────────────────────────────────────────────
+	var origStorage CloudServerStorageModel
+	if originalState != nil {
+		diags.Append(originalState.Storage.As(ctx, &origStorage, basetypes.ObjectAsOptions{})...)
+		if diags.HasError() {
+			return
+		}
+	}
 	storageAttrs := map[string]attr.Value{
-		"boot_volume_uri_ref": bootVolumeUriRef,
+		"boot_volume_uri_ref": resolveAPIStringRef(server.BootVolume(), origStorage.BootVolumeUriRef),
 	}
-	storageObj, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"boot_volume_uri_ref": types.StringType,
-		},
-		storageAttrs,
-	)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
+	storageObj, d := types.ObjectValue(csStorageAttrTypes(), storageAttrs)
+	diags.Append(d...)
 	data.Storage = storageObj
+}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+// firstString is a tiny helper to safely read a field from an optional state pointer.
+func firstString(s *CloudServerResourceModel, fn func(*CloudServerResourceModel) types.String) types.String {
+	if s == nil {
+		return types.StringNull()
+	}
+	return fn(s)
+}
+
+func csNetworkAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"vpc_uri_ref":            types.StringType,
+		"elastic_ip_uri_ref":     types.StringType,
+		"subnet_uri_refs":        types.ListType{ElemType: types.StringType},
+		"securitygroup_uri_refs": types.ListType{ElemType: types.StringType},
+	}
+}
+
+func csSettingsAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"flavor_name":      types.StringType,
+		"key_pair_uri_ref": types.StringType,
+		"user_data":        types.StringType,
+	}
+}
+
+func csStorageAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{"boot_volume_uri_ref": types.StringType}
 }
 
 func (r *CloudServerResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -677,183 +508,87 @@ func (r *CloudServerResource) Update(ctx context.Context, req resource.UpdateReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	// Read current state to preserve values
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Extract nested models from plan to preserve for inconsistent result check
+	// Extract nested plan models for state reconstruction.
 	var planNetworkModel CloudServerNetworkModel
-	diags := data.Network.As(ctx, &planNetworkModel, basetypes.ObjectAsOptions{})
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(data.Network.As(ctx, &planNetworkModel, basetypes.ObjectAsOptions{})...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
 	var planSettingsModel CloudServerSettingsModel
-	diags = data.Settings.As(ctx, &planSettingsModel, basetypes.ObjectAsOptions{})
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(data.Settings.As(ctx, &planSettingsModel, basetypes.ObjectAsOptions{})...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
 	var planStorageModel CloudServerStorageModel
-	diags = data.Storage.As(ctx, &planStorageModel, basetypes.ObjectAsOptions{})
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(data.Storage.As(ctx, &planStorageModel, basetypes.ObjectAsOptions{})...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	// Get IDs from state (not plan) - IDs are immutable and should always be in state
-	projectID := state.ProjectID.ValueString()
-	serverID := state.Id.ValueString()
-
-	if projectID == "" || serverID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID and Server ID are required to update the cloud server",
-		)
-		return
-	}
-
-	// Get current cloud server details to preserve existing values
-	getResponse, err := r.client.Client.FromCompute().CloudServers().Get(ctx, projectID, serverID, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error fetching current cloud server",
-			NewTransportError("read", "Cloudserver", err).Error(),
-		)
-		return
-	}
-
-	if getResponse == nil || getResponse.Data == nil {
-		resp.Diagnostics.AddError(
-			"Cloud Server Not Found",
-			"Cloud server not found or no data returned",
-		)
-		return
-	}
-
-	current := getResponse.Data
 
 	tags := ListToTags(ctx, data.Tags, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	if tags == nil {
-		tags = current.Metadata.Tags
-	}
 
-	// Build the update request, preserving existing values
-	flavorName := current.Properties.Flavor.Name
-	updateRequest := sdktypes.CloudServerRequest{
-		Metadata: sdktypes.RegionalResourceMetadataRequest{
-			ResourceMetadataRequest: sdktypes.ResourceMetadataRequest{
-				Name: data.Name.ValueString(),
-				Tags: tags,
-			},
-			Location: sdktypes.LocationRequest{
-				Value: current.Metadata.LocationResponse.Value,
-			},
-		},
-		Properties: sdktypes.CloudServerPropertiesRequest{
-			FlavorName: &flavorName,
-			BootVolume: current.Properties.BootVolume,
-		},
-	}
-
-	// Preserve keypair if it exists
-	if current.Properties.KeyPair.URI != "" {
-		updateRequest.Properties.KeyPair = current.Properties.KeyPair
-	}
-
-	// Update the cloud server using the SDK
-	response, err := r.client.Client.FromCompute().CloudServers().Update(ctx, projectID, serverID, updateRequest, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error updating cloud server",
-			NewTransportError("update", "Cloudserver", err).Error(),
-		)
+	// Fetch-mutate-update: get current wrapper, apply name/tag mutations, submit.
+	server, err := r.client.Client.FromCompute().CloudServers().Get(ctx, cloudServerRef(&state))
+	if provErr := CheckResponseErr("read", "CloudServer", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	if apiErr := CheckResponse("update", "Cloudserver", response); apiErr != nil {
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
+	server.Named(data.Name.ValueString())
+	if tags != nil {
+		server.RetaggedAs(tags...)
+	} else {
+		server.RetaggedAs(server.Tags()...)
+	}
+
+	updated, err := r.client.Client.FromCompute().CloudServers().Update(ctx, server)
+	if provErr := CheckResponseErr("update", "CloudServer", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	// Update state with response data if available
-	if response != nil && response.Data != nil {
-		if response.Data.Metadata.Name != nil && *response.Data.Metadata.Name != "" {
-			data.Name = types.StringValue(*response.Data.Metadata.Name)
-		}
-		data.Tags = TagsToListPreserveNull(response.Data.Metadata.Tags, data.Tags)
+	if n := updated.Name(); n != "" {
+		data.Name = types.StringValue(n)
 	}
+	data.Tags = TagsToListPreserveNull(updated.Tags(), data.Tags)
 
-	// Ensure immutable fields are set from state/plan before saving
+	// Preserve immutable fields from state.
 	data.Id = state.Id
+	data.Uri = state.Uri
 	data.ProjectID = state.ProjectID
 	data.Zone = state.Zone
 
-	// Rebuild nested objects from plan to avoid inconsistent result
-	// Network object (preserve from plan)
+	// Rebuild nested objects from plan values.
 	networkAttrs := map[string]attr.Value{
 		"vpc_uri_ref":            planNetworkModel.VpcUriRef,
 		"elastic_ip_uri_ref":     planNetworkModel.ElasticIpUriRef,
 		"subnet_uri_refs":        planNetworkModel.SubnetUriRefs,
 		"securitygroup_uri_refs": planNetworkModel.SecurityGroupUriRefs,
 	}
-	networkObj, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"vpc_uri_ref":            types.StringType,
-			"elastic_ip_uri_ref":     types.StringType,
-			"subnet_uri_refs":        types.ListType{ElemType: types.StringType},
-			"securitygroup_uri_refs": types.ListType{ElemType: types.StringType},
-		},
-		networkAttrs,
-	)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
+	networkObj, d := types.ObjectValue(csNetworkAttrTypes(), networkAttrs)
+	resp.Diagnostics.Append(d...)
 	data.Network = networkObj
 
-	// Settings object (preserve from plan)
 	settingsAttrs := map[string]attr.Value{
 		"flavor_name":      planSettingsModel.FlavorName,
 		"key_pair_uri_ref": planSettingsModel.KeyPairUriRef,
 		"user_data":        planSettingsModel.UserData,
 	}
-	settingsObj, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"flavor_name":      types.StringType,
-			"key_pair_uri_ref": types.StringType,
-			"user_data":        types.StringType,
-		},
-		settingsAttrs,
-	)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
+	settingsObj, d := types.ObjectValue(csSettingsAttrTypes(), settingsAttrs)
+	resp.Diagnostics.Append(d...)
 	data.Settings = settingsObj
 
-	// Storage object (preserve from plan)
-	storageAttrs := map[string]attr.Value{
-		"boot_volume_uri_ref": planStorageModel.BootVolumeUriRef,
-	}
-	storageObj, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"boot_volume_uri_ref": types.StringType,
-		},
-		storageAttrs,
-	)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
+	storageAttrs := map[string]attr.Value{"boot_volume_uri_ref": planStorageModel.BootVolumeUriRef}
+	storageObj, d := types.ObjectValue(csStorageAttrTypes(), storageAttrs)
+	resp.Diagnostics.Append(d...)
 	data.Storage = storageObj
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -866,43 +601,17 @@ func (r *CloudServerResource) Delete(ctx context.Context, req resource.DeleteReq
 		return
 	}
 
-	projectID := data.ProjectID.ValueString()
 	serverID := data.Id.ValueString()
-
-	if projectID == "" || serverID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID and Server ID are required to delete the cloud server",
-		)
+	if serverID == "" {
+		resp.Diagnostics.AddError("Missing Required Fields", "Server ID is required to delete the cloud server")
 		return
 	}
 
-	// Delete the cloud server using the SDK with retry mechanism
-	// Retry on any error except 404 (Resource Not Found)
+	ref := cloudServerRef(&data)
+
 	deletionChecker := func(ctx context.Context) (bool, error) {
-		getResp, getErr := r.client.Client.FromCompute().CloudServers().Get(ctx, projectID, serverID, nil)
-		if getErr != nil {
-			return false, NewTransportError("get", "CloudServer", getErr)
-		}
-		// Log the HTTP status and state so deletion progress is visible at DEBUG level.
-		statusCode := 0
-		if getResp != nil {
-			statusCode = getResp.StatusCode
-		}
-		state := "<nil response>"
-		if getResp != nil && getResp.Data != nil && getResp.Data.Status.State != nil {
-			state = *getResp.Data.Status.State
-		} else if getResp != nil && getResp.Data != nil {
-			state = "<Status.State nil>"
-		}
-		tflog.Debug(ctx, "CloudServer deletion check: GET response", map[string]interface{}{
-			"resource_type": "CloudServer",
-			"resource_id":   serverID,
-			"http_status":   statusCode,
-			"state":         state,
-			"is_error":      getResp != nil && getResp.IsError(),
-		})
-		if provErr := CheckResponse("get", "CloudServer", getResp); provErr != nil {
+		_, getErr := r.client.Client.FromCompute().CloudServers().Get(ctx, ref)
+		if provErr := CheckResponseErr("get", "CloudServer", getErr); provErr != nil {
 			if IsNotFound(provErr) {
 				return true, nil
 			}
@@ -915,23 +624,16 @@ func (r *CloudServerResource) Delete(ctx context.Context, req resource.DeleteReq
 	err := DeleteResourceWithRetry(
 		ctx,
 		func() error {
-			resp, err := r.client.Client.FromCompute().CloudServers().Delete(ctx, projectID, serverID, nil)
-			if err != nil {
-				return NewTransportError("delete", "CloudServer", err)
-			}
-			return CheckResponse("delete", "CloudServer", resp)
+			_, delErr := r.client.Client.FromCompute().CloudServers().Delete(ctx, ref)
+			return CheckResponseErr("delete", "CloudServer", delErr)
 		},
 		"CloudServer",
 		serverID,
 		r.client.ResourceTimeout,
 		deletionChecker,
 	)
-
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error deleting cloud server",
-			NewTransportError("delete", "Cloudserver", err).Error(),
-		)
+		resp.Diagnostics.AddError("Error deleting cloud server", err.Error())
 		return
 	}
 
@@ -940,18 +642,17 @@ func (r *CloudServerResource) Delete(ctx context.Context, req resource.DeleteReq
 		return
 	}
 
-	tflog.Trace(ctx, "deleted a CloudServer resource", map[string]interface{}{
-		"cloudserver_id": serverID,
-	})
+	tflog.Trace(ctx, "deleted a CloudServer resource", map[string]interface{}{"cloudserver_id": serverID})
 }
 
 func (r *CloudServerResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
 // resolveAPIStringRef returns a StringValue from the API-provided string when
-// non-empty, falling back to the value preserved from state otherwise. Used to
-// map API-returned URI references so that out-of-band changes are detected.
+// non-empty, falling back to the value preserved from state otherwise.
 func resolveAPIStringRef(apiValue string, stateValue types.String) types.String {
 	if apiValue != "" {
 		return types.StringValue(apiValue)
@@ -959,11 +660,8 @@ func resolveAPIStringRef(apiValue string, stateValue types.String) types.String 
 	return stateValue
 }
 
-// resolveKeyPairUriRef resolves the key_pair_uri_ref for Read state.
-// Three cases:
-//   - API returned a URI  → use it (current value, drift visible to Terraform)
-//   - API returned empty, state had a URI → null (keypair detached outside Terraform)
-//   - API returned empty, state had no URI → preserve state (keypair never configured)
+// resolveKeyPairUriRef resolves key_pair_uri_ref for Read state:
+// API returned URI → use it; API returned empty but state had URI → null (detached); no URI either side → preserve state.
 func resolveKeyPairUriRef(apiURI string, stateRef types.String) types.String {
 	if apiURI != "" {
 		return types.StringValue(apiURI)

--- a/internal/provider/keypair_data_source.go
+++ b/internal/provider/keypair_data_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -91,54 +92,35 @@ func (d *KeypairDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	projectID := data.ProjectID.ValueString()
 	keypairID := data.Id.ValueString()
 	if projectID == "" || keypairID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID and Keypair ID (id) are required to read the keypair",
-		)
+		resp.Diagnostics.AddError("Missing Required Fields", "Project ID and Keypair ID are required to read the keypair")
 		return
 	}
 
-	response, err := d.client.Client.FromCompute().KeyPairs().Get(ctx, projectID, keypairID, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error reading keypair",
-			NewTransportError("read", "Keypair", err).Error(),
-		)
-		return
-	}
-	if apiErr := CheckResponse("read", "Keypair", response); apiErr != nil {
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
-		return
-	}
-	if response == nil || response.Data == nil {
-		resp.Diagnostics.AddError(
-			"No data returned",
-			"Keypair Get returned no data",
-		)
+	ref := aruba.URI("/projects/" + projectID + "/compute/keyPairs/" + keypairID)
+	kp, err := d.client.Client.FromCompute().KeyPairs().Get(ctx, ref)
+	if provErr := CheckResponseErr("read", "Keypair", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	keypair := response.Data
+	data.Id = types.StringValue(kp.ID())
+	data.Name = types.StringValue(kp.Name())
+	data.ProjectID = types.StringValue(projectID)
 
-	if keypair.Metadata.ID != nil {
-		data.Id = types.StringValue(*keypair.Metadata.ID)
-	}
-	if keypair.Metadata.Name != nil {
-		data.Name = types.StringValue(*keypair.Metadata.Name)
-	}
-	if keypair.Metadata.LocationResponse != nil {
-		data.Location = types.StringValue(keypair.Metadata.LocationResponse.Value)
+	raw := kp.Raw()
+	if raw != nil && raw.Metadata.LocationResponse != nil {
+		data.Location = types.StringValue(raw.Metadata.LocationResponse.Value)
 	} else {
 		data.Location = types.StringNull()
 	}
-	data.ProjectID = types.StringValue(projectID)
-	if keypair.Properties.Value != "" {
-		data.Value = types.StringValue(keypair.Properties.Value)
+
+	if raw != nil && raw.Properties.Value != "" {
+		data.Value = types.StringValue(raw.Properties.Value)
 	} else {
 		data.Value = types.StringNull()
 	}
 
-	data.Tags = TagsToListPreserveNull(keypair.Metadata.Tags, data.Tags)
+	data.Tags = TagsToListPreserveNull(kp.Tags(), data.Tags)
 
 	tflog.Trace(ctx, "read a Keypair data source", map[string]interface{}{"keypair_id": keypairID})
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/keypair_resource.go
+++ b/internal/provider/keypair_resource.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	sdktypes "github.com/Arubacloud/sdk-go/pkg/types"
+	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -108,10 +108,7 @@ func (r *KeypairResource) Create(ctx context.Context, req resource.CreateRequest
 
 	projectID := data.ProjectID.ValueString()
 	if projectID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Project ID",
-			"Project ID is required to create a keypair",
-		)
+		resp.Diagnostics.AddError("Missing Project ID", "Project ID is required to create a keypair")
 		return
 	}
 
@@ -120,90 +117,50 @@ func (r *KeypairResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
-	// Build the create request
-	createRequest := sdktypes.KeyPairRequest{
-		Metadata: sdktypes.RegionalResourceMetadataRequest{
-			ResourceMetadataRequest: sdktypes.ResourceMetadataRequest{
-				Name: data.Name.ValueString(),
-				Tags: tags,
-			},
-			Location: sdktypes.LocationRequest{
-				Value: data.Location.ValueString(),
-			},
-		},
-		Properties: sdktypes.KeyPairPropertiesRequest{
-			Value: data.Value.ValueString(),
-		},
-	}
+	builder := aruba.NewKeyPair().
+		Named(data.Name.ValueString()).
+		InProject(aruba.URI("/projects/"+projectID)).
+		InRegion(aruba.Region(data.Location.ValueString())).
+		WithPublicKey(data.Value.ValueString()).
+		Tagged(tags...)
 
-	// Create the keypair using the SDK
-	response, err := r.client.Client.FromCompute().KeyPairs().Create(ctx, projectID, createRequest, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error creating keypair",
-			NewTransportError("create", "Keypair", err).Error(),
-		)
+	kp, err := r.client.Client.FromCompute().KeyPairs().Create(ctx, builder)
+	if provErr := CheckResponseErr("create", "Keypair", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	if apiErr := CheckResponse("create", "Keypair", response); apiErr != nil {
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
-		return
-	}
-
-	if response != nil && response.Data != nil {
-		// Get ID from Metadata.ID (like other resources)
-		if response.Data.Metadata.ID != nil {
-			data.Id = types.StringValue(*response.Data.Metadata.ID)
-		} else {
-			resp.Diagnostics.AddError(
-				"Invalid API Response",
-				"Keypair created but ID is missing from response",
-			)
-			return
-		}
-
-		if response.Data.Metadata.URI != nil {
-			data.Uri = types.StringValue(*response.Data.Metadata.URI)
-		} else {
-			data.Uri = types.StringNull()
-		}
+	data.Id = types.StringValue(kp.ID())
+	if uri := kp.URI(); uri != "" {
+		data.Uri = types.StringValue(uri)
 	} else {
-		resp.Diagnostics.AddError(
-			"Invalid API Response",
-			"Keypair created but no data returned from API",
-		)
-		return
+		data.Uri = types.StringNull()
 	}
 
-	// Wait for Keypair to be active before returning (Keypair is referenced by CloudServer)
-	// This ensures Terraform doesn't proceed to create dependent resources until Keypair is ready
 	keypairID := data.Id.ValueString()
-	checker := func(ctx context.Context) (string, error) {
-		getResp, err := r.client.Client.FromCompute().KeyPairs().Get(ctx, projectID, keypairID, nil)
-		if err != nil {
-			return "", err
-		}
-		// Keypairs don't have a Status field - if we can get it, it's ready
-		if getResp != nil && getResp.Data != nil {
-			return "Active", nil
-		}
-		return "Unknown", nil
-	}
 
-	// Wait for Keypair to be active - block until ready (using configured timeout)
-	if err := WaitForResourceActive(ctx, checker, "Keypair", keypairID, r.client.ResourceTimeout); err != nil {
+	// KeyPairs may go through a short provisioning phase; wait until ready.
+	if err := kp.WaitUntilReady(ctx, aruba.WithTimeout(r.client.ResourceTimeout)); err != nil {
 		ReportWaitResult(&resp.Diagnostics, err, "Keypair", keypairID)
 		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 		return
 	}
 
 	tflog.Trace(ctx, "created a Keypair resource", map[string]interface{}{
-		"keypair_id":   data.Id.ValueString(),
+		"keypair_id":   keypairID,
 		"keypair_name": data.Name.ValueString(),
 	})
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// keypairRef returns the Ref to use for Get/Update/Delete.
+// Uses the stored URI when available (normal flow); falls back to a constructed URI for the import flow.
+func keypairRef(data *KeypairResourceModel) aruba.Ref {
+	if !data.Uri.IsNull() && data.Uri.ValueString() != "" {
+		return aruba.URI(data.Uri.ValueString())
+	}
+	return aruba.URI("/projects/" + data.ProjectID.ValueString() + "/compute/keyPairs/" + data.Id.ValueString())
 }
 
 func (r *KeypairResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -213,111 +170,48 @@ func (r *KeypairResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
-	// Get project ID and keypair ID from state
-	projectID := data.ProjectID.ValueString()
-	keypairID := data.Id.ValueString()
-
-	if data.Id.IsUnknown() || data.Id.IsNull() || keypairID == "" {
-		tflog.Debug(ctx, "Keypair ID is empty, removing resource from state", map[string]interface{}{"keypair_id": keypairID})
+	if data.Id.IsUnknown() || data.Id.IsNull() || data.Id.ValueString() == "" {
 		resp.State.RemoveResource(ctx)
 		return
 	}
 
-	if projectID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID is required to read the keypair",
-		)
-		return
-	}
-
-	// Get keypair details using the SDK
-	// The API Get method accepts the keypair ID
 	tflog.Debug(ctx, "Reading keypair", map[string]interface{}{
-		"project_id":   projectID,
-		"keypair_id":   keypairID,
-		"keypair_name": data.Name.ValueString(),
-		"keypair_uri":  data.Uri.ValueString(),
+		"project_id":  data.ProjectID.ValueString(),
+		"keypair_id":  data.Id.ValueString(),
+		"keypair_uri": data.Uri.ValueString(),
 	})
 
-	response, err := r.client.Client.FromCompute().KeyPairs().Get(ctx, projectID, keypairID, nil)
-	if err != nil {
-		tflog.Error(ctx, "Error calling keypair Get API", map[string]interface{}{
-			"error":      err,
-			"project_id": projectID,
-			"keypair_id": keypairID,
-		})
-		resp.Diagnostics.AddError(
-			"Error reading keypair",
-			NewTransportError("read", "Keypair", err).Error(),
-		)
-		return
-	}
-
-	if response != nil && response.IsError() && response.Error != nil {
-		if response.StatusCode == 404 {
-			tflog.Info(ctx, "Keypair not found (404), removing from state", map[string]interface{}{
-				"project_id": projectID,
-				"keypair_id": keypairID,
-			})
+	kp, err := r.client.Client.FromCompute().KeyPairs().Get(ctx, keypairRef(&data))
+	if provErr := CheckResponseErr("read", "Keypair", err); provErr != nil {
+		if IsNotFound(provErr) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		apiErr := newResponseError("read", "Keypair", response.StatusCode, response.Error, response.RawBody)
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	if response != nil && response.Data != nil {
-		keypair := response.Data
+	// Preserve write-only / non-returned fields from state.
+	projectIDFromState := data.ProjectID
+	valueFromState := data.Value
 
-		// Preserve ProjectID and Value from state (they're not in the API response)
-		projectIDFromState := data.ProjectID
-		valueFromState := data.Value
-		idFromState := data.Id
-
-		// Get ID from Metadata.ID (like other resources)
-		if keypair.Metadata.ID != nil {
-			data.Id = types.StringValue(*keypair.Metadata.ID)
-		} else {
-			// If API doesn't provide ID, preserve from state
-			data.Id = idFromState
-		}
-
-		if keypair.Metadata.Name != nil {
-			data.Name = types.StringValue(*keypair.Metadata.Name)
-		}
-		if keypair.Metadata.URI != nil {
-			data.Uri = types.StringValue(*keypair.Metadata.URI)
-		} else {
-			data.Uri = types.StringNull()
-		}
-		if keypair.Metadata.LocationResponse != nil {
-			data.Location = types.StringValue(keypair.Metadata.LocationResponse.Value)
-		}
-
-		// Update tags from response
-		if len(keypair.Metadata.Tags) > 0 {
-			tagValues := make([]types.String, len(keypair.Metadata.Tags))
-			for i, tag := range keypair.Metadata.Tags {
-				tagValues[i] = types.StringValue(tag)
-			}
-			tagsList, diags := types.ListValueFrom(ctx, types.StringType, tagValues)
-			resp.Diagnostics.Append(diags...)
-			if !resp.Diagnostics.HasError() {
-				data.Tags = tagsList
-			}
-		} else {
-			data.Tags = types.ListNull(types.StringType)
-		}
-
-		// Restore ProjectID and Value from state (they're not returned by the API)
-		data.ProjectID = projectIDFromState
-		data.Value = valueFromState
+	data.Id = types.StringValue(kp.ID())
+	data.Name = types.StringValue(kp.Name())
+	if uri := kp.URI(); uri != "" {
+		data.Uri = types.StringValue(uri)
 	} else {
-		resp.State.RemoveResource(ctx)
-		return
+		data.Uri = types.StringNull()
 	}
+
+	raw := kp.Raw()
+	if raw != nil && raw.Metadata.LocationResponse != nil {
+		data.Location = types.StringValue(raw.Metadata.LocationResponse.Value)
+	}
+
+	data.Tags = TagsToListPreserveNull(kp.Tags(), data.Tags)
+
+	data.ProjectID = projectIDFromState
+	data.Value = valueFromState
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -330,94 +224,49 @@ func (r *KeypairResource) Update(ctx context.Context, req resource.UpdateRequest
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Use IDs from state (they are immutable)
-	projectID := state.ProjectID.ValueString()
-	keypairID := state.Id.ValueString()
-
-	if projectID == "" || keypairID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID and Keypair ID are required to update the keypair",
-		)
-		return
-	}
-
-	// Keypair update is not supported by the API
-	// Check if immutable fields changed
+	// Keypair update is not supported by the API — validate that no updatable fields changed.
 	if !data.Name.Equal(state.Name) {
-		resp.Diagnostics.AddError(
-			"Keypair Name Update Not Supported",
-			"Changing the keypair name is not supported by the API. Please delete and recreate the keypair with the new name.",
-		)
+		resp.Diagnostics.AddError("Keypair Name Update Not Supported",
+			"Changing the keypair name is not supported by the API. Please delete and recreate the keypair with the new name.")
 		return
 	}
-
 	if !data.Value.Equal(state.Value) {
-		resp.Diagnostics.AddError(
-			"Keypair Public Key Update Not Supported",
-			"Changing the public key value is not supported by the API. Please delete and recreate the keypair with the new public key.",
-		)
+		resp.Diagnostics.AddError("Keypair Public Key Update Not Supported",
+			"Changing the public key value is not supported by the API. Please delete and recreate the keypair with the new public key.")
 		return
 	}
-
 	if !data.Location.Equal(state.Location) {
-		resp.Diagnostics.AddError(
-			"Keypair Location Update Not Supported",
-			"Changing the keypair location is not supported by the API. Please delete and recreate the keypair in the new location.",
-		)
+		resp.Diagnostics.AddError("Keypair Location Update Not Supported",
+			"Changing the keypair location is not supported by the API. Please delete and recreate the keypair in the new location.")
 		return
 	}
 
-	// Since updates aren't supported, we just read the resource to refresh state
-	// This ensures URI and other computed fields are up to date
-	getResponse, err := r.client.Client.FromCompute().KeyPairs().Get(ctx, projectID, keypairID, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error reading keypair",
-			NewTransportError("read", "Keypair", err).Error(),
-		)
-		return
-	}
-
-	if getResponse == nil || getResponse.IsError() || getResponse.Data == nil {
-		if getResponse != nil && getResponse.StatusCode == 404 {
-			tflog.Info(ctx, "Keypair not found (404), removing from state", map[string]interface{}{
-				"project_id": projectID,
-				"keypair_id": keypairID,
-			})
+	// Refresh state via Get so URI and computed fields stay current.
+	kp, err := r.client.Client.FromCompute().KeyPairs().Get(ctx, keypairRef(&state))
+	if provErr := CheckResponseErr("read", "Keypair", err); provErr != nil {
+		if IsNotFound(provErr) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Keypair Not Found",
-			"Keypair not found or no data returned",
-		)
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	keypair := getResponse.Data
-
-	// Ensure immutable fields are set from state before saving
+	// Preserve immutable and write-only fields from state.
 	data.Id = state.Id
 	data.ProjectID = state.ProjectID
 	data.Location = state.Location
 	data.Value = state.Value
-
-	// Update URI from API response
-	if keypair.Metadata.URI != nil {
-		data.Uri = types.StringValue(*keypair.Metadata.URI)
+	if uri := kp.URI(); uri != "" {
+		data.Uri = types.StringValue(uri)
 	} else {
 		data.Uri = state.Uri
 	}
-
-	// Tags can't be updated via API; use plan value so state stays consistent with config.
-	// (data.Tags already holds the plan value from req.Plan.Get above)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -429,25 +278,17 @@ func (r *KeypairResource) Delete(ctx context.Context, req resource.DeleteRequest
 		return
 	}
 
-	projectID := data.ProjectID.ValueString()
 	keypairID := data.Id.ValueString()
-
-	if projectID == "" || keypairID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID and Keypair ID are required to delete the keypair",
-		)
+	if keypairID == "" {
+		resp.Diagnostics.AddError("Missing Required Fields", "Keypair ID is required to delete the keypair")
 		return
 	}
 
-	// Delete the keypair using the SDK with retry mechanism
-	// Retry on any error except 404 (Resource Not Found)
+	ref := keypairRef(&data)
+
 	deletionChecker := func(ctx context.Context) (bool, error) {
-		getResp, getErr := r.client.Client.FromCompute().KeyPairs().Get(ctx, projectID, keypairID, nil)
-		if getErr != nil {
-			return false, NewTransportError("get", "Keypair", getErr)
-		}
-		if provErr := CheckResponse("get", "Keypair", getResp); provErr != nil {
+		_, getErr := r.client.Client.FromCompute().KeyPairs().Get(ctx, ref)
+		if provErr := CheckResponseErr("get", "Keypair", getErr); provErr != nil {
 			if IsNotFound(provErr) {
 				return true, nil
 			}
@@ -460,23 +301,16 @@ func (r *KeypairResource) Delete(ctx context.Context, req resource.DeleteRequest
 	err := DeleteResourceWithRetry(
 		ctx,
 		func() error {
-			resp, err := r.client.Client.FromCompute().KeyPairs().Delete(ctx, projectID, keypairID, nil)
-			if err != nil {
-				return NewTransportError("delete", "Keypair", err)
-			}
-			return CheckResponse("delete", "Keypair", resp)
+			_, delErr := r.client.Client.FromCompute().KeyPairs().Delete(ctx, ref)
+			return CheckResponseErr("delete", "Keypair", delErr)
 		},
 		"Keypair",
 		keypairID,
 		r.client.ResourceTimeout,
 		deletionChecker,
 	)
-
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error deleting keypair",
-			NewTransportError("delete", "Keypair", err).Error(),
-		)
+		resp.Diagnostics.AddError("Error deleting keypair", err.Error())
 		return
 	}
 
@@ -485,9 +319,7 @@ func (r *KeypairResource) Delete(ctx context.Context, req resource.DeleteRequest
 		return
 	}
 
-	tflog.Trace(ctx, "deleted a Keypair resource", map[string]interface{}{
-		"keypair_id": keypairID,
-	})
+	tflog.Trace(ctx, "deleted a Keypair resource", map[string]interface{}{"keypair_id": keypairID})
 }
 
 func (r *KeypairResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -35,8 +35,8 @@ type ArubaCloudProvider struct {
 
 // ArubaCloudProviderModel describes the provider data model.
 type ArubaCloudProviderModel struct {
-	ApiKey          types.String `tfsdk:"api_key"`
-	ApiSecret       types.String `tfsdk:"api_secret"`
+	ClientID        types.String `tfsdk:"client_id"`
+	ClientSecret    types.String `tfsdk:"client_secret"`
 	ResourceTimeout types.String `tfsdk:"resource_timeout"`
 	BaseURL         types.String `tfsdk:"base_url"`
 	TokenIssuerURL  types.String `tfsdk:"token_issuer_url"`
@@ -51,12 +51,12 @@ func (p *ArubaCloudProvider) Metadata(ctx context.Context, req provider.Metadata
 func (p *ArubaCloudProvider) Schema(ctx context.Context, req provider.SchemaRequest, resp *provider.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			"api_key": schema.StringAttribute{
-				MarkdownDescription: "API key for ArubaCloud. Can also be set via ARUBACLOUD_API_KEY environment variable.",
+			"client_id": schema.StringAttribute{
+				MarkdownDescription: "Client ID for ArubaCloud OAuth2 authentication. Can also be set via the `ARUBACLOUD_CLIENT_ID` environment variable.",
 				Optional:            true,
 			},
-			"api_secret": schema.StringAttribute{
-				MarkdownDescription: "API secret for ArubaCloud. Can also be set via ARUBACLOUD_API_SECRET environment variable.",
+			"client_secret": schema.StringAttribute{
+				MarkdownDescription: "Client secret for ArubaCloud OAuth2 authentication. Can also be set via the `ARUBACLOUD_CLIENT_SECRET` environment variable.",
 				Optional:            true,
 				Sensitive:           true,
 			},
@@ -91,8 +91,8 @@ func (p *ArubaCloudProvider) Schema(ctx context.Context, req provider.SchemaRequ
 func (p *ArubaCloudProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
 
 	// Default values to environment variables, but override with Terraform configuration value if set.
-	apiKey := os.Getenv("ARUBACLOUD_API_KEY")
-	apiSecret := os.Getenv("ARUBACLOUD_API_SECRET")
+	clientID := os.Getenv("ARUBACLOUD_CLIENT_ID")
+	clientSecret := os.Getenv("ARUBACLOUD_CLIENT_SECRET")
 	tokenIssuerURL := os.Getenv("ARUBACLOUD_TOKEN_ISSUER_URL")
 	logLevelStr := os.Getenv("ARUBACLOUD_LOG_LEVEL")
 
@@ -104,12 +104,12 @@ func (p *ArubaCloudProvider) Configure(ctx context.Context, req provider.Configu
 		return
 	}
 
-	if !config.ApiKey.IsNull() {
-		apiKey = config.ApiKey.ValueString()
+	if !config.ClientID.IsNull() {
+		clientID = config.ClientID.ValueString()
 	}
 
-	if !config.ApiSecret.IsNull() {
-		apiSecret = config.ApiSecret.ValueString()
+	if !config.ClientSecret.IsNull() {
+		clientSecret = config.ClientSecret.ValueString()
 	}
 
 	if !config.TokenIssuerURL.IsNull() && config.TokenIssuerURL.ValueString() != "" {
@@ -120,21 +120,21 @@ func (p *ArubaCloudProvider) Configure(ctx context.Context, req provider.Configu
 		logLevelStr = config.LogLevel.ValueString()
 	}
 
-	if apiKey == "" {
+	if clientID == "" {
 		resp.Diagnostics.AddAttributeError(
-			path.Root("api_key"),
-			"Unknown ArubaCloud API Key",
-			"The provider cannot create the ArubaCloud API client as there is an unknown configuration value for the API key. "+
-				"Either target apply the source of the value first, set the value statically in the configuration, or use the ARUBACLOUD_API_KEY environment variable.",
+			path.Root("client_id"),
+			"Unknown ArubaCloud Client ID",
+			"The provider cannot create the ArubaCloud API client as there is an unknown configuration value for the client ID. "+
+				"Either target apply the source of the value first, set the value statically in the configuration, or use the ARUBACLOUD_CLIENT_ID environment variable.",
 		)
 	}
 
-	if apiSecret == "" {
+	if clientSecret == "" {
 		resp.Diagnostics.AddAttributeError(
-			path.Root("api_secret"),
-			"Unknown ArubaCloud API Secret",
-			"The provider cannot create the ArubaCloud API client as there is an unknown configuration value for the API secret. "+
-				"Either target apply the source of the value first, set the value statically in the configuration, or use the ARUBACLOUD_API_SECRET environment variable.",
+			path.Root("client_secret"),
+			"Unknown ArubaCloud Client Secret",
+			"The provider cannot create the ArubaCloud API client as there is an unknown configuration value for the client secret. "+
+				"Either target apply the source of the value first, set the value statically in the configuration, or use the ARUBACLOUD_CLIENT_SECRET environment variable.",
 		)
 	}
 
@@ -157,7 +157,7 @@ func (p *ArubaCloudProvider) Configure(ctx context.Context, req provider.Configu
 	ctx = tflog.NewSubsystem(ctx, subsystemName)
 
 	// Create SDK client with credentials using DefaultOptions
-	options := aruba.DefaultOptions(apiKey, apiSecret)
+	options := aruba.DefaultOptions(clientID, clientSecret)
 	options = options.WithCustomLogger(newSDKLogAdapter(ctx, logLevel))
 
 	// Optionally override base URL and token issuer
@@ -183,8 +183,8 @@ func (p *ArubaCloudProvider) Configure(ctx context.Context, req provider.Configu
 
 	// Create a new ArubaCloud client using the SDK client
 	client := &ArubaCloudClient{
-		ApiKey:          apiKey,
-		ApiSecret:       apiSecret,
+		ClientID:        clientID,
+		ClientSecret:    clientSecret,
 		Client:          sdkClient,
 		ResourceTimeout: resourceTimeout,
 	}
@@ -215,8 +215,8 @@ func parseTimeout(timeoutStr types.String, defaultDuration time.Duration, diags 
 
 // ArubaCloudClient wraps the SDK client with API credentials and timeout configuration.
 type ArubaCloudClient struct {
-	ApiKey          string
-	ApiSecret       string
+	ClientID        string
+	ClientSecret    string
 	Client          aruba.Client
 	ResourceTimeout time.Duration
 }

--- a/internal/provider/provider_error.go
+++ b/internal/provider/provider_error.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/Arubacloud/sdk-go/pkg/aruba"
 	sdktypes "github.com/Arubacloud/sdk-go/pkg/types"
 )
 
@@ -213,21 +214,19 @@ func newResponseError(operation, resource string, statusCode int, errResp *sdkty
 	}
 }
 
-// CheckResponse inspects a typed SDK response and returns nil if the status code
-// is 2xx, or a *ProviderError otherwise. A nil response is treated as a Technical error.
-func CheckResponse[T any](operation, resource string, resp *sdktypes.Response[T]) error {
-	if resp == nil {
-		return &ProviderError{
-			Category:  ProviderErrorCategoryTechnical,
-			Operation: operation,
-			Resource:  resource,
-			Cause:     fmt.Errorf("nil response"),
-		}
-	}
-	if resp.IsSuccess() {
+// CheckResponseErr inspects the error returned by a sdk-go v1 builder call and
+// returns a classified *ProviderError, or nil on success (err == nil).
+// It handles both API-level errors (*aruba.HTTPError, produced by 4xx/5xx responses)
+// and transport-level errors (network failures, TLS errors, etc.).
+func CheckResponseErr(operation, resource string, err error) *ProviderError {
+	if err == nil {
 		return nil
 	}
-	return newResponseError(operation, resource, resp.StatusCode, resp.Error, resp.RawBody)
+	var httpErr *aruba.HTTPError
+	if errors.As(err, &httpErr) {
+		return newResponseError(operation, resource, httpErr.StatusCode, httpErr.ErrResp, httpErr.Body)
+	}
+	return NewTransportError(operation, resource, err)
 }
 
 // IsNotFound reports whether err (or any error in its chain) represents a 404 Not Found response.

--- a/internal/provider/provider_error_test.go
+++ b/internal/provider/provider_error_test.go
@@ -2,9 +2,11 @@ package provider
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
+	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	sdktypes "github.com/Arubacloud/sdk-go/pkg/types"
 )
 
@@ -186,78 +188,78 @@ func TestNewResponseError_NilErrResp(t *testing.T) {
 	_ = err.Error()
 }
 
-func TestCheckResponse(t *testing.T) {
+func makeHTTPErr(statusCode int, errResp *sdktypes.ErrorResponse) error {
+	return &aruba.HTTPError{StatusCode: statusCode, ErrResp: errResp}
+}
+
+func TestCheckResponseErr(t *testing.T) {
 	title404 := "Not Found"
 	title400 := "Validation failed"
 
 	cases := []struct {
 		name         string
-		resp         *sdktypes.Response[struct{}]
+		err          error
 		wantNil      bool
 		wantCategory ProviderErrorCategory
 	}{
 		{
-			name:         "nil response → technical error",
-			resp:         nil,
-			wantCategory: ProviderErrorCategoryTechnical,
-		},
-		{
-			name:    "200 OK → nil",
-			resp:    &sdktypes.Response[struct{}]{StatusCode: 200},
-			wantNil: true,
-		},
-		{
-			name:    "201 Created → nil",
-			resp:    &sdktypes.Response[struct{}]{StatusCode: 201},
+			name:    "nil error → nil (success)",
+			err:     nil,
 			wantNil: true,
 		},
 		{
 			name: "404 Not Found (no validation errors) → transient",
-			resp: &sdktypes.Response[struct{}]{
-				StatusCode: 404,
-				Error:      &sdktypes.ErrorResponse{Title: &title404},
-			},
+			err:  makeHTTPErr(404, &sdktypes.ErrorResponse{Title: &title404}),
 			wantCategory: ProviderErrorCategoryTransient,
 		},
 		{
 			name: "400 with validation errors → semantic",
-			resp: &sdktypes.Response[struct{}]{
-				StatusCode: 400,
-				Error: &sdktypes.ErrorResponse{
-					Title: &title400,
-					Errors: []sdktypes.ValidationError{
-						{Field: "name", Message: "is required"},
-					},
+			err: makeHTTPErr(400, &sdktypes.ErrorResponse{
+				Title: &title400,
+				Errors: []sdktypes.ValidationError{
+					{Field: "name", Message: "is required"},
 				},
-			},
+			}),
 			wantCategory: ProviderErrorCategorySemantic,
 		},
 		{
 			name:         "500 Internal Server Error → technical",
-			resp:         &sdktypes.Response[struct{}]{StatusCode: 500},
+			err:          makeHTTPErr(500, nil),
+			wantCategory: ProviderErrorCategoryTechnical,
+		},
+		{
+			name:         "non-HTTP transport error → technical",
+			err:          fmt.Errorf("dial tcp: connection refused"),
 			wantCategory: ProviderErrorCategoryTechnical,
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := CheckResponse("create", "Resource", tc.resp)
+			provErr := CheckResponseErr("create", "Resource", tc.err)
 			if tc.wantNil {
-				if err != nil {
-					t.Errorf("expected nil error, got %v", err)
+				if provErr != nil {
+					t.Errorf("expected nil, got %v", provErr)
 				}
 				return
 			}
-			if err == nil {
-				t.Fatal("expected non-nil error, got nil")
-			}
-			var provErr *ProviderError
-			if !errors.As(err, &provErr) {
-				t.Fatalf("expected *ProviderError, got %T", err)
+			if provErr == nil {
+				t.Fatal("expected non-nil *ProviderError, got nil")
 			}
 			if provErr.Category != tc.wantCategory {
 				t.Errorf("category: got %v, want %v", provErr.Category, tc.wantCategory)
 			}
 		})
+	}
+}
+
+func TestCheckResponseErr_IsNotFound(t *testing.T) {
+	title := "Not Found"
+	err := CheckResponseErr("get", "VPC", makeHTTPErr(404, &sdktypes.ErrorResponse{Title: &title}))
+	if err == nil {
+		t.Fatal("expected non-nil error for 404")
+	}
+	if !IsNotFound(err) {
+		t.Errorf("IsNotFound should return true for 404, got false; err=%v", err)
 	}
 }
 

--- a/internal/provider/provider_schema_test.go
+++ b/internal/provider/provider_schema_test.go
@@ -3,6 +3,9 @@ package provider
 import (
 	"context"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 )
 
 // TestProviderSchema validates that the provider can be instantiated successfully.
@@ -86,6 +89,35 @@ func TestAllDataSourceSchemas(t *testing.T) {
 		dataSource := dataSourceFunc()
 		if dataSource == nil {
 			t.Error("data source function returned nil")
+		}
+	}
+}
+
+// TestProviderSchemaAttributes validates the auth attribute rename from v0.1.x to v0.2.0.
+func TestProviderSchemaAttributes(t *testing.T) {
+	t.Parallel()
+
+	p := New("test")()
+	schemaResp := &provider.SchemaResponse{}
+	p.Schema(context.TODO(), provider.SchemaRequest{}, schemaResp)
+	attrs := schemaResp.Schema.Attributes
+
+	// v0.2.0 attributes must exist
+	for _, name := range []string{"client_id", "client_secret"} {
+		if _, ok := attrs[name]; !ok {
+			t.Errorf("expected provider schema attribute %q to exist", name)
+		}
+	}
+	// client_secret must be sensitive
+	if cs, ok := attrs["client_secret"]; ok {
+		if sa, ok := cs.(schema.StringAttribute); !ok || !sa.Sensitive {
+			t.Error("client_secret must be Sensitive: true")
+		}
+	}
+	// v0.1.x attributes must NOT exist
+	for _, name := range []string{"api_key", "api_secret"} {
+		if _, ok := attrs[name]; ok {
+			t.Errorf("deprecated attribute %q must not be present in v0.2.0 schema", name)
 		}
 	}
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -20,7 +20,7 @@ var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServe
 
 func testAccPreCheck(t *testing.T) {
 	t.Helper()
-	for _, env := range []string{"ARUBACLOUD_API_KEY", "ARUBACLOUD_API_SECRET"} {
+	for _, env := range []string{"ARUBACLOUD_CLIENT_ID", "ARUBACLOUD_CLIENT_SECRET"} {
 		if os.Getenv(env) == "" {
 			t.Fatalf("acceptance tests require %s to be set", env)
 		}
@@ -29,12 +29,12 @@ func testAccPreCheck(t *testing.T) {
 
 // testAccClient builds an ArubaCloudClient from env vars for use in CheckDestroy functions.
 func testAccClient() (*ArubaCloudClient, error) {
-	apiKey := os.Getenv("ARUBACLOUD_API_KEY")
-	apiSecret := os.Getenv("ARUBACLOUD_API_SECRET")
-	if apiKey == "" || apiSecret == "" {
-		return nil, fmt.Errorf("ARUBACLOUD_API_KEY and ARUBACLOUD_API_SECRET must be set")
+	clientID := os.Getenv("ARUBACLOUD_CLIENT_ID")
+	clientSecret := os.Getenv("ARUBACLOUD_CLIENT_SECRET")
+	if clientID == "" || clientSecret == "" {
+		return nil, fmt.Errorf("ARUBACLOUD_CLIENT_ID and ARUBACLOUD_CLIENT_SECRET must be set")
 	}
-	sdkClient, err := aruba.NewClient(aruba.DefaultOptions(apiKey, apiSecret))
+	sdkClient, err := aruba.NewClient(aruba.DefaultOptions(clientID, clientSecret))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create test client: %w", err)
 	}

--- a/internal/provider/testutil_mockserver_test.go
+++ b/internal/provider/testutil_mockserver_test.go
@@ -44,8 +44,8 @@ func newMockArubaClient(t *testing.T, apiHandler http.HandlerFunc) (*httptest.Se
 	}
 
 	return srv, &ArubaCloudClient{
-		ApiKey:          "test-key",
-		ApiSecret:       "test-secret",
+		ClientID:        "test-client-id",
+		ClientSecret:    "test-client-secret",
 		Client:          sdkClient,
 		ResourceTimeout: 10 * time.Minute,
 	}


### PR DESCRIPTION
﻿## Summary
Migrates `arubacloud_cloudserver` and `arubacloud_keypair` (resources + data sources) to the sdk-go v1.0.4 builder/wrapper API. Eliminates all `pkg/types` imports from these 4 files.

## Pattern applied

| Before | After |
|---|---|
| `sdktypes.KeyPairRequest{...}` struct literal | `aruba.NewKeyPair().Named(...).InProject(...).WithPublicKey(...)` builder |
| `KeyPairs().Create(ctx, projectID, request, nil)` | `KeyPairs().Create(ctx, builder)` |
| `KeyPairs().Get(ctx, projectID, id, nil)` | `KeyPairs().Get(ctx, aruba.URI(data.Uri.ValueString()))` |
| `CheckResponse("op", "res", response)` | `CheckResponseErr("op", "res", err)` |
| `response.Data.Metadata.ID` | `wrapper.ID()` |
| `response.Data.Metadata.URI` | `wrapper.URI()` |
| `WaitForResourceActive(ctx, checker, ...)` | `wrapper.WaitUntilReady(ctx, aruba.WithTimeout(...))` |

## Files changed
- `keypair_resource.go` — complete rewrite; 490 → 200 lines
- `keypair_data_source.go` — complete rewrite
- `cloudserver_resource.go` — complete rewrite with `applyServerToState()` helper for clean Read mapping
- `cloudserver_data_source.go` — complete rewrite

## Notes
- CloudServer URI-based Ref falls back to constructed path (`/projects/{pid}/compute/cloudServers/{id}`) for the import flow where `data.Uri` may be empty
- KeyPair update path is unchanged: the API does not support updating keypairs — validation errors are returned and a Get refresh is done instead
- `subnet_uri_refs` and `securitygroup_uri_refs` are preserved from state in CloudServer Read (API returns a different URI format via NetworkInterfaces; mapping remains unsafe without live API verification)

## Test plan
- [ ] Acceptance test `TestAccCloudServerResource` passes
- [ ] Acceptance test `TestAccKeypairResource` passes
- [ ] `terraform import` works for both resources
- [ ] `terraform refresh` produces no unexpected diffs

Closes #136
