### PR TITLE
refactor: migrate extended networking resources (VPCPeering, VPNTunnel, VPNRoute) to sdk-go v1.0.4 builder API

### DIFF
--- a/internal/provider/vpcpeering_data_source.go
+++ b/internal/provider/vpcpeering_data_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -85,27 +86,15 @@ func (d *VPCPeeringDataSource) Read(ctx context.Context, req datasource.ReadRequ
 		return
 	}
 
-	response, err := d.client.Client.FromNetwork().VPCPeerings().Get(ctx, projectID, vpcID, peeringID, nil)
-	if err != nil {
-		resp.Diagnostics.AddError("Error reading VPC peering", NewTransportError("read", "Vpcpeering", err).Error())
-		return
-	}
-	if apiErr := CheckResponse("read", "Vpcpeering", response); apiErr != nil {
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
-		return
-	}
-	if response == nil || response.Data == nil {
-		resp.Diagnostics.AddError("No data returned", "VPC Peering Get returned no data")
+	peering, err := d.client.Client.FromNetwork().VPCPeerings().Get(ctx,
+		aruba.VPCPeeringRef(projectID, vpcID, peeringID))
+	if provErr := CheckResponseErr("read", "VPCPeering", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	peering := response.Data
-	if peering.Metadata.ID != nil {
-		data.Id = types.StringValue(*peering.Metadata.ID)
-	}
-	if peering.Metadata.Name != nil {
-		data.Name = types.StringValue(*peering.Metadata.Name)
-	}
+	data.Id = types.StringValue(peering.ID())
+	data.Name = types.StringValue(peering.Name())
 	data.ProjectId = types.StringValue(projectID)
 	data.VpcId = types.StringValue(vpcID)
 

--- a/internal/provider/vpcpeering_resource.go
+++ b/internal/provider/vpcpeering_resource.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	sdktypes "github.com/Arubacloud/sdk-go/pkg/types"
+	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -96,6 +96,27 @@ func (r *VpcPeeringResource) Configure(ctx context.Context, req resource.Configu
 	r.client = client
 }
 
+func vpcPeeringRef(data *VpcPeeringResourceModel) aruba.Ref {
+	if !data.Uri.IsNull() && data.Uri.ValueString() != "" {
+		return aruba.URI(data.Uri.ValueString())
+	}
+	return aruba.VPCPeeringRef(data.ProjectId.ValueString(), data.VpcId.ValueString(), data.Id.ValueString())
+}
+
+func applyVPCPeeringToModel(p *aruba.VPCPeering, data *VpcPeeringResourceModel) {
+	data.Id = types.StringValue(p.ID())
+	data.Uri = strVal(p.URI())
+	data.Name = types.StringValue(p.Name())
+	data.Tags = TagsToListPreserveNull(p.Tags(), data.Tags)
+	if p.RemoteVPCURI() != "" {
+		data.PeerVpc = types.StringValue(p.RemoteVPCURI())
+	}
+	raw := p.Raw()
+	if raw != nil && raw.Metadata.LocationResponse != nil {
+		data.Location = types.StringValue(raw.Metadata.LocationResponse.Value)
+	}
+}
+
 func (r *VpcPeeringResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data VpcPeeringResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
@@ -106,101 +127,59 @@ func (r *VpcPeeringResource) Create(ctx context.Context, req resource.CreateRequ
 	projectID := data.ProjectId.ValueString()
 	vpcID := data.VpcId.ValueString()
 
-	if projectID == "" || vpcID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID and VPC ID are required to create a VPC peering",
-		)
-		return
-	}
-
 	tags := ListToTags(ctx, data.Tags, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Build peer VPC URI
+	// Normalise peer VPC value: if bare ID, construct the full URI.
 	peerVPCURI := data.PeerVpc.ValueString()
 	if !strings.HasPrefix(peerVPCURI, "/") {
 		peerVPCURI = fmt.Sprintf("/projects/%s/providers/Aruba.Network/vpcs/%s", projectID, peerVPCURI)
 	}
 
-	// Build the create request
-	createRequest := sdktypes.VPCPeeringRequest{
-		Metadata: sdktypes.RegionalResourceMetadataRequest{
-			ResourceMetadataRequest: sdktypes.ResourceMetadataRequest{
-				Name: data.Name.ValueString(),
-				Tags: tags,
-			},
-			Location: sdktypes.LocationRequest{
-				Value: data.Location.ValueString(),
-			},
-		},
-		Properties: sdktypes.VPCPeeringPropertiesRequest{
-			RemoteVPC: &sdktypes.ReferenceResource{
-				URI: peerVPCURI,
-			},
-		},
-	}
-
-	// Create the VPC peering using the SDK
-	response, err := r.client.Client.FromNetwork().VPCPeerings().Create(ctx, projectID, vpcID, createRequest, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error creating VPC peering",
-			NewTransportError("create", "Vpcpeering", err).Error(),
-		)
+	vpcURI := aruba.URI("/projects/" + projectID + "/network/vpcs/" + vpcID)
+	peering, err := r.client.Client.FromNetwork().VPCPeerings().Create(ctx,
+		aruba.NewVPCPeering().
+			Named(data.Name.ValueString()).
+			InVPC(vpcURI).
+			InRegion(aruba.Region(data.Location.ValueString())).
+			Tagged(tags...).
+			PeeredWith(aruba.URI(peerVPCURI)),
+	)
+	if provErr := CheckResponseErr("create", "VPCPeering", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	if apiErr := CheckResponse("create", "Vpcpeering", response); apiErr != nil {
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
+	data.Id = types.StringValue(peering.ID())
+	data.Uri = strVal(peering.URI())
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	if response != nil && response.Data != nil {
-		if response.Data.Metadata.ID != nil {
-			data.Id = types.StringValue(*response.Data.Metadata.ID)
-		}
-		if response.Data.Metadata.URI != nil {
-			data.Uri = types.StringValue(*response.Data.Metadata.URI)
-		} else {
-			data.Uri = types.StringNull()
-		}
+	if waitErr := peering.WaitUntilReady(ctx, aruba.WithTimeout(r.client.ResourceTimeout)); waitErr != nil {
+		ReportWaitResult(&resp.Diagnostics, waitErr, "VPCPeering", data.Id.ValueString())
+		return
+	}
+
+	fresh, freshErr := r.client.Client.FromNetwork().VPCPeerings().Get(ctx, vpcPeeringRef(&data))
+	if freshErr == nil {
+		projectID := data.ProjectId
+		vpcID := data.VpcId
+		applyVPCPeeringToModel(fresh, &data)
+		data.ProjectId = projectID
+		data.VpcId = vpcID
 	} else {
-		resp.Diagnostics.AddError(
-			"Invalid API Response",
-			"VPC peering created but no data returned from API",
-		)
-		return
-	}
-
-	// Wait for VPC Peering to be active before returning (VpcPeering is referenced by VpcPeeringRoute)
-	// This ensures Terraform doesn't proceed to create dependent resources until VPC Peering is ready
-	peeringID := data.Id.ValueString()
-	checker := func(ctx context.Context) (string, error) {
-		getResp, err := r.client.Client.FromNetwork().VPCPeerings().Get(ctx, projectID, vpcID, peeringID, nil)
-		if err != nil {
-			return "", err
-		}
-		if getResp != nil && getResp.Data != nil && getResp.Data.Status.State != nil {
-			return *getResp.Data.Status.State, nil
-		}
-		return "Unknown", nil
-	}
-
-	// Wait for VPC Peering to be active - block until ready (using configured timeout)
-	if err := WaitForResourceActive(ctx, checker, "VpcPeering", peeringID, r.client.ResourceTimeout); err != nil {
-		ReportWaitResult(&resp.Diagnostics, err, "VpcPeering", peeringID)
-		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-		return
+		tflog.Warn(ctx, fmt.Sprintf("Failed to refresh VPCPeering after creation: %v", freshErr))
 	}
 
 	tflog.Trace(ctx, "created a VPC Peering resource", map[string]interface{}{
 		"vpcpeering_id":   data.Id.ValueString(),
 		"vpcpeering_name": data.Name.ValueString(),
 	})
-
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -210,114 +189,44 @@ func (r *VpcPeeringResource) Read(ctx context.Context, req resource.ReadRequest,
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	projectID := data.ProjectId.ValueString()
-	vpcID := data.VpcId.ValueString()
-	peeringID := data.Id.ValueString()
-
-	if data.Id.IsUnknown() || data.Id.IsNull() || peeringID == "" {
-		tflog.Debug(ctx, "VPC Peering ID is empty, removing resource from state", map[string]interface{}{"peering_id": peeringID})
+	if data.Id.IsNull() || data.Id.ValueString() == "" {
 		resp.State.RemoveResource(ctx)
 		return
 	}
-	if projectID == "" || vpcID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID and VPC ID are required to read the VPC peering",
-		)
-		return
-	}
 
-	// Get VPC peering details using the SDK
-	response, err := r.client.Client.FromNetwork().VPCPeerings().Get(ctx, projectID, vpcID, peeringID, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error reading VPC peering",
-			NewTransportError("read", "Vpcpeering", err).Error(),
-		)
-		return
-	}
-
-	if apiErr := CheckResponse("read", "Vpcpeering", response); apiErr != nil {
-		if IsNotFound(apiErr) {
+	peering, err := r.client.Client.FromNetwork().VPCPeerings().Get(ctx, vpcPeeringRef(&data))
+	if provErr := CheckResponseErr("read", "VPCPeering", err); provErr != nil {
+		if IsNotFound(provErr) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	// If the resource is still provisioning (e.g. after a Create timeout that saved
-	// partial state), resume the wait so the next terraform apply reconciles correctly.
-	if response.Data.Status.State != nil {
-		switch st := *response.Data.Status.State; {
-		case isFailedState(st):
-			resp.Diagnostics.AddWarning(
-				"Resource in Failed State",
-				fmt.Sprintf("VpcPeering %q is in a terminal failure state (%s). "+
-					"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", peeringID, st),
-			)
-		case IsCreatingState(st):
-			checker := func(ctx context.Context) (string, error) {
-				getResp, err := r.client.Client.FromNetwork().VPCPeerings().Get(ctx, projectID, vpcID, peeringID, nil)
-				if err != nil {
-					return "", err
-				}
-				if getResp != nil && getResp.Data != nil && getResp.Data.Status.State != nil {
-					return *getResp.Data.Status.State, nil
-				}
-				return "Unknown", nil
-			}
-			if err := WaitForResourceActive(ctx, checker, "VpcPeering", peeringID, r.client.ResourceTimeout); err != nil {
-				ReportWaitResult(&resp.Diagnostics, err, "VpcPeering", peeringID)
-				resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-				return
-			}
-			// Re-read to get the final active state.
-			response, err = r.client.Client.FromNetwork().VPCPeerings().Get(ctx, projectID, vpcID, peeringID, nil)
-			if err != nil {
-				resp.Diagnostics.AddError("Error reading VpcPeering after provisioning wait",
-					NewTransportError("read", "Vpcpeering", err).Error())
-				return
-			}
-			if apiErr := CheckResponse("read", "Vpcpeering", response); apiErr != nil {
-				if IsNotFound(apiErr) {
-					resp.State.RemoveResource(ctx)
-					return
-				}
-				resp.Diagnostics.AddError("API Error", apiErr.Error())
-				return
-			}
+	st := string(peering.State())
+	switch {
+	case isFailedState(st):
+		resp.Diagnostics.AddWarning("Resource in Failed State",
+			fmt.Sprintf("VPCPeering %q is in a terminal failure state (%s). "+
+				"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", data.Id.ValueString(), st))
+	case IsCreatingState(st):
+		if waitErr := peering.WaitUntilReady(ctx, aruba.WithTimeout(r.client.ResourceTimeout)); waitErr != nil {
+			ReportWaitResult(&resp.Diagnostics, waitErr, "VPCPeering", data.Id.ValueString())
+			return
+		}
+		peering, err = r.client.Client.FromNetwork().VPCPeerings().Get(ctx, vpcPeeringRef(&data))
+		if provErr := CheckResponseErr("read", "VPCPeering", err); provErr != nil {
+			resp.Diagnostics.AddError("API Error", provErr.Error())
+			return
 		}
 	}
 
-	if response != nil && response.Data != nil {
-		peering := response.Data
-
-		if peering.Metadata.ID != nil {
-			data.Id = types.StringValue(*peering.Metadata.ID)
-		}
-		if peering.Metadata.URI != nil {
-			data.Uri = types.StringValue(*peering.Metadata.URI)
-		} else {
-			data.Uri = types.StringNull()
-		}
-		if peering.Metadata.Name != nil {
-			data.Name = types.StringValue(*peering.Metadata.Name)
-		}
-		if peering.Metadata.LocationResponse != nil {
-			data.Location = types.StringValue(peering.Metadata.LocationResponse.Value)
-		}
-		if peering.Properties.RemoteVPC != nil {
-			data.PeerVpc = types.StringValue(peering.Properties.RemoteVPC.URI)
-		}
-
-		data.Tags = TagsToListPreserveNull(peering.Metadata.Tags, data.Tags)
-	} else {
-		resp.State.RemoveResource(ctx)
-		return
-	}
-
+	projectID := data.ProjectId
+	vpcID := data.VpcId
+	applyVPCPeeringToModel(peering, &data)
+	data.ProjectId = projectID
+	data.VpcId = vpcID
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -326,67 +235,8 @@ func (r *VpcPeeringResource) Update(ctx context.Context, req resource.UpdateRequ
 	var state VpcPeeringResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// Get IDs from state (not plan) - IDs are immutable and should always be in state
-	projectID := state.ProjectId.ValueString()
-	vpcID := state.VpcId.ValueString()
-	peeringID := state.Id.ValueString()
-
-	if projectID == "" || vpcID == "" || peeringID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID, VPC ID, and Peering ID are required to update the VPC peering",
-		)
-		return
-	}
-
-	// Get current VPC peering details
-	getResponse, err := r.client.Client.FromNetwork().VPCPeerings().Get(ctx, projectID, vpcID, peeringID, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error fetching current VPC peering",
-			NewTransportError("read", "Vpcpeering", err).Error(),
-		)
-		return
-	}
-
-	if getResponse == nil || getResponse.Data == nil {
-		resp.Diagnostics.AddError(
-			"VPC Peering Not Found",
-			"VPC peering not found or no data returned",
-		)
-		return
-	}
-
-	current := getResponse.Data
-
-	// Check if VPC peering is in InCreation state
-	if current.Status.State != nil && *current.Status.State == "InCreation" {
-		resp.Diagnostics.AddError(
-			"Cannot Update VPC Peering",
-			"Cannot update VPC peering while it is in 'InCreation' state. Please wait until the VPC peering is fully created.",
-		)
-		return
-	}
-
-	// Get region value
-	regionValue := ""
-	if current.Metadata.LocationResponse != nil {
-		regionValue = current.Metadata.LocationResponse.Value
-	}
-	if regionValue == "" {
-		resp.Diagnostics.AddError(
-			"Missing Region",
-			"Unable to determine region value for VPC peering",
-		)
 		return
 	}
 
@@ -394,53 +244,34 @@ func (r *VpcPeeringResource) Update(ctx context.Context, req resource.UpdateRequ
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	if tags == nil {
-		tags = current.Metadata.Tags
-	}
 
-	// Build update request - only name and tags can be updated, peer VPC must remain unchanged
-	updateRequest := sdktypes.VPCPeeringRequest{
-		Metadata: sdktypes.RegionalResourceMetadataRequest{
-			ResourceMetadataRequest: sdktypes.ResourceMetadataRequest{
-				Name: data.Name.ValueString(),
-				Tags: tags,
-			},
-			Location: sdktypes.LocationRequest{
-				Value: regionValue,
-			},
-		},
-		Properties: sdktypes.VPCPeeringPropertiesRequest{
-			// Peer VPC cannot be updated - use current value
-			RemoteVPC: current.Properties.RemoteVPC,
-		},
-	}
-
-	// Update the VPC peering using the SDK
-	response, err := r.client.Client.FromNetwork().VPCPeerings().Update(ctx, projectID, vpcID, peeringID, updateRequest, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error updating VPC peering",
-			NewTransportError("update", "Vpcpeering", err).Error(),
-		)
+	peering, err := r.client.Client.FromNetwork().VPCPeerings().Get(ctx, vpcPeeringRef(&state))
+	if provErr := CheckResponseErr("read", "VPCPeering", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	if apiErr := CheckResponse("update", "Vpcpeering", response); apiErr != nil {
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
+	peering.Named(data.Name.ValueString())
+	if tags != nil {
+		peering.RetaggedAs(tags...)
+	} else {
+		peering.RetaggedAs(peering.Tags()...)
+	}
+
+	updated, err := r.client.Client.FromNetwork().VPCPeerings().Update(ctx, peering)
+	if provErr := CheckResponseErr("update", "VPCPeering", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	// Ensure immutable fields are set from state before saving
 	data.Id = state.Id
+	data.Uri = state.Uri
 	data.ProjectId = state.ProjectId
 	data.VpcId = state.VpcId
-
-	if response != nil && response.Data != nil {
-		// Update from response if available (should match state)
-		if response.Data.Metadata.ID != nil {
-			data.Id = types.StringValue(*response.Data.Metadata.ID)
-		}
-	}
+	data.PeerVpc = state.PeerVpc
+	data.Location = state.Location
+	data.Name = types.StringValue(updated.Name())
+	data.Tags = TagsToListPreserveNull(updated.Tags(), data.Tags)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -452,26 +283,12 @@ func (r *VpcPeeringResource) Delete(ctx context.Context, req resource.DeleteRequ
 		return
 	}
 
-	projectID := data.ProjectId.ValueString()
-	vpcID := data.VpcId.ValueString()
+	ref := vpcPeeringRef(&data)
 	peeringID := data.Id.ValueString()
 
-	if projectID == "" || vpcID == "" || peeringID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID, VPC ID, and Peering ID are required to delete the VPC peering",
-		)
-		return
-	}
-
-	// Delete the VPC peering using the SDK with retry mechanism
-	// Retry on any error except 404 (Resource Not Found)
 	deletionChecker := func(ctx context.Context) (bool, error) {
-		getResp, getErr := r.client.Client.FromNetwork().VPCPeerings().Get(ctx, projectID, vpcID, peeringID, nil)
-		if getErr != nil {
-			return false, NewTransportError("get", "VPCPeering", getErr)
-		}
-		if provErr := CheckResponse("get", "VPCPeering", getResp); provErr != nil {
+		_, getErr := r.client.Client.FromNetwork().VPCPeerings().Get(ctx, ref)
+		if provErr := CheckResponseErr("get", "VPCPeering", getErr); provErr != nil {
 			if IsNotFound(provErr) {
 				return true, nil
 			}
@@ -481,37 +298,19 @@ func (r *VpcPeeringResource) Delete(ctx context.Context, req resource.DeleteRequ
 	}
 
 	deleteStart := time.Now()
-	err := DeleteResourceWithRetry(
-		ctx,
-		func() error {
-			resp, err := r.client.Client.FromNetwork().VPCPeerings().Delete(ctx, projectID, vpcID, peeringID, nil)
-			if err != nil {
-				return NewTransportError("delete", "VPCPeering", err)
-			}
-			return CheckResponse("delete", "VPCPeering", resp)
-		},
-		"VPCPeering",
-		peeringID,
-		r.client.ResourceTimeout,
-		deletionChecker,
-	)
-
+	err := DeleteResourceWithRetry(ctx, func() error {
+		return CheckResponseErr("delete", "VPCPeering",
+			r.client.Client.FromNetwork().VPCPeerings().Delete(ctx, ref))
+	}, "VPCPeering", peeringID, r.client.ResourceTimeout, deletionChecker)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error deleting VPC peering",
-			NewTransportError("delete", "Vpcpeering", err).Error(),
-		)
+		resp.Diagnostics.AddError("Error deleting VPCPeering", err.Error())
 		return
 	}
-
 	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "VPCPeering", peeringID, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
 		resp.Diagnostics.AddError("Error waiting for VPCPeering deletion", waitErr.Error())
 		return
 	}
-
-	tflog.Trace(ctx, "deleted a VPC Peering resource", map[string]interface{}{
-		"vpcpeering_id": peeringID,
-	})
+	tflog.Trace(ctx, "deleted a VPC Peering resource", map[string]interface{}{"vpcpeering_id": peeringID})
 }
 
 func (r *VpcPeeringResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/internal/provider/vpcpeeringroute_data_source.go
+++ b/internal/provider/vpcpeeringroute_data_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -91,24 +92,16 @@ func (d *VPCPeeringRouteDataSource) Read(ctx context.Context, req datasource.Rea
 		return
 	}
 
-	response, err := d.client.Client.FromNetwork().VPCPeeringRoutes().Get(ctx, projectID, vpcID, peeringID, routeID, nil)
-	if err != nil {
-		resp.Diagnostics.AddError("Error reading VPC peering route", NewTransportError("read", "Vpcpeeringroute", err).Error())
-		return
-	}
-	if apiErr := CheckResponse("read", "Vpcpeeringroute", response); apiErr != nil {
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
-		return
-	}
-	if response == nil || response.Data == nil {
-		resp.Diagnostics.AddError("No data returned", "VPC Peering Route Get returned no data")
+	route, err := d.client.Client.FromNetwork().VPCPeeringRoutes().Get(ctx,
+		aruba.VPCPeeringRouteRef(projectID, vpcID, peeringID, routeID))
+	if provErr := CheckResponseErr("read", "VPCPeeringRoute", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	route := response.Data
-	// VPC Peering Route uses name as ID
-	data.Id = types.StringValue(route.Metadata.Name)
-	data.Name = types.StringValue(route.Metadata.Name)
+	// VPCPeeringRoute uses name as ID.
+	data.Id = types.StringValue(route.Name())
+	data.Name = types.StringValue(route.Name())
 	data.ProjectId = types.StringValue(projectID)
 	data.VpcId = types.StringValue(vpcID)
 	data.VpcPeeringId = types.StringValue(peeringID)

--- a/internal/provider/vpcpeeringroute_resource.go
+++ b/internal/provider/vpcpeeringroute_resource.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	sdktypes "github.com/Arubacloud/sdk-go/pkg/types"
+	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -105,6 +105,35 @@ func (r *VpcPeeringRouteResource) Configure(ctx context.Context, req resource.Co
 	r.client = client
 }
 
+func vpcPeeringRouteRef(data *VpcPeeringRouteResourceModel) aruba.Ref {
+	if !data.Uri.IsNull() && data.Uri.ValueString() != "" {
+		return aruba.URI(data.Uri.ValueString())
+	}
+	return aruba.VPCPeeringRouteRef(
+		data.ProjectId.ValueString(),
+		data.VpcId.ValueString(),
+		data.VpcPeeringId.ValueString(),
+		data.Id.ValueString(),
+	)
+}
+
+func applyVPCPeeringRouteToModel(route *aruba.VPCPeeringRoute, data *VpcPeeringRouteResourceModel) {
+	// VPCPeeringRoute uses name as ID (no separate UUID from API).
+	data.Id = types.StringValue(route.Name())
+	data.Uri = strVal(route.URI())
+	data.Name = types.StringValue(route.Name())
+	data.Tags = TagsToListPreserveNull(route.Tags(), data.Tags)
+	if route.LocalCIDR() != "" {
+		data.LocalNetworkAddress = types.StringValue(route.LocalCIDR())
+	}
+	if route.RemoteCIDR() != "" {
+		data.RemoteNetworkAddress = types.StringValue(route.RemoteCIDR())
+	}
+	if route.BillingPeriod() != "" {
+		data.BillingPeriod = types.StringValue(string(route.BillingPeriod()))
+	}
+}
+
 func (r *VpcPeeringRouteResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data VpcPeeringRouteResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
@@ -116,87 +145,37 @@ func (r *VpcPeeringRouteResource) Create(ctx context.Context, req resource.Creat
 	vpcID := data.VpcId.ValueString()
 	peeringID := data.VpcPeeringId.ValueString()
 
-	if projectID == "" || vpcID == "" || peeringID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID, VPC ID, and VPC Peering ID are required to create a VPC peering route",
-		)
-		return
-	}
-
 	tags := ListToTags(ctx, data.Tags, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Build the create request
-	createRequest := sdktypes.VPCPeeringRouteRequest{
-		Metadata: sdktypes.ResourceMetadataRequest{
-			Name: data.Name.ValueString(),
-			Tags: tags,
-		},
-		Properties: sdktypes.VPCPeeringRoutePropertiesRequest{
-			LocalNetworkAddress:  data.LocalNetworkAddress.ValueString(),
-			RemoteNetworkAddress: data.RemoteNetworkAddress.ValueString(),
-			BillingPlan: sdktypes.BillingPeriodResource{
-				BillingPeriod: data.BillingPeriod.ValueString(),
-			},
-		},
-	}
-
-	// Create the VPC peering route using the SDK
-	response, err := r.client.Client.FromNetwork().VPCPeeringRoutes().Create(ctx, projectID, vpcID, peeringID, createRequest, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error creating VPC peering route",
-			NewTransportError("create", "Vpcpeeringroute", err).Error(),
-		)
+	peeringRef := aruba.VPCPeeringRef(projectID, vpcID, peeringID)
+	route, err := r.client.Client.FromNetwork().VPCPeeringRoutes().Create(ctx,
+		aruba.NewVPCPeeringRoute().
+			Named(data.Name.ValueString()).
+			InVPCPeering(peeringRef).
+			Tagged(tags...).
+			WithLocalCIDR(data.LocalNetworkAddress.ValueString()).
+			WithRemoteCIDR(data.RemoteNetworkAddress.ValueString()).
+			BilledBy(aruba.BillingPeriod(data.BillingPeriod.ValueString())),
+	)
+	if provErr := CheckResponseErr("create", "VPCPeeringRoute", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	if response != nil && response.IsError() && response.Error != nil {
-		errorMsg := "Failed to create VPC peering route"
-		if response.Error.Title != nil {
-			errorMsg = fmt.Sprintf("%s: %s", errorMsg, *response.Error.Title)
-		}
-		if response.Error.Detail != nil {
-			errorMsg = fmt.Sprintf("%s - %s", errorMsg, *response.Error.Detail)
-		}
-		resp.Diagnostics.AddError("API Error", errorMsg)
+	// VPCPeeringRoute uses name as ID.
+	data.Id = types.StringValue(route.Name())
+	data.Uri = strVal(route.URI())
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	if response != nil && response.Data != nil {
-		// VPC Peering Route uses name as ID
-		data.Id = types.StringValue(response.Data.Metadata.Name)
-		// VPC Peering Route uses RegionalResourceMetadataRequest which doesn't have URI
-		data.Uri = types.StringNull()
-	} else {
-		resp.Diagnostics.AddError(
-			"Invalid API Response",
-			"VPC peering route created but no data returned from API",
-		)
-		return
-	}
-
-	// Wait for VPC Peering Route to be active before returning
-	// This ensures Terraform doesn't proceed until VPC Peering Route is ready
-	routeID := data.Id.ValueString()
-	checker := func(ctx context.Context) (string, error) {
-		getResp, err := r.client.Client.FromNetwork().VPCPeeringRoutes().Get(ctx, projectID, vpcID, peeringID, routeID, nil)
-		if err != nil {
-			return "", err
-		}
-		if getResp != nil && getResp.Data != nil && getResp.Data.Status.State != nil {
-			return *getResp.Data.Status.State, nil
-		}
-		return "Unknown", nil
-	}
-
-	// Wait for VPC Peering Route to be active - block until ready (using configured timeout)
-	if err := WaitForResourceActive(ctx, checker, "VpcPeeringRoute", routeID, r.client.ResourceTimeout); err != nil {
-		ReportWaitResult(&resp.Diagnostics, err, "VpcPeeringRoute", routeID)
-		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	if waitErr := route.WaitUntilReady(ctx, aruba.WithTimeout(r.client.ResourceTimeout)); waitErr != nil {
+		ReportWaitResult(&resp.Diagnostics, waitErr, "VPCPeeringRoute", data.Id.ValueString())
 		return
 	}
 
@@ -204,7 +183,6 @@ func (r *VpcPeeringRouteResource) Create(ctx context.Context, req resource.Creat
 		"vpcpeeringroute_id":   data.Id.ValueString(),
 		"vpcpeeringroute_name": data.Name.ValueString(),
 	})
-
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -214,114 +192,46 @@ func (r *VpcPeeringRouteResource) Read(ctx context.Context, req resource.ReadReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	projectID := data.ProjectId.ValueString()
-	vpcID := data.VpcId.ValueString()
-	peeringID := data.VpcPeeringId.ValueString()
-	routeID := data.Id.ValueString()
-
-	if data.Id.IsUnknown() || data.Id.IsNull() || routeID == "" {
-		tflog.Debug(ctx, "VPC Peering Route ID is empty, removing resource from state", map[string]interface{}{"route_id": routeID})
+	if data.Id.IsNull() || data.Id.ValueString() == "" {
 		resp.State.RemoveResource(ctx)
 		return
 	}
-	if projectID == "" || vpcID == "" || peeringID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID, VPC ID, and VPC Peering ID are required to read the VPC peering route",
-		)
-		return
-	}
 
-	// Get VPC peering route details using the SDK
-	response, err := r.client.Client.FromNetwork().VPCPeeringRoutes().Get(ctx, projectID, vpcID, peeringID, routeID, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error reading VPC peering route",
-			NewTransportError("read", "Vpcpeeringroute", err).Error(),
-		)
-		return
-	}
-
-	if response != nil && response.IsError() && response.Error != nil {
-		if response.StatusCode == 404 {
+	route, err := r.client.Client.FromNetwork().VPCPeeringRoutes().Get(ctx, vpcPeeringRouteRef(&data))
+	if provErr := CheckResponseErr("read", "VPCPeeringRoute", err); provErr != nil {
+		if IsNotFound(provErr) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		errorMsg := "Failed to read VPC peering route"
-		if response.Error.Title != nil {
-			errorMsg = fmt.Sprintf("%s: %s", errorMsg, *response.Error.Title)
-		}
-		if response.Error.Detail != nil {
-			errorMsg = fmt.Sprintf("%s - %s", errorMsg, *response.Error.Detail)
-		}
-		resp.Diagnostics.AddError("API Error", errorMsg)
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	// If the resource is still provisioning (e.g. after a Create timeout that saved
-	// partial state), resume the wait so the next terraform apply reconciles correctly.
-	if response != nil && response.Data != nil && response.Data.Status.State != nil {
-		switch st := *response.Data.Status.State; {
-		case isFailedState(st):
-			resp.Diagnostics.AddWarning(
-				"Resource in Failed State",
-				fmt.Sprintf("VpcPeeringRoute %q is in a terminal failure state (%s). "+
-					"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", routeID, st),
-			)
-		case IsCreatingState(st):
-			checker := func(ctx context.Context) (string, error) {
-				getResp, err := r.client.Client.FromNetwork().VPCPeeringRoutes().Get(ctx, projectID, vpcID, peeringID, routeID, nil)
-				if err != nil {
-					return "", err
-				}
-				if getResp != nil && getResp.Data != nil && getResp.Data.Status.State != nil {
-					return *getResp.Data.Status.State, nil
-				}
-				return "Unknown", nil
-			}
-			if err := WaitForResourceActive(ctx, checker, "VpcPeeringRoute", routeID, r.client.ResourceTimeout); err != nil {
-				ReportWaitResult(&resp.Diagnostics, err, "VpcPeeringRoute", routeID)
-				resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-				return
-			}
-			// Re-read to get the final active state.
-			response, err = r.client.Client.FromNetwork().VPCPeeringRoutes().Get(ctx, projectID, vpcID, peeringID, routeID, nil)
-			if err != nil {
-				resp.Diagnostics.AddError("Error reading VpcPeeringRoute after provisioning wait",
-					NewTransportError("read", "Vpcpeeringroute", err).Error())
-				return
-			}
-			if response != nil && response.IsError() && response.Error != nil {
-				if response.StatusCode == 404 {
-					resp.State.RemoveResource(ctx)
-					return
-				}
-				resp.Diagnostics.AddError("API Error", "Failed to read VPC peering route after provisioning wait")
-				return
-			}
+	st := string(route.State())
+	switch {
+	case isFailedState(st):
+		resp.Diagnostics.AddWarning("Resource in Failed State",
+			fmt.Sprintf("VPCPeeringRoute %q is in a terminal failure state (%s). "+
+				"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", data.Id.ValueString(), st))
+	case IsCreatingState(st):
+		if waitErr := route.WaitUntilReady(ctx, aruba.WithTimeout(r.client.ResourceTimeout)); waitErr != nil {
+			ReportWaitResult(&resp.Diagnostics, waitErr, "VPCPeeringRoute", data.Id.ValueString())
+			return
+		}
+		route, err = r.client.Client.FromNetwork().VPCPeeringRoutes().Get(ctx, vpcPeeringRouteRef(&data))
+		if provErr := CheckResponseErr("read", "VPCPeeringRoute", err); provErr != nil {
+			resp.Diagnostics.AddError("API Error", provErr.Error())
+			return
 		}
 	}
 
-	if response != nil && response.Data != nil {
-		route := response.Data
-
-		data.Id = types.StringValue(route.Metadata.Name)
-		// VPC Peering Route uses RegionalResourceMetadataRequest which doesn't have URI
-		data.Uri = types.StringNull()
-		data.Name = types.StringValue(route.Metadata.Name)
-		data.LocalNetworkAddress = types.StringValue(route.Properties.LocalNetworkAddress)
-		data.RemoteNetworkAddress = types.StringValue(route.Properties.RemoteNetworkAddress)
-		if route.Properties.BillingPlan.BillingPeriod != "" {
-			data.BillingPeriod = types.StringValue(route.Properties.BillingPlan.BillingPeriod)
-		}
-
-		data.Tags = TagsToListPreserveNull(route.Metadata.Tags, data.Tags)
-	} else {
-		resp.State.RemoveResource(ctx)
-		return
-	}
-
+	projectID := data.ProjectId
+	vpcID := data.VpcId
+	peeringID := data.VpcPeeringId
+	applyVPCPeeringRouteToModel(route, &data)
+	data.ProjectId = projectID
+	data.VpcId = vpcID
+	data.VpcPeeringId = peeringID
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -330,55 +240,8 @@ func (r *VpcPeeringRouteResource) Update(ctx context.Context, req resource.Updat
 	var state VpcPeeringRouteResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// Get IDs from state (not plan) - IDs are immutable and should always be in state
-	projectID := state.ProjectId.ValueString()
-	vpcID := state.VpcId.ValueString()
-	peeringID := state.VpcPeeringId.ValueString()
-	routeID := state.Id.ValueString()
-
-	if projectID == "" || vpcID == "" || peeringID == "" || routeID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID, VPC ID, VPC Peering ID, and Route ID are required to update the VPC peering route",
-		)
-		return
-	}
-
-	// Get current VPC peering route details
-	getResponse, err := r.client.Client.FromNetwork().VPCPeeringRoutes().Get(ctx, projectID, vpcID, peeringID, routeID, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error fetching current VPC peering route",
-			NewTransportError("read", "Vpcpeeringroute", err).Error(),
-		)
-		return
-	}
-
-	if getResponse == nil || getResponse.Data == nil {
-		resp.Diagnostics.AddError(
-			"VPC Peering Route Not Found",
-			"VPC peering route not found or no data returned",
-		)
-		return
-	}
-
-	current := getResponse.Data
-
-	// Check if VPC peering route is in InCreation state
-	if current.Status.State != nil && *current.Status.State == "InCreation" {
-		resp.Diagnostics.AddError(
-			"Cannot Update VPC Peering Route",
-			"Cannot update VPC peering route while it is in 'InCreation' state. Please wait until the VPC peering route is fully created.",
-		)
 		return
 	}
 
@@ -386,55 +249,36 @@ func (r *VpcPeeringRouteResource) Update(ctx context.Context, req resource.Updat
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	if tags == nil {
-		tags = current.Metadata.Tags
-	}
 
-	// Build update request
-	updateRequest := sdktypes.VPCPeeringRouteRequest{
-		Metadata: sdktypes.ResourceMetadataRequest{
-			Name: data.Name.ValueString(),
-			Tags: tags,
-		},
-		Properties: sdktypes.VPCPeeringRoutePropertiesRequest{
-			LocalNetworkAddress:  data.LocalNetworkAddress.ValueString(),
-			RemoteNetworkAddress: data.RemoteNetworkAddress.ValueString(),
-			BillingPlan: sdktypes.BillingPeriodResource{
-				BillingPeriod: data.BillingPeriod.ValueString(),
-			},
-		},
-	}
-
-	// Update the VPC peering route using the SDK
-	response, err := r.client.Client.FromNetwork().VPCPeeringRoutes().Update(ctx, projectID, vpcID, peeringID, routeID, updateRequest, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error updating VPC peering route",
-			NewTransportError("update", "Vpcpeeringroute", err).Error(),
-		)
+	route, err := r.client.Client.FromNetwork().VPCPeeringRoutes().Get(ctx, vpcPeeringRouteRef(&state))
+	if provErr := CheckResponseErr("read", "VPCPeeringRoute", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	if response != nil && response.IsError() && response.Error != nil {
-		errorMsg := "Failed to update VPC peering route"
-		if response.Error.Title != nil {
-			errorMsg = fmt.Sprintf("%s: %s", errorMsg, *response.Error.Title)
-		}
-		if response.Error.Detail != nil {
-			errorMsg = fmt.Sprintf("%s - %s", errorMsg, *response.Error.Detail)
-		}
-		resp.Diagnostics.AddError("API Error", errorMsg)
+	route.Named(data.Name.ValueString())
+	if tags != nil {
+		route.RetaggedAs(tags...)
+	} else {
+		route.RetaggedAs(route.Tags()...)
+	}
+
+	updated, err := r.client.Client.FromNetwork().VPCPeeringRoutes().Update(ctx, route)
+	if provErr := CheckResponseErr("update", "VPCPeeringRoute", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	// Ensure immutable fields are set from state before saving
 	data.Id = state.Id
+	data.Uri = state.Uri
 	data.ProjectId = state.ProjectId
 	data.VpcId = state.VpcId
 	data.VpcPeeringId = state.VpcPeeringId
-
-	// Note: VpcPeeringRoute uses name as ID and response doesn't have Metadata.ID
-	// ID is already set from state above
+	data.LocalNetworkAddress = state.LocalNetworkAddress
+	data.RemoteNetworkAddress = state.RemoteNetworkAddress
+	data.BillingPeriod = state.BillingPeriod
+	data.Name = types.StringValue(updated.Name())
+	data.Tags = TagsToListPreserveNull(updated.Tags(), data.Tags)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -446,27 +290,12 @@ func (r *VpcPeeringRouteResource) Delete(ctx context.Context, req resource.Delet
 		return
 	}
 
-	projectID := data.ProjectId.ValueString()
-	vpcID := data.VpcId.ValueString()
-	peeringID := data.VpcPeeringId.ValueString()
+	ref := vpcPeeringRouteRef(&data)
 	routeID := data.Id.ValueString()
 
-	if projectID == "" || vpcID == "" || peeringID == "" || routeID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID, VPC ID, VPC Peering ID, and Route ID are required to delete the VPC peering route",
-		)
-		return
-	}
-
-	// Delete the VPC peering route using the SDK with retry mechanism
-	// Retry on any error except 404 (Resource Not Found)
 	deletionChecker := func(ctx context.Context) (bool, error) {
-		getResp, getErr := r.client.Client.FromNetwork().VPCPeeringRoutes().Get(ctx, projectID, vpcID, peeringID, routeID, nil)
-		if getErr != nil {
-			return false, NewTransportError("get", "VPCPeeringRoute", getErr)
-		}
-		if provErr := CheckResponse("get", "VPCPeeringRoute", getResp); provErr != nil {
+		_, getErr := r.client.Client.FromNetwork().VPCPeeringRoutes().Get(ctx, ref)
+		if provErr := CheckResponseErr("get", "VPCPeeringRoute", getErr); provErr != nil {
 			if IsNotFound(provErr) {
 				return true, nil
 			}
@@ -476,37 +305,19 @@ func (r *VpcPeeringRouteResource) Delete(ctx context.Context, req resource.Delet
 	}
 
 	deleteStart := time.Now()
-	err := DeleteResourceWithRetry(
-		ctx,
-		func() error {
-			resp, err := r.client.Client.FromNetwork().VPCPeeringRoutes().Delete(ctx, projectID, vpcID, peeringID, routeID, nil)
-			if err != nil {
-				return NewTransportError("delete", "VPCPeeringRoute", err)
-			}
-			return CheckResponse("delete", "VPCPeeringRoute", resp)
-		},
-		"VPCPeeringRoute",
-		routeID,
-		r.client.ResourceTimeout,
-		deletionChecker,
-	)
-
+	err := DeleteResourceWithRetry(ctx, func() error {
+		return CheckResponseErr("delete", "VPCPeeringRoute",
+			r.client.Client.FromNetwork().VPCPeeringRoutes().Delete(ctx, ref))
+	}, "VPCPeeringRoute", routeID, r.client.ResourceTimeout, deletionChecker)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error deleting VPC peering route",
-			NewTransportError("delete", "Vpcpeeringroute", err).Error(),
-		)
+		resp.Diagnostics.AddError("Error deleting VPCPeeringRoute", err.Error())
 		return
 	}
-
 	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "VPCPeeringRoute", routeID, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
 		resp.Diagnostics.AddError("Error waiting for VPCPeeringRoute deletion", waitErr.Error())
 		return
 	}
-
-	tflog.Trace(ctx, "deleted a VPC Peering Route resource", map[string]interface{}{
-		"vpcpeeringroute_id": routeID,
-	})
+	tflog.Trace(ctx, "deleted a VPC Peering Route resource", map[string]interface{}{"vpcpeeringroute_id": routeID})
 }
 
 func (r *VpcPeeringRouteResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/internal/provider/vpnroute_data_source.go
+++ b/internal/provider/vpnroute_data_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -95,31 +96,19 @@ func (d *VPNRouteDataSource) Read(ctx context.Context, req datasource.ReadReques
 		return
 	}
 
-	response, err := d.client.Client.FromNetwork().VPNRoutes().Get(ctx, projectID, vpnTunnelID, routeID, nil)
-	if err != nil {
-		resp.Diagnostics.AddError("Error reading VPN route", NewTransportError("read", "Vpnroute", err).Error())
-		return
-	}
-	if apiErr := CheckResponse("read", "Vpnroute", response); apiErr != nil {
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
-		return
-	}
-	if response == nil || response.Data == nil {
-		resp.Diagnostics.AddError("No data returned", "VPN Route Get returned no data")
+	route, err := d.client.Client.FromNetwork().VPNRoutes().Get(ctx,
+		aruba.VPNRouteRef(projectID, vpnTunnelID, routeID))
+	if provErr := CheckResponseErr("read", "VPNRoute", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	route := response.Data
-	if route.Metadata.ID != nil {
-		data.Id = types.StringValue(*route.Metadata.ID)
-	}
-	if route.Metadata.Name != nil {
-		data.Name = types.StringValue(*route.Metadata.Name)
-	}
+	data.Id = types.StringValue(route.ID())
+	data.Name = types.StringValue(route.Name())
 	data.ProjectId = types.StringValue(projectID)
 	data.VpnTunnelId = types.StringValue(vpnTunnelID)
-	data.Destination = types.StringValue(route.Properties.CloudSubnet)
-	data.Gateway = types.StringValue(route.Properties.OnPremSubnet)
+	data.Destination = types.StringValue(route.CloudSubnet())
+	data.Gateway = types.StringValue(route.OnPremSubnet())
 
 	tflog.Trace(ctx, "read a VPN Route data source", map[string]interface{}{"route_id": routeID})
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/vpnroute_resource.go
+++ b/internal/provider/vpnroute_resource.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	sdktypes "github.com/Arubacloud/sdk-go/pkg/types"
+	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -106,6 +106,31 @@ func (r *VPNRouteResource) Configure(ctx context.Context, req resource.Configure
 	r.client = client
 }
 
+func vpnRouteRef(data *VPNRouteResourceModel) aruba.Ref {
+	if !data.Uri.IsNull() && data.Uri.ValueString() != "" {
+		return aruba.URI(data.Uri.ValueString())
+	}
+	return aruba.VPNRouteRef(data.ProjectId.ValueString(), data.VPNTunnelId.ValueString(), data.Id.ValueString())
+}
+
+func extractVPNRouteSubnets(data *VPNRouteResourceModel) (cloudSubnet, onPremSubnet string) {
+	if data.Properties.IsNull() || data.Properties.IsUnknown() {
+		return
+	}
+	attrs := data.Properties.Attributes()
+	if v, ok := attrs["cloud_subnet"]; ok {
+		if s, ok := v.(types.String); ok && !s.IsNull() {
+			cloudSubnet = s.ValueString()
+		}
+	}
+	if v, ok := attrs["on_prem_subnet"]; ok {
+		if s, ok := v.(types.String); ok && !s.IsNull() {
+			onPremSubnet = s.ValueString()
+		}
+	}
+	return
+}
+
 func (r *VPNRouteResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data VPNRouteResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
@@ -116,108 +141,38 @@ func (r *VPNRouteResource) Create(ctx context.Context, req resource.CreateReques
 	projectID := data.ProjectId.ValueString()
 	vpnTunnelID := data.VPNTunnelId.ValueString()
 
-	if projectID == "" || vpnTunnelID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID and VPN Tunnel ID are required to create a VPN route",
-		)
-		return
-	}
-
 	tags := ListToTags(ctx, data.Tags, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Extract properties from Terraform object
-	propertiesObj, diags := data.Properties.ToObjectValue(ctx)
-	resp.Diagnostics.Append(diags...)
+	cloudSubnet, onPremSubnet := extractVPNRouteSubnets(&data)
+
+	tunnelRef := aruba.VPNTunnelRef(projectID, vpnTunnelID)
+	route, err := r.client.Client.FromNetwork().VPNRoutes().Create(ctx,
+		aruba.NewVPNRoute().
+			Named(data.Name.ValueString()).
+			InVPNTunnel(tunnelRef).
+			InRegion(aruba.Region(data.Location.ValueString())).
+			Tagged(tags...).
+			WithCloudSubnet(cloudSubnet).
+			WithOnPremSubnet(onPremSubnet),
+	)
+	if provErr := CheckResponseErr("create", "VPNRoute", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
+		return
+	}
+
+	data.Id = types.StringValue(route.ID())
+	data.Uri = strVal(route.URI())
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	propertiesAttrs := propertiesObj.Attributes()
-	cloudSubnetAttr, ok := propertiesAttrs["cloud_subnet"].(types.String)
-	if !ok {
-		resp.Diagnostics.AddError("Invalid Type", "cloud_subnet must be a String")
-		return
-	}
-	cloudSubnet := cloudSubnetAttr.ValueString()
-
-	onPremSubnetAttr, ok := propertiesAttrs["on_prem_subnet"].(types.String)
-	if !ok {
-		resp.Diagnostics.AddError("Invalid Type", "on_prem_subnet must be a String")
-		return
-	}
-	onPremSubnet := onPremSubnetAttr.ValueString()
-
-	// Build the create request
-	createRequest := sdktypes.VPNRouteRequest{
-		Metadata: sdktypes.RegionalResourceMetadataRequest{
-			ResourceMetadataRequest: sdktypes.ResourceMetadataRequest{
-				Name: data.Name.ValueString(),
-				Tags: tags,
-			},
-			Location: sdktypes.LocationRequest{
-				Value: data.Location.ValueString(),
-			},
-		},
-		Properties: sdktypes.VPNRoutePropertiesRequest{
-			CloudSubnet:  cloudSubnet,
-			OnPremSubnet: onPremSubnet,
-		},
-	}
-
-	// Create the VPN route using the SDK
-	response, err := r.client.Client.FromNetwork().VPNRoutes().Create(ctx, projectID, vpnTunnelID, createRequest, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error creating VPN route",
-			NewTransportError("create", "Vpnroute", err).Error(),
-		)
-		return
-	}
-
-	if apiErr := CheckResponse("create", "Vpnroute", response); apiErr != nil {
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
-		return
-	}
-
-	if response != nil && response.Data != nil {
-		if response.Data.Metadata.ID != nil {
-			data.Id = types.StringValue(*response.Data.Metadata.ID)
-		}
-		if response.Data.Metadata.URI != nil {
-			data.Uri = types.StringValue(*response.Data.Metadata.URI)
-		} else {
-			data.Uri = types.StringNull()
-		}
-	} else {
-		resp.Diagnostics.AddError(
-			"Invalid API Response",
-			"VPN route created but no data returned from API",
-		)
-		return
-	}
-
-	// Wait for VPN Route to be active before returning (VPNRoute references VPNTunnel)
-	// This ensures Terraform doesn't proceed to create dependent resources until VPN Route is ready
-	routeID := data.Id.ValueString()
-	checker := func(ctx context.Context) (string, error) {
-		getResp, err := r.client.Client.FromNetwork().VPNRoutes().Get(ctx, projectID, vpnTunnelID, routeID, nil)
-		if err != nil {
-			return "", err
-		}
-		if getResp != nil && getResp.Data != nil && getResp.Data.Status.State != nil {
-			return *getResp.Data.Status.State, nil
-		}
-		return "Unknown", nil
-	}
-
-	// Wait for VPN Route to be active - block until ready (using configured timeout)
-	if err := WaitForResourceActive(ctx, checker, "VPNRoute", routeID, r.client.ResourceTimeout); err != nil {
-		ReportWaitResult(&resp.Diagnostics, err, "VPNRoute", routeID)
-		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	if waitErr := route.WaitUntilReady(ctx, aruba.WithTimeout(r.client.ResourceTimeout)); waitErr != nil {
+		ReportWaitResult(&resp.Diagnostics, waitErr, "VPNRoute", data.Id.ValueString())
 		return
 	}
 
@@ -225,7 +180,6 @@ func (r *VPNRouteResource) Create(ctx context.Context, req resource.CreateReques
 		"vpnroute_id":   data.Id.ValueString(),
 		"vpnroute_name": data.Name.ValueString(),
 	})
-
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -235,124 +189,60 @@ func (r *VPNRouteResource) Read(ctx context.Context, req resource.ReadRequest, r
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	projectID := data.ProjectId.ValueString()
-	vpnTunnelID := data.VPNTunnelId.ValueString()
-	routeID := data.Id.ValueString()
-
-	if data.Id.IsUnknown() || data.Id.IsNull() || routeID == "" {
-		tflog.Debug(ctx, "VPN Route ID is empty, removing resource from state", map[string]interface{}{"route_id": routeID})
+	if data.Id.IsNull() || data.Id.ValueString() == "" {
 		resp.State.RemoveResource(ctx)
 		return
 	}
-	if projectID == "" || vpnTunnelID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID and VPN Tunnel ID are required to read the VPN route",
-		)
-		return
-	}
 
-	// Get VPN route details using the SDK
-	response, err := r.client.Client.FromNetwork().VPNRoutes().Get(ctx, projectID, vpnTunnelID, routeID, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error reading VPN route",
-			NewTransportError("read", "Vpnroute", err).Error(),
-		)
-		return
-	}
-
-	if apiErr := CheckResponse("read", "Vpnroute", response); apiErr != nil {
-		if IsNotFound(apiErr) {
+	route, err := r.client.Client.FromNetwork().VPNRoutes().Get(ctx, vpnRouteRef(&data))
+	if provErr := CheckResponseErr("read", "VPNRoute", err); provErr != nil {
+		if IsNotFound(provErr) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	// If the resource is still provisioning (e.g. after a Create timeout that saved
-	// partial state), resume the wait so the next terraform apply reconciles correctly.
-	if response.Data.Status.State != nil {
-		switch st := *response.Data.Status.State; {
-		case isFailedState(st):
-			resp.Diagnostics.AddWarning(
-				"Resource in Failed State",
-				fmt.Sprintf("VPNRoute %q is in a terminal failure state (%s). "+
-					"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", routeID, st),
-			)
-		case IsCreatingState(st):
-			checker := func(ctx context.Context) (string, error) {
-				getResp, err := r.client.Client.FromNetwork().VPNRoutes().Get(ctx, projectID, vpnTunnelID, routeID, nil)
-				if err != nil {
-					return "", err
-				}
-				if getResp != nil && getResp.Data != nil && getResp.Data.Status.State != nil {
-					return *getResp.Data.Status.State, nil
-				}
-				return "Unknown", nil
-			}
-			if err := WaitForResourceActive(ctx, checker, "VPNRoute", routeID, r.client.ResourceTimeout); err != nil {
-				ReportWaitResult(&resp.Diagnostics, err, "VPNRoute", routeID)
-				resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-				return
-			}
-			// Re-read to get the final active state.
-			response, err = r.client.Client.FromNetwork().VPNRoutes().Get(ctx, projectID, vpnTunnelID, routeID, nil)
-			if err != nil {
-				resp.Diagnostics.AddError("Error reading VPNRoute after provisioning wait",
-					NewTransportError("read", "Vpnroute", err).Error())
-				return
-			}
-			if apiErr := CheckResponse("read", "Vpnroute", response); apiErr != nil {
-				if IsNotFound(apiErr) {
-					resp.State.RemoveResource(ctx)
-					return
-				}
-				resp.Diagnostics.AddError("API Error", apiErr.Error())
-				return
-			}
+	st := string(route.State())
+	switch {
+	case isFailedState(st):
+		resp.Diagnostics.AddWarning("Resource in Failed State",
+			fmt.Sprintf("VPNRoute %q is in a terminal failure state (%s). "+
+				"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", data.Id.ValueString(), st))
+	case IsCreatingState(st):
+		if waitErr := route.WaitUntilReady(ctx, aruba.WithTimeout(r.client.ResourceTimeout)); waitErr != nil {
+			ReportWaitResult(&resp.Diagnostics, waitErr, "VPNRoute", data.Id.ValueString())
+			return
+		}
+		route, err = r.client.Client.FromNetwork().VPNRoutes().Get(ctx, vpnRouteRef(&data))
+		if provErr := CheckResponseErr("read", "VPNRoute", err); provErr != nil {
+			resp.Diagnostics.AddError("API Error", provErr.Error())
+			return
 		}
 	}
 
-	if response != nil && response.Data != nil {
-		route := response.Data
+	data.Id = types.StringValue(route.ID())
+	data.Uri = strVal(route.URI())
+	data.Name = types.StringValue(route.Name())
+	data.Tags = TagsToListPreserveNull(route.Tags(), data.Tags)
+	if route.Region() != "" {
+		data.Location = types.StringValue(string(route.Region()))
+	}
 
-		if route.Metadata.ID != nil {
-			data.Id = types.StringValue(*route.Metadata.ID)
-		}
-		if route.Metadata.URI != nil {
-			data.Uri = types.StringValue(*route.Metadata.URI)
-		} else {
-			data.Uri = types.StringNull()
-		}
-		if route.Metadata.Name != nil {
-			data.Name = types.StringValue(*route.Metadata.Name)
-		}
-		if route.Metadata.LocationResponse != nil {
-			data.Location = types.StringValue(route.Metadata.LocationResponse.Value)
-		}
-
-		// Update properties from response
-		propertiesMap := map[string]attr.Value{
-			"cloud_subnet":   types.StringValue(route.Properties.CloudSubnet),
-			"on_prem_subnet": types.StringValue(route.Properties.OnPremSubnet),
-		}
-
-		propertiesObj, diags := types.ObjectValue(map[string]attr.Type{
+	propertiesObj, diags := types.ObjectValue(
+		map[string]attr.Type{
 			"cloud_subnet":   types.StringType,
 			"on_prem_subnet": types.StringType,
-		}, propertiesMap)
-		resp.Diagnostics.Append(diags...)
-		if !resp.Diagnostics.HasError() {
-			data.Properties = propertiesObj
-		}
-
-		data.Tags = TagsToListPreserveNull(route.Metadata.Tags, data.Tags)
-	} else {
-		resp.State.RemoveResource(ctx)
-		return
+		},
+		map[string]attr.Value{
+			"cloud_subnet":   types.StringValue(route.CloudSubnet()),
+			"on_prem_subnet": types.StringValue(route.OnPremSubnet()),
+		},
+	)
+	resp.Diagnostics.Append(diags...)
+	if !resp.Diagnostics.HasError() {
+		data.Properties = propertiesObj
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -363,67 +253,8 @@ func (r *VPNRouteResource) Update(ctx context.Context, req resource.UpdateReques
 	var state VPNRouteResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// Get IDs from state (not plan) - IDs are immutable and should always be in state
-	projectID := state.ProjectId.ValueString()
-	vpnTunnelID := state.VPNTunnelId.ValueString()
-	routeID := state.Id.ValueString()
-
-	if projectID == "" || vpnTunnelID == "" || routeID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID, VPN Tunnel ID, and Route ID are required to update the VPN route",
-		)
-		return
-	}
-
-	// Get current VPN route details
-	getResponse, err := r.client.Client.FromNetwork().VPNRoutes().Get(ctx, projectID, vpnTunnelID, routeID, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error fetching current VPN route",
-			NewTransportError("read", "Vpnroute", err).Error(),
-		)
-		return
-	}
-
-	if getResponse == nil || getResponse.Data == nil {
-		resp.Diagnostics.AddError(
-			"VPN Route Not Found",
-			"VPN route not found or no data returned",
-		)
-		return
-	}
-
-	current := getResponse.Data
-
-	// Check if VPN route is in InCreation state
-	if current.Status.State != nil && *current.Status.State == "InCreation" {
-		resp.Diagnostics.AddError(
-			"Cannot Update VPN Route",
-			"Cannot update VPN route while it is in 'InCreation' state. Please wait until the VPN route is fully created.",
-		)
-		return
-	}
-
-	// Get region value
-	regionValue := ""
-	if current.Metadata.LocationResponse != nil {
-		regionValue = current.Metadata.LocationResponse.Value
-	}
-	if regionValue == "" {
-		resp.Diagnostics.AddError(
-			"Missing Region",
-			"Unable to determine region value for VPN route",
-		)
 		return
 	}
 
@@ -431,74 +262,55 @@ func (r *VPNRouteResource) Update(ctx context.Context, req resource.UpdateReques
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	if tags == nil {
-		tags = current.Metadata.Tags
-	}
 
-	// Extract properties
-	propertiesObj, diags := data.Properties.ToObjectValue(ctx)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
+	route, err := r.client.Client.FromNetwork().VPNRoutes().Get(ctx, vpnRouteRef(&state))
+	if provErr := CheckResponseErr("read", "VPNRoute", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	propertiesAttrs := propertiesObj.Attributes()
-	cloudSubnetAttr, ok := propertiesAttrs["cloud_subnet"].(types.String)
-	if !ok {
-		resp.Diagnostics.AddError("Invalid Type", "cloud_subnet must be a String")
-		return
+	route.Named(data.Name.ValueString())
+	if tags != nil {
+		route.RetaggedAs(tags...)
+	} else {
+		route.RetaggedAs(route.Tags()...)
 	}
-	cloudSubnet := cloudSubnetAttr.ValueString()
-
-	onPremSubnetAttr, ok := propertiesAttrs["on_prem_subnet"].(types.String)
-	if !ok {
-		resp.Diagnostics.AddError("Invalid Type", "on_prem_subnet must be a String")
-		return
+	// Update subnets from plan.
+	cloudSubnet, onPremSubnet := extractVPNRouteSubnets(&data)
+	if cloudSubnet != "" {
+		route.WithCloudSubnet(cloudSubnet)
 	}
-	onPremSubnet := onPremSubnetAttr.ValueString()
-
-	// Build update request
-	updateRequest := sdktypes.VPNRouteRequest{
-		Metadata: sdktypes.RegionalResourceMetadataRequest{
-			ResourceMetadataRequest: sdktypes.ResourceMetadataRequest{
-				Name: data.Name.ValueString(),
-				Tags: tags,
-			},
-			Location: sdktypes.LocationRequest{
-				Value: regionValue,
-			},
-		},
-		Properties: sdktypes.VPNRoutePropertiesRequest{
-			CloudSubnet:  cloudSubnet,
-			OnPremSubnet: onPremSubnet,
-		},
+	if onPremSubnet != "" {
+		route.WithOnPremSubnet(onPremSubnet)
 	}
 
-	// Update the VPN route using the SDK
-	response, err := r.client.Client.FromNetwork().VPNRoutes().Update(ctx, projectID, vpnTunnelID, routeID, updateRequest, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error updating VPN route",
-			NewTransportError("update", "Vpnroute", err).Error(),
-		)
+	updated, err := r.client.Client.FromNetwork().VPNRoutes().Update(ctx, route)
+	if provErr := CheckResponseErr("update", "VPNRoute", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	if apiErr := CheckResponse("update", "Vpnroute", response); apiErr != nil {
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
-		return
-	}
-
-	// Ensure immutable fields are set from state before saving
 	data.Id = state.Id
+	data.Uri = state.Uri
 	data.ProjectId = state.ProjectId
 	data.VPNTunnelId = state.VPNTunnelId
+	data.Location = state.Location
+	data.Name = types.StringValue(updated.Name())
+	data.Tags = TagsToListPreserveNull(updated.Tags(), data.Tags)
 
-	if response != nil && response.Data != nil {
-		// Update from response if available (should match state)
-		if response.Data.Metadata.ID != nil {
-			data.Id = types.StringValue(*response.Data.Metadata.ID)
-		}
+	propertiesObj, diags := types.ObjectValue(
+		map[string]attr.Type{
+			"cloud_subnet":   types.StringType,
+			"on_prem_subnet": types.StringType,
+		},
+		map[string]attr.Value{
+			"cloud_subnet":   types.StringValue(updated.CloudSubnet()),
+			"on_prem_subnet": types.StringValue(updated.OnPremSubnet()),
+		},
+	)
+	resp.Diagnostics.Append(diags...)
+	if !resp.Diagnostics.HasError() {
+		data.Properties = propertiesObj
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -511,26 +323,12 @@ func (r *VPNRouteResource) Delete(ctx context.Context, req resource.DeleteReques
 		return
 	}
 
-	projectID := data.ProjectId.ValueString()
-	vpnTunnelID := data.VPNTunnelId.ValueString()
+	ref := vpnRouteRef(&data)
 	routeID := data.Id.ValueString()
 
-	if projectID == "" || vpnTunnelID == "" || routeID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID, VPN Tunnel ID, and Route ID are required to delete the VPN route",
-		)
-		return
-	}
-
-	// Delete the VPN route using the SDK with retry mechanism
-	// Retry on any error except 404 (Resource Not Found)
 	deletionChecker := func(ctx context.Context) (bool, error) {
-		getResp, getErr := r.client.Client.FromNetwork().VPNRoutes().Get(ctx, projectID, vpnTunnelID, routeID, nil)
-		if getErr != nil {
-			return false, NewTransportError("get", "VPNRoute", getErr)
-		}
-		if provErr := CheckResponse("get", "VPNRoute", getResp); provErr != nil {
+		_, getErr := r.client.Client.FromNetwork().VPNRoutes().Get(ctx, ref)
+		if provErr := CheckResponseErr("get", "VPNRoute", getErr); provErr != nil {
 			if IsNotFound(provErr) {
 				return true, nil
 			}
@@ -540,37 +338,19 @@ func (r *VPNRouteResource) Delete(ctx context.Context, req resource.DeleteReques
 	}
 
 	deleteStart := time.Now()
-	err := DeleteResourceWithRetry(
-		ctx,
-		func() error {
-			resp, err := r.client.Client.FromNetwork().VPNRoutes().Delete(ctx, projectID, vpnTunnelID, routeID, nil)
-			if err != nil {
-				return NewTransportError("delete", "VPNRoute", err)
-			}
-			return CheckResponse("delete", "VPNRoute", resp)
-		},
-		"VPNRoute",
-		routeID,
-		r.client.ResourceTimeout,
-		deletionChecker,
-	)
-
+	err := DeleteResourceWithRetry(ctx, func() error {
+		return CheckResponseErr("delete", "VPNRoute",
+			r.client.Client.FromNetwork().VPNRoutes().Delete(ctx, ref))
+	}, "VPNRoute", routeID, r.client.ResourceTimeout, deletionChecker)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error deleting VPN route",
-			NewTransportError("delete", "Vpnroute", err).Error(),
-		)
+		resp.Diagnostics.AddError("Error deleting VPNRoute", err.Error())
 		return
 	}
-
 	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "VPNRoute", routeID, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
 		resp.Diagnostics.AddError("Error waiting for VPNRoute deletion", waitErr.Error())
 		return
 	}
-
-	tflog.Trace(ctx, "deleted a VPN Route resource", map[string]interface{}{
-		"vpnroute_id": routeID,
-	})
+	tflog.Trace(ctx, "deleted a VPN Route resource", map[string]interface{}{"vpnroute_id": routeID})
 }
 
 func (r *VPNRouteResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/internal/provider/vpntunnel_data_source.go
+++ b/internal/provider/vpntunnel_data_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -89,31 +90,27 @@ func (d *VPNTunnelDataSource) Read(ctx context.Context, req datasource.ReadReque
 		return
 	}
 
-	response, err := d.client.Client.FromNetwork().VPNTunnels().Get(ctx, projectID, tunnelID, nil)
-	if err != nil {
-		resp.Diagnostics.AddError("Error reading VPN tunnel", NewTransportError("read", "Vpntunnel", err).Error())
-		return
-	}
-	if apiErr := CheckResponse("read", "Vpntunnel", response); apiErr != nil {
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
-		return
-	}
-	if response == nil || response.Data == nil {
-		resp.Diagnostics.AddError("No data returned", "VPN Tunnel Get returned no data")
+	tunnel, err := d.client.Client.FromNetwork().VPNTunnels().Get(ctx,
+		aruba.VPNTunnelRef(projectID, tunnelID))
+	if provErr := CheckResponseErr("read", "VPNTunnel", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	tunnel := response.Data
-	if tunnel.Metadata.ID != nil {
-		data.Id = types.StringValue(*tunnel.Metadata.ID)
-	}
-	if tunnel.Metadata.Name != nil {
-		data.Name = types.StringValue(*tunnel.Metadata.Name)
-	}
+	data.Id = types.StringValue(tunnel.ID())
+	data.Name = types.StringValue(tunnel.Name())
 	data.ProjectId = types.StringValue(projectID)
-	// remote_peer and status are not directly available in the metadata response
-	data.RemotePeer = types.StringNull()
-	data.Status = types.StringNull()
+	// PeerClientPublicIP is the remote peer — exposed via wrapper accessor.
+	if peer := tunnel.PeerClientPublicIP(); peer != "" {
+		data.RemotePeer = types.StringValue(peer)
+	} else {
+		data.RemotePeer = types.StringNull()
+	}
+	if st := string(tunnel.State()); st != "" {
+		data.Status = types.StringValue(st)
+	} else {
+		data.Status = types.StringNull()
+	}
 
 	tflog.Trace(ctx, "read a VPN Tunnel data source", map[string]interface{}{"tunnel_id": tunnelID})
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/vpntunnel_resource.go
+++ b/internal/provider/vpntunnel_resource.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	sdktypes "github.com/Arubacloud/sdk-go/pkg/types"
+	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -225,19 +225,204 @@ func (r *VPNTunnelResource) Configure(ctx context.Context, req resource.Configur
 	r.client = client
 }
 
+func vpnTunnelRef(data *VPNTunnelResourceModel) aruba.Ref {
+	if !data.Uri.IsNull() && data.Uri.ValueString() != "" {
+		return aruba.URI(data.Uri.ValueString())
+	}
+	return aruba.VPNTunnelRef(data.ProjectId.ValueString(), data.Id.ValueString())
+}
+
+// buildVPNTunnel constructs a *aruba.VPNTunnel builder from model properties.
+func buildVPNTunnel(ctx context.Context, data *VPNTunnelResourceModel, tags []string) *aruba.VPNTunnel {
+	projectID := data.ProjectId.ValueString()
+
+	builder := aruba.NewVPNTunnel().
+		Named(data.Name.ValueString()).
+		InProject(aruba.URI("/projects/" + projectID)).
+		InRegion(aruba.Region(data.Location.ValueString())).
+		Tagged(tags...)
+
+	if data.Properties.IsNull() || data.Properties.IsUnknown() {
+		return builder
+	}
+	attrs := data.Properties.Attributes()
+
+	if v, ok := attrs["vpn_type"]; ok {
+		if s, ok := v.(types.String); ok && !s.IsNull() {
+			builder = builder.OfType(aruba.VPNType(s.ValueString()))
+		}
+	}
+	if v, ok := attrs["vpn_client_protocol"]; ok {
+		if s, ok := v.(types.String); ok && !s.IsNull() {
+			builder = builder.WithVPNClientProtocol(aruba.VPNClientProtocol(s.ValueString()))
+		}
+	}
+	if v, ok := attrs["billing_period"]; ok {
+		if s, ok := v.(types.String); ok && !s.IsNull() {
+			builder = builder.BilledBy(aruba.BillingPeriod(s.ValueString()))
+		}
+	}
+
+	// IP configurations
+	if v, ok := attrs["ip_configurations"]; ok {
+		if ipCfgObj, ok := v.(types.Object); ok && !ipCfgObj.IsNull() {
+			ipCfgAttrs := ipCfgObj.Attributes()
+			ipCfg := aruba.NewVPNIPConfig()
+
+			if vpcAttr, ok := ipCfgAttrs["vpc"]; ok {
+				if vpcObj, ok := vpcAttr.(types.Object); ok && !vpcObj.IsNull() {
+					if idAttr, ok := vpcObj.Attributes()["id"]; ok {
+						if s, ok := idAttr.(types.String); ok && !s.IsNull() {
+							vpcID := s.ValueString()
+							if !strings.HasPrefix(vpcID, "/") {
+								vpcID = fmt.Sprintf("/projects/%s/providers/Aruba.Network/vpcs/%s", projectID, vpcID)
+							}
+							ipCfg.WithVPC(aruba.URI(vpcID))
+						}
+					}
+				}
+			}
+			if subnetAttr, ok := ipCfgAttrs["subnet"]; ok {
+				if subnetObj, ok := subnetAttr.(types.Object); ok && !subnetObj.IsNull() {
+					if idAttr, ok := subnetObj.Attributes()["id"]; ok {
+						if s, ok := idAttr.(types.String); ok && !s.IsNull() {
+							// subnet name and CIDR — we use the id as name, CIDR left empty
+							ipCfg.WithSubnet(s.ValueString(), "")
+						}
+					}
+				}
+			}
+			if pubIPAttr, ok := ipCfgAttrs["public_ip"]; ok {
+				if pubIPObj, ok := pubIPAttr.(types.Object); ok && !pubIPObj.IsNull() {
+					if idAttr, ok := pubIPObj.Attributes()["id"]; ok {
+						if s, ok := idAttr.(types.String); ok && !s.IsNull() {
+							eipID := s.ValueString()
+							if !strings.HasPrefix(eipID, "/") {
+								eipID = fmt.Sprintf("/projects/%s/providers/Aruba.Network/elasticips/%s", projectID, eipID)
+							}
+							ipCfg.WithElasticIP(aruba.URI(eipID))
+						}
+					}
+				}
+			}
+			builder = builder.WithIPConfig(ipCfg)
+		}
+	}
+
+	// VPN client settings
+	if v, ok := attrs["vpn_client_settings"]; ok {
+		if clientObj, ok := v.(types.Object); ok && !clientObj.IsNull() {
+			clientAttrs := clientObj.Attributes()
+
+			if v, ok := clientAttrs["peer_client_public_ip"]; ok {
+				if s, ok := v.(types.String); ok && !s.IsNull() {
+					builder = builder.WithPeerClientPublicIP(s.ValueString())
+				}
+			}
+
+			if ikeAttr, ok := clientAttrs["ike"]; ok {
+				if ikeObj, ok := ikeAttr.(types.Object); ok && !ikeObj.IsNull() {
+					ike := aruba.NewVPNIKE()
+					ikeAttrs := ikeObj.Attributes()
+					if v, ok := ikeAttrs["lifetime"]; ok {
+						if n, ok := v.(types.Int64); ok && !n.IsNull() {
+							ike.WithLifetimeSeconds(int(n.ValueInt64()))
+						}
+					}
+					if v, ok := ikeAttrs["encryption"]; ok {
+						if s, ok := v.(types.String); ok && !s.IsNull() {
+							ike.WithEncryption(aruba.IKEEncryption(s.ValueString()))
+						}
+					}
+					if v, ok := ikeAttrs["hash"]; ok {
+						if s, ok := v.(types.String); ok && !s.IsNull() {
+							ike.WithHash(aruba.IKEHash(s.ValueString()))
+						}
+					}
+					if v, ok := ikeAttrs["dh_group"]; ok {
+						if s, ok := v.(types.String); ok && !s.IsNull() {
+							ike.WithDHGroup(aruba.IKEDHGroup(s.ValueString()))
+						}
+					}
+					if v, ok := ikeAttrs["dpd_action"]; ok {
+						if s, ok := v.(types.String); ok && !s.IsNull() {
+							ike.WithDPDAction(aruba.IKEDPDAction(s.ValueString()))
+						}
+					}
+					if v, ok := ikeAttrs["dpd_interval"]; ok {
+						if n, ok := v.(types.Int64); ok && !n.IsNull() {
+							ike.WithDPDIntervalSeconds(int(n.ValueInt64()))
+						}
+					}
+					if v, ok := ikeAttrs["dpd_timeout"]; ok {
+						if n, ok := v.(types.Int64); ok && !n.IsNull() {
+							ike.WithDPDTimeoutSeconds(int(n.ValueInt64()))
+						}
+					}
+					builder = builder.WithIKESettings(ike)
+				}
+			}
+
+			if espAttr, ok := clientAttrs["esp"]; ok {
+				if espObj, ok := espAttr.(types.Object); ok && !espObj.IsNull() {
+					esp := aruba.NewVPNESP()
+					espAttrs := espObj.Attributes()
+					if v, ok := espAttrs["lifetime"]; ok {
+						if n, ok := v.(types.Int64); ok && !n.IsNull() {
+							esp.WithLifetimeSeconds(int(n.ValueInt64()))
+						}
+					}
+					if v, ok := espAttrs["encryption"]; ok {
+						if s, ok := v.(types.String); ok && !s.IsNull() {
+							esp.WithEncryption(aruba.ESPEncryption(s.ValueString()))
+						}
+					}
+					if v, ok := espAttrs["hash"]; ok {
+						if s, ok := v.(types.String); ok && !s.IsNull() {
+							esp.WithHash(aruba.ESPHash(s.ValueString()))
+						}
+					}
+					if v, ok := espAttrs["pfs"]; ok {
+						if s, ok := v.(types.String); ok && !s.IsNull() {
+							esp.WithPFS(aruba.ESPPFSGroup(s.ValueString()))
+						}
+					}
+					builder = builder.WithESPSettings(esp)
+				}
+			}
+
+			if pskAttr, ok := clientAttrs["psk"]; ok {
+				if pskObj, ok := pskAttr.(types.Object); ok && !pskObj.IsNull() {
+					psk := aruba.NewVPNPSK()
+					pskAttrs := pskObj.Attributes()
+					if v, ok := pskAttrs["cloud_site"]; ok {
+						if s, ok := v.(types.String); ok && !s.IsNull() {
+							psk.WithCloudSite(s.ValueString())
+						}
+					}
+					if v, ok := pskAttrs["on_prem_site"]; ok {
+						if s, ok := v.(types.String); ok && !s.IsNull() {
+							psk.WithOnPremSite(s.ValueString())
+						}
+					}
+					if v, ok := pskAttrs["secret"]; ok {
+						if s, ok := v.(types.String); ok && !s.IsNull() {
+							psk.WithKey(s.ValueString())
+						}
+					}
+					builder = builder.WithPSKSettings(psk)
+				}
+			}
+		}
+	}
+
+	return builder
+}
+
 func (r *VPNTunnelResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data VPNTunnelResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	projectID := data.ProjectId.ValueString()
-	if projectID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Project ID",
-			"Project ID is required to create a VPN tunnel",
-		)
 		return
 	}
 
@@ -246,357 +431,22 @@ func (r *VPNTunnelResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	// Extract properties from Terraform object
-	propertiesObj, diags := data.Properties.ToObjectValue(ctx)
-	resp.Diagnostics.Append(diags...)
+	tunnel, err := r.client.Client.FromNetwork().VPNTunnels().Create(ctx, buildVPNTunnel(ctx, &data, tags))
+	if provErr := CheckResponseErr("create", "VPNTunnel", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
+		return
+	}
+
+	data.Id = types.StringValue(tunnel.ID())
+	data.Uri = strVal(tunnel.URI())
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	propertiesAttrs := propertiesObj.Attributes()
-
-	// Extract VPN type and protocol
-	vpnType := "Site-To-Site"
-	if vpnTypeAttr, ok := propertiesAttrs["vpn_type"]; ok && vpnTypeAttr != nil {
-		if vpnTypeStr, ok := vpnTypeAttr.(types.String); ok && !vpnTypeStr.IsNull() {
-			vpnType = vpnTypeStr.ValueString()
-		}
-	}
-
-	protocol := "ikev2"
-	if protocolAttr, ok := propertiesAttrs["vpn_client_protocol"]; ok && protocolAttr != nil {
-		if protocolStr, ok := protocolAttr.(types.String); ok && !protocolStr.IsNull() {
-			protocol = protocolStr.ValueString()
-		}
-	}
-
-	billingPeriod := "Hour"
-	if billingAttr, ok := propertiesAttrs["billing_period"]; ok && billingAttr != nil {
-		if billingStr, ok := billingAttr.(types.String); ok && !billingStr.IsNull() {
-			billingPeriod = billingStr.ValueString()
-		}
-	}
-
-	// Extract IP configurations
-	var ipConfig *sdktypes.IPConfigurations
-	if ipConfigAttr, ok := propertiesAttrs["ip_configurations"]; ok && ipConfigAttr != nil {
-		if ipConfigObj, ok := ipConfigAttr.(types.Object); ok && !ipConfigObj.IsNull() {
-			ipConfigObjValue, diags := ipConfigObj.ToObjectValue(ctx)
-			resp.Diagnostics.Append(diags...)
-			if !resp.Diagnostics.HasError() {
-				ipConfigAttrs := ipConfigObjValue.Attributes()
-				ipConfig = &sdktypes.IPConfigurations{}
-
-				// Extract VPC
-				if vpcAttr, ok := ipConfigAttrs["vpc"]; ok && vpcAttr != nil {
-					if vpcObj, ok := vpcAttr.(types.Object); ok && !vpcObj.IsNull() {
-						vpcObjValue, diags := vpcObj.ToObjectValue(ctx)
-						resp.Diagnostics.Append(diags...)
-						if !resp.Diagnostics.HasError() {
-							vpcAttrs := vpcObjValue.Attributes()
-							if vpcIDAttr, ok := vpcAttrs["id"]; ok && vpcIDAttr != nil {
-								if vpcIDStr, ok := vpcIDAttr.(types.String); ok && !vpcIDStr.IsNull() {
-									vpcID := vpcIDStr.ValueString()
-									if !strings.HasPrefix(vpcID, "/") {
-										vpcID = fmt.Sprintf("/projects/%s/providers/Aruba.Network/vpcs/%s", projectID, vpcID)
-									}
-									ipConfig.VPC = &sdktypes.ReferenceResource{URI: vpcID}
-								}
-							}
-						}
-					}
-				}
-
-				// Extract Subnet
-				if subnetAttr, ok := ipConfigAttrs["subnet"]; ok && subnetAttr != nil {
-					if subnetObj, ok := subnetAttr.(types.Object); ok && !subnetObj.IsNull() {
-						subnetObjValue, diags := subnetObj.ToObjectValue(ctx)
-						resp.Diagnostics.Append(diags...)
-						if !resp.Diagnostics.HasError() {
-							subnetAttrs := subnetObjValue.Attributes()
-							if subnetIDAttr, ok := subnetAttrs["id"]; ok && subnetIDAttr != nil {
-								if subnetIDStr, ok := subnetIDAttr.(types.String); ok && !subnetIDStr.IsNull() {
-									subnetID := subnetIDStr.ValueString()
-									if !strings.HasPrefix(subnetID, "/") {
-										// Need VPC ID for subnet URI - try to get from VPC if available
-										if ipConfig.VPC != nil {
-											// Extract VPC ID from URI
-											vpcURI := ipConfig.VPC.URI
-											parts := strings.Split(vpcURI, "/")
-											if len(parts) > 0 {
-												vpcID := parts[len(parts)-1]
-												subnetID = fmt.Sprintf("/projects/%s/providers/Aruba.Network/vpcs/%s/subnets/%s", projectID, vpcID, subnetID)
-											}
-										}
-									}
-									// Subnet field expects SubnetInfo, which has CIDR and Name fields
-									// Extract subnet name from URI or use the ID as name
-									subnetName := subnetID
-									if strings.Contains(subnetID, "/") {
-										parts := strings.Split(subnetID, "/")
-										if len(parts) > 0 {
-											subnetName = parts[len(parts)-1]
-										}
-									}
-									ipConfig.Subnet = &sdktypes.SubnetInfo{
-										Name: subnetName,
-										// CIDR can be empty if not provided
-									}
-								}
-							}
-						}
-					}
-				}
-
-				// Extract Public IP
-				if publicIPAttr, ok := ipConfigAttrs["public_ip"]; ok && publicIPAttr != nil {
-					if publicIPObj, ok := publicIPAttr.(types.Object); ok && !publicIPObj.IsNull() {
-						publicIPObjValue, diags := publicIPObj.ToObjectValue(ctx)
-						resp.Diagnostics.Append(diags...)
-						if !resp.Diagnostics.HasError() {
-							publicIPAttrs := publicIPObjValue.Attributes()
-							if publicIPIDAttr, ok := publicIPAttrs["id"]; ok && publicIPIDAttr != nil {
-								if publicIPIDStr, ok := publicIPIDAttr.(types.String); ok && !publicIPIDStr.IsNull() {
-									publicIPID := publicIPIDStr.ValueString()
-									if !strings.HasPrefix(publicIPID, "/") {
-										publicIPID = fmt.Sprintf("/projects/%s/providers/Aruba.Network/elasticips/%s", projectID, publicIPID)
-									}
-									ipConfig.PublicIP = &sdktypes.ReferenceResource{URI: publicIPID}
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-	}
-
-	// Extract VPN client settings
-	var vpnClientSettings *sdktypes.VPNClientSettings
-	if vpnClientAttr, ok := propertiesAttrs["vpn_client_settings"]; ok && vpnClientAttr != nil {
-		if vpnClientObj, ok := vpnClientAttr.(types.Object); ok && !vpnClientObj.IsNull() {
-			vpnClientObjValue, diags := vpnClientObj.ToObjectValue(ctx)
-			resp.Diagnostics.Append(diags...)
-			if !resp.Diagnostics.HasError() {
-				vpnClientAttrs := vpnClientObjValue.Attributes()
-				vpnClientSettings = &sdktypes.VPNClientSettings{}
-
-				// Extract IKE settings
-				if ikeAttr, ok := vpnClientAttrs["ike"]; ok && ikeAttr != nil {
-					if ikeObj, ok := ikeAttr.(types.Object); ok && !ikeObj.IsNull() {
-						ikeObjValue, diags := ikeObj.ToObjectValue(ctx)
-						resp.Diagnostics.Append(diags...)
-						if !resp.Diagnostics.HasError() {
-							ikeAttrs := ikeObjValue.Attributes()
-							ikeSettings := &sdktypes.IKESettings{}
-
-							if lifetimeAttr, ok := ikeAttrs["lifetime"]; ok && lifetimeAttr != nil {
-								if lifetimeInt, ok := lifetimeAttr.(types.Int64); ok && !lifetimeInt.IsNull() {
-									lifetime := int32(lifetimeInt.ValueInt64())
-									// Lifetime field expects int32, not *int32
-									ikeSettings.Lifetime = lifetime
-								}
-							}
-							if encryptionAttr, ok := ikeAttrs["encryption"]; ok && encryptionAttr != nil {
-								if encryptionStr, ok := encryptionAttr.(types.String); ok && !encryptionStr.IsNull() {
-									encryption := encryptionStr.ValueString()
-									ikeSettings.Encryption = &encryption
-								}
-							}
-							if hashAttr, ok := ikeAttrs["hash"]; ok && hashAttr != nil {
-								if hashStr, ok := hashAttr.(types.String); ok && !hashStr.IsNull() {
-									hash := hashStr.ValueString()
-									ikeSettings.Hash = &hash
-								}
-							}
-							if dhGroupAttr, ok := ikeAttrs["dh_group"]; ok && dhGroupAttr != nil {
-								if dhGroupStr, ok := dhGroupAttr.(types.String); ok && !dhGroupStr.IsNull() {
-									dhGroup := dhGroupStr.ValueString()
-									ikeSettings.DHGroup = &dhGroup
-								}
-							}
-							if dpdActionAttr, ok := ikeAttrs["dpd_action"]; ok && dpdActionAttr != nil {
-								if dpdActionStr, ok := dpdActionAttr.(types.String); ok && !dpdActionStr.IsNull() {
-									dpdAction := dpdActionStr.ValueString()
-									ikeSettings.DPDAction = &dpdAction
-								}
-							}
-							if dpdIntervalAttr, ok := ikeAttrs["dpd_interval"]; ok && dpdIntervalAttr != nil {
-								if dpdIntervalInt, ok := dpdIntervalAttr.(types.Int64); ok && !dpdIntervalInt.IsNull() {
-									dpdInterval := int32(dpdIntervalInt.ValueInt64())
-									// DPDInterval field expects int32, not *int32
-									ikeSettings.DPDInterval = dpdInterval
-								}
-							}
-							if dpdTimeoutAttr, ok := ikeAttrs["dpd_timeout"]; ok && dpdTimeoutAttr != nil {
-								if dpdTimeoutInt, ok := dpdTimeoutAttr.(types.Int64); ok && !dpdTimeoutInt.IsNull() {
-									dpdTimeout := int32(dpdTimeoutInt.ValueInt64())
-									// DPDTimeout field expects int32, not *int32
-									ikeSettings.DPDTimeout = dpdTimeout
-								}
-							}
-
-							vpnClientSettings.IKE = ikeSettings
-						}
-					}
-				}
-
-				// Extract ESP settings
-				if espAttr, ok := vpnClientAttrs["esp"]; ok && espAttr != nil {
-					if espObj, ok := espAttr.(types.Object); ok && !espObj.IsNull() {
-						espObjValue, diags := espObj.ToObjectValue(ctx)
-						resp.Diagnostics.Append(diags...)
-						if !resp.Diagnostics.HasError() {
-							espAttrs := espObjValue.Attributes()
-							espSettings := &sdktypes.ESPSettings{}
-
-							if lifetimeAttr, ok := espAttrs["lifetime"]; ok && lifetimeAttr != nil {
-								if lifetimeInt, ok := lifetimeAttr.(types.Int64); ok && !lifetimeInt.IsNull() {
-									lifetime := int32(lifetimeInt.ValueInt64())
-									// Lifetime field expects int32, not *int32
-									espSettings.Lifetime = lifetime
-								}
-							}
-							if encryptionAttr, ok := espAttrs["encryption"]; ok && encryptionAttr != nil {
-								if encryptionStr, ok := encryptionAttr.(types.String); ok && !encryptionStr.IsNull() {
-									encryption := encryptionStr.ValueString()
-									espSettings.Encryption = &encryption
-								}
-							}
-							if hashAttr, ok := espAttrs["hash"]; ok && hashAttr != nil {
-								if hashStr, ok := hashAttr.(types.String); ok && !hashStr.IsNull() {
-									hash := hashStr.ValueString()
-									espSettings.Hash = &hash
-								}
-							}
-							if pfsAttr, ok := espAttrs["pfs"]; ok && pfsAttr != nil {
-								if pfsStr, ok := pfsAttr.(types.String); ok && !pfsStr.IsNull() {
-									pfs := pfsStr.ValueString()
-									espSettings.PFS = &pfs
-								}
-							}
-
-							vpnClientSettings.ESP = espSettings
-						}
-					}
-				}
-
-				// Extract PSK settings
-				if pskAttr, ok := vpnClientAttrs["psk"]; ok && pskAttr != nil {
-					if pskObj, ok := pskAttr.(types.Object); ok && !pskObj.IsNull() {
-						pskObjValue, diags := pskObj.ToObjectValue(ctx)
-						resp.Diagnostics.Append(diags...)
-						if !resp.Diagnostics.HasError() {
-							pskAttrs := pskObjValue.Attributes()
-							pskSettings := &sdktypes.PSKSettings{}
-
-							if cloudSiteAttr, ok := pskAttrs["cloud_site"]; ok && cloudSiteAttr != nil {
-								if cloudSiteStr, ok := cloudSiteAttr.(types.String); ok && !cloudSiteStr.IsNull() {
-									cloudSite := cloudSiteStr.ValueString()
-									pskSettings.CloudSite = &cloudSite
-								}
-							}
-							if onPremSiteAttr, ok := pskAttrs["on_prem_site"]; ok && onPremSiteAttr != nil {
-								if onPremSiteStr, ok := onPremSiteAttr.(types.String); ok && !onPremSiteStr.IsNull() {
-									onPremSite := onPremSiteStr.ValueString()
-									pskSettings.OnPremSite = &onPremSite
-								}
-							}
-							if secretAttr, ok := pskAttrs["secret"]; ok && secretAttr != nil {
-								if secretStr, ok := secretAttr.(types.String); ok && !secretStr.IsNull() {
-									secret := secretStr.ValueString()
-									pskSettings.Secret = &secret
-								}
-							}
-
-							vpnClientSettings.PSK = pskSettings
-						}
-					}
-				}
-
-				// Extract peer client public IP
-				if peerIPAttr, ok := vpnClientAttrs["peer_client_public_ip"]; ok && peerIPAttr != nil {
-					if peerIPStr, ok := peerIPAttr.(types.String); ok && !peerIPStr.IsNull() {
-						peerIP := peerIPStr.ValueString()
-						vpnClientSettings.PeerClientPublicIP = &peerIP
-					}
-				}
-			}
-		}
-	}
-
-	// Build the create request
-	createRequest := sdktypes.VPNTunnelRequest{
-		Metadata: sdktypes.RegionalResourceMetadataRequest{
-			ResourceMetadataRequest: sdktypes.ResourceMetadataRequest{
-				Name: data.Name.ValueString(),
-				Tags: tags,
-			},
-			Location: sdktypes.LocationRequest{
-				Value: data.Location.ValueString(),
-			},
-		},
-		Properties: sdktypes.VPNTunnelPropertiesRequest{
-			VPNType:           &vpnType,
-			VPNClientProtocol: &protocol,
-			IPConfigurations:  ipConfig,
-			VPNClientSettings: vpnClientSettings,
-			BillingPlan: &sdktypes.BillingPeriodResource{
-				BillingPeriod: billingPeriod,
-			},
-		},
-	}
-
-	// Create the VPN tunnel using the SDK
-	response, err := r.client.Client.FromNetwork().VPNTunnels().Create(ctx, projectID, createRequest, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error creating VPN tunnel",
-			NewTransportError("create", "Vpntunnel", err).Error(),
-		)
-		return
-	}
-
-	if apiErr := CheckResponse("create", "Vpntunnel", response); apiErr != nil {
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
-		return
-	}
-
-	if response != nil && response.Data != nil {
-		if response.Data.Metadata.ID != nil {
-			data.Id = types.StringValue(*response.Data.Metadata.ID)
-		}
-		if response.Data.Metadata.URI != nil {
-			data.Uri = types.StringValue(*response.Data.Metadata.URI)
-		} else {
-			data.Uri = types.StringNull()
-		}
-	} else {
-		resp.Diagnostics.AddError(
-			"Invalid API Response",
-			"VPN tunnel created but no data returned from API",
-		)
-		return
-	}
-
-	// Wait for VPN Tunnel to be active before returning
-	// This ensures Terraform doesn't proceed to create dependent resources until VPN Tunnel is ready
-	tunnelID := data.Id.ValueString()
-	checker := func(ctx context.Context) (string, error) {
-		getResp, err := r.client.Client.FromNetwork().VPNTunnels().Get(ctx, projectID, tunnelID, nil)
-		if err != nil {
-			return "", err
-		}
-		if getResp != nil && getResp.Data != nil && getResp.Data.Status.State != nil {
-			return *getResp.Data.Status.State, nil
-		}
-		return "Unknown", nil
-	}
-
-	// Wait for VPN Tunnel to be active - block until ready (using configured timeout)
-	if err := WaitForResourceActive(ctx, checker, "VPNTunnel", tunnelID, r.client.ResourceTimeout); err != nil {
-		ReportWaitResult(&resp.Diagnostics, err, "VPNTunnel", tunnelID)
-		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	if waitErr := tunnel.WaitUntilReady(ctx, aruba.WithTimeout(r.client.ResourceTimeout)); waitErr != nil {
+		ReportWaitResult(&resp.Diagnostics, waitErr, "VPNTunnel", data.Id.ValueString())
 		return
 	}
 
@@ -604,7 +454,6 @@ func (r *VPNTunnelResource) Create(ctx context.Context, req resource.CreateReque
 		"vpntunnel_id":   data.Id.ValueString(),
 		"vpntunnel_name": data.Name.ValueString(),
 	})
-
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -614,112 +463,47 @@ func (r *VPNTunnelResource) Read(ctx context.Context, req resource.ReadRequest, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	projectID := data.ProjectId.ValueString()
-	tunnelID := data.Id.ValueString()
-
-	if data.Id.IsUnknown() || data.Id.IsNull() || tunnelID == "" {
-		tflog.Debug(ctx, "VPN Tunnel ID is empty, removing resource from state", map[string]interface{}{"tunnel_id": tunnelID})
+	if data.Id.IsNull() || data.Id.ValueString() == "" {
 		resp.State.RemoveResource(ctx)
 		return
 	}
-	if projectID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID is required to read the VPN tunnel",
-		)
-		return
-	}
 
-	// Get VPN tunnel details using the SDK
-	response, err := r.client.Client.FromNetwork().VPNTunnels().Get(ctx, projectID, tunnelID, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error reading VPN tunnel",
-			NewTransportError("read", "Vpntunnel", err).Error(),
-		)
-		return
-	}
-
-	if apiErr := CheckResponse("read", "Vpntunnel", response); apiErr != nil {
-		if IsNotFound(apiErr) {
+	tunnel, err := r.client.Client.FromNetwork().VPNTunnels().Get(ctx, vpnTunnelRef(&data))
+	if provErr := CheckResponseErr("read", "VPNTunnel", err); provErr != nil {
+		if IsNotFound(provErr) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	// If the resource is still provisioning (e.g. after a Create timeout that saved
-	// partial state), resume the wait so the next terraform apply reconciles correctly.
-	if response.Data.Status.State != nil {
-		switch st := *response.Data.Status.State; {
-		case isFailedState(st):
-			resp.Diagnostics.AddWarning(
-				"Resource in Failed State",
-				fmt.Sprintf("VPNTunnel %q is in a terminal failure state (%s). "+
-					"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", tunnelID, st),
-			)
-		case IsCreatingState(st):
-			checker := func(ctx context.Context) (string, error) {
-				getResp, err := r.client.Client.FromNetwork().VPNTunnels().Get(ctx, projectID, tunnelID, nil)
-				if err != nil {
-					return "", err
-				}
-				if getResp != nil && getResp.Data != nil && getResp.Data.Status.State != nil {
-					return *getResp.Data.Status.State, nil
-				}
-				return "Unknown", nil
-			}
-			if err := WaitForResourceActive(ctx, checker, "VPNTunnel", tunnelID, r.client.ResourceTimeout); err != nil {
-				ReportWaitResult(&resp.Diagnostics, err, "VPNTunnel", tunnelID)
-				resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-				return
-			}
-			// Re-read to get the final active state.
-			response, err = r.client.Client.FromNetwork().VPNTunnels().Get(ctx, projectID, tunnelID, nil)
-			if err != nil {
-				resp.Diagnostics.AddError("Error reading VPNTunnel after provisioning wait",
-					NewTransportError("read", "Vpntunnel", err).Error())
-				return
-			}
-			if apiErr := CheckResponse("read", "Vpntunnel", response); apiErr != nil {
-				if IsNotFound(apiErr) {
-					resp.State.RemoveResource(ctx)
-					return
-				}
-				resp.Diagnostics.AddError("API Error", apiErr.Error())
-				return
-			}
+	st := string(tunnel.State())
+	switch {
+	case isFailedState(st):
+		resp.Diagnostics.AddWarning("Resource in Failed State",
+			fmt.Sprintf("VPNTunnel %q is in a terminal failure state (%s). "+
+				"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", data.Id.ValueString(), st))
+	case IsCreatingState(st):
+		if waitErr := tunnel.WaitUntilReady(ctx, aruba.WithTimeout(r.client.ResourceTimeout)); waitErr != nil {
+			ReportWaitResult(&resp.Diagnostics, waitErr, "VPNTunnel", data.Id.ValueString())
+			return
+		}
+		tunnel, err = r.client.Client.FromNetwork().VPNTunnels().Get(ctx, vpnTunnelRef(&data))
+		if provErr := CheckResponseErr("read", "VPNTunnel", err); provErr != nil {
+			resp.Diagnostics.AddError("API Error", provErr.Error())
+			return
 		}
 	}
 
-	if response != nil && response.Data != nil {
-		tunnel := response.Data
-
-		if tunnel.Metadata.ID != nil {
-			data.Id = types.StringValue(*tunnel.Metadata.ID)
-		}
-		if tunnel.Metadata.URI != nil {
-			data.Uri = types.StringValue(*tunnel.Metadata.URI)
-		} else {
-			data.Uri = types.StringNull()
-		}
-		if tunnel.Metadata.Name != nil {
-			data.Name = types.StringValue(*tunnel.Metadata.Name)
-		}
-		if tunnel.Metadata.LocationResponse != nil {
-			data.Location = types.StringValue(tunnel.Metadata.LocationResponse.Value)
-		}
-
-		data.Tags = TagsToListPreserveNull(tunnel.Metadata.Tags, data.Tags)
-
-		// Note: Properties are complex nested structures - for now, we preserve the existing state
-		// A full implementation would reconstruct the properties object from the API response
-	} else {
-		resp.State.RemoveResource(ctx)
-		return
+	data.Id = types.StringValue(tunnel.ID())
+	data.Uri = strVal(tunnel.URI())
+	data.Name = types.StringValue(tunnel.Name())
+	data.Tags = TagsToListPreserveNull(tunnel.Tags(), data.Tags)
+	if tunnel.Region() != "" {
+		data.Location = types.StringValue(string(tunnel.Region()))
 	}
+	// Properties (PSK secrets etc.) are not returned by API — preserve existing state.
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -729,66 +513,8 @@ func (r *VPNTunnelResource) Update(ctx context.Context, req resource.UpdateReque
 	var state VPNTunnelResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// Get IDs from state (not plan) - IDs are immutable and should always be in state
-	projectID := state.ProjectId.ValueString()
-	tunnelID := state.Id.ValueString()
-
-	if projectID == "" || tunnelID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID and Tunnel ID are required to update the VPN tunnel",
-		)
-		return
-	}
-
-	// Get current VPN tunnel details
-	getResponse, err := r.client.Client.FromNetwork().VPNTunnels().Get(ctx, projectID, tunnelID, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error fetching current VPN tunnel",
-			NewTransportError("read", "Vpntunnel", err).Error(),
-		)
-		return
-	}
-
-	if getResponse == nil || getResponse.Data == nil {
-		resp.Diagnostics.AddError(
-			"VPN Tunnel Not Found",
-			"VPN tunnel not found or no data returned",
-		)
-		return
-	}
-
-	current := getResponse.Data
-
-	// Check if VPN tunnel is in InCreation state
-	if current.Status.State != nil && *current.Status.State == "InCreation" {
-		resp.Diagnostics.AddError(
-			"Cannot Update VPN Tunnel",
-			"Cannot update VPN tunnel while it is in 'InCreation' state. Please wait until the VPN tunnel is fully created.",
-		)
-		return
-	}
-
-	// Get region value
-	regionValue := ""
-	if current.Metadata.LocationResponse != nil {
-		regionValue = current.Metadata.LocationResponse.Value
-	}
-	if regionValue == "" {
-		resp.Diagnostics.AddError(
-			"Missing Region",
-			"Unable to determine region value for VPN tunnel",
-		)
 		return
 	}
 
@@ -796,56 +522,33 @@ func (r *VPNTunnelResource) Update(ctx context.Context, req resource.UpdateReque
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	if tags == nil {
-		tags = current.Metadata.Tags
-	}
 
-	// Build update request - only name and tags can be updated, properties must remain unchanged
-	updateRequest := sdktypes.VPNTunnelRequest{
-		Metadata: sdktypes.RegionalResourceMetadataRequest{
-			ResourceMetadataRequest: sdktypes.ResourceMetadataRequest{
-				Name: data.Name.ValueString(),
-				Tags: tags,
-			},
-			Location: sdktypes.LocationRequest{
-				Value: regionValue,
-			},
-		},
-		Properties: sdktypes.VPNTunnelPropertiesRequest{
-			// Properties cannot be updated - use current values
-			VPNType:           current.Properties.VPNType,
-			VPNClientProtocol: current.Properties.VPNClientProtocol,
-			IPConfigurations:  current.Properties.IPConfigurations,
-			VPNClientSettings: current.Properties.VPNClientSettings,
-			BillingPlan:       current.Properties.BillingPlan,
-		},
-	}
-
-	// Update the VPN tunnel using the SDK
-	response, err := r.client.Client.FromNetwork().VPNTunnels().Update(ctx, projectID, tunnelID, updateRequest, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error updating VPN tunnel",
-			NewTransportError("update", "Vpntunnel", err).Error(),
-		)
+	tunnel, err := r.client.Client.FromNetwork().VPNTunnels().Get(ctx, vpnTunnelRef(&state))
+	if provErr := CheckResponseErr("read", "VPNTunnel", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	if apiErr := CheckResponse("update", "Vpntunnel", response); apiErr != nil {
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
+	tunnel.Named(data.Name.ValueString())
+	if tags != nil {
+		tunnel.RetaggedAs(tags...)
+	} else {
+		tunnel.RetaggedAs(tunnel.Tags()...)
+	}
+
+	updated, err := r.client.Client.FromNetwork().VPNTunnels().Update(ctx, tunnel)
+	if provErr := CheckResponseErr("update", "VPNTunnel", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	// Ensure immutable fields are set from state before saving
 	data.Id = state.Id
+	data.Uri = state.Uri
 	data.ProjectId = state.ProjectId
-
-	if response != nil && response.Data != nil {
-		// Update from response if available (should match state)
-		if response.Data.Metadata.ID != nil {
-			data.Id = types.StringValue(*response.Data.Metadata.ID)
-		}
-	}
+	data.Location = state.Location
+	data.Properties = state.Properties // Properties are immutable — preserve from state.
+	data.Name = types.StringValue(updated.Name())
+	data.Tags = TagsToListPreserveNull(updated.Tags(), data.Tags)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -857,25 +560,12 @@ func (r *VPNTunnelResource) Delete(ctx context.Context, req resource.DeleteReque
 		return
 	}
 
-	projectID := data.ProjectId.ValueString()
+	ref := vpnTunnelRef(&data)
 	tunnelID := data.Id.ValueString()
 
-	if projectID == "" || tunnelID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID and Tunnel ID are required to delete the VPN tunnel",
-		)
-		return
-	}
-
-	// Delete the VPN tunnel using the SDK with retry mechanism
-	// Retry on any error except 404 (Resource Not Found)
 	deletionChecker := func(ctx context.Context) (bool, error) {
-		getResp, getErr := r.client.Client.FromNetwork().VPNTunnels().Get(ctx, projectID, tunnelID, nil)
-		if getErr != nil {
-			return false, NewTransportError("get", "VPNTunnel", getErr)
-		}
-		if provErr := CheckResponse("get", "VPNTunnel", getResp); provErr != nil {
+		_, getErr := r.client.Client.FromNetwork().VPNTunnels().Get(ctx, ref)
+		if provErr := CheckResponseErr("get", "VPNTunnel", getErr); provErr != nil {
 			if IsNotFound(provErr) {
 				return true, nil
 			}
@@ -885,37 +575,19 @@ func (r *VPNTunnelResource) Delete(ctx context.Context, req resource.DeleteReque
 	}
 
 	deleteStart := time.Now()
-	err := DeleteResourceWithRetry(
-		ctx,
-		func() error {
-			resp, err := r.client.Client.FromNetwork().VPNTunnels().Delete(ctx, projectID, tunnelID, nil)
-			if err != nil {
-				return NewTransportError("delete", "VPNTunnel", err)
-			}
-			return CheckResponse("delete", "VPNTunnel", resp)
-		},
-		"VPNTunnel",
-		tunnelID,
-		r.client.ResourceTimeout,
-		deletionChecker,
-	)
-
+	err := DeleteResourceWithRetry(ctx, func() error {
+		return CheckResponseErr("delete", "VPNTunnel",
+			r.client.Client.FromNetwork().VPNTunnels().Delete(ctx, ref))
+	}, "VPNTunnel", tunnelID, r.client.ResourceTimeout, deletionChecker)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error deleting VPN tunnel",
-			NewTransportError("delete", "Vpntunnel", err).Error(),
-		)
+		resp.Diagnostics.AddError("Error deleting VPNTunnel", err.Error())
 		return
 	}
-
 	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "VPNTunnel", tunnelID, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
 		resp.Diagnostics.AddError("Error waiting for VPNTunnel deletion", waitErr.Error())
 		return
 	}
-
-	tflog.Trace(ctx, "deleted a VPN Tunnel resource", map[string]interface{}{
-		"vpntunnel_id": tunnelID,
-	})
+	tflog.Trace(ctx, "deleted a VPN Tunnel resource", map[string]interface{}{"vpntunnel_id": tunnelID})
 }
 
 func (r *VPNTunnelResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {


### PR DESCRIPTION
## Summary

Migrates VPCPeering, VPCPeeringRoute, VPNTunnel, and VPNRoute (resources + data sources) to the sdk-go v1.0.4 builder/wrapper API. Eliminates all `pkg/types` imports from these 8 files.

- `vpcpeering_resource.go` — `NewVPCPeering().Named(...).InVPC(vpcRef).InRegion(...).PeeredWith(peerRef).Tagged(...)`
- `vpcpeeringroute_resource.go` — `NewVPCPeeringRoute().Named(...).InVPCPeering(peeringRef).WithLocalCIDR(...).WithRemoteCIDR(...).BilledBy(...)`
- `vpntunnel_resource.go` — `NewVPNTunnel()...WithIKESettings(NewVPNIKE()...).WithESPSettings(NewVPNESP()...).WithPSKSettings(NewVPNPSK()...)`
- `vpnroute_resource.go` — `NewVPNRoute().Named(...).InVPNTunnel(tunnelRef).InRegion(...).WithCloudSubnet(...).WithOnPremSubnet(...)`
- All four data sources updated to use new `Get(ctx, Ref)` signatures

## Notes
- VPNTunnel properties (IKE/ESP/PSK) are not reconstructed from API on Read since PSK secrets are write-only — existing state is preserved (matching prior behavior)
- VPCPeeringRoute uses name as ID (not UUID) — `data.Id = route.Name()` pattern preserved
- Peer VPC value (bare ID or full URI) is normalised to a provider URI before being passed to `PeeredWith()`

## Test plan
- [ ] Acceptance test `TestAccVPCPeeringResource` passes
- [ ] Acceptance test `TestAccVPCPeeringRouteResource` passes
- [ ] Acceptance test `TestAccVPNTunnelResource` passes
- [ ] Acceptance test `TestAccVPNRouteResource` passes
- [ ] `terraform import` works for all 4 resources

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)