### PR TITLE
refactor: migrate database resources (DBaaS, Database, Grant, Backup, User) to sdk-go v1.0.4 builder API

### DIFF
--- a/internal/provider/cloudserver_data_source.go
+++ b/internal/provider/cloudserver_data_source.go
@@ -163,7 +163,7 @@ func (d *CloudServerDataSource) Read(ctx context.Context, req datasource.ReadReq
 	data.Name = types.StringValue(server.Name())
 	data.ProjectID = types.StringValue(projectID)
 	data.Tags = TagsToListPreserveNull(server.Tags(), data.Tags)
-	data.FlavorName = types.StringValue(server.Flavor())
+	data.FlavorName = types.StringValue(string(server.Flavor()))
 	data.VpcUriRef = types.StringValue(server.VPC())
 	data.BootVolumeUriRef = types.StringValue(server.BootVolume())
 	data.KeyPairUriRef = types.StringValue(server.KeyPair())
@@ -173,7 +173,7 @@ func (d *CloudServerDataSource) Read(ctx context.Context, req datasource.ReadReq
 	raw := server.Raw()
 	if raw != nil {
 		if raw.Metadata.LocationResponse != nil {
-			data.Location = types.StringValue(raw.Metadata.LocationResponse.Value)
+			data.Location = types.StringValue(string(raw.Metadata.LocationResponse.Value))
 		} else {
 			data.Location = types.StringNull()
 		}

--- a/internal/provider/cloudserver_resource.go
+++ b/internal/provider/cloudserver_resource.go
@@ -411,9 +411,9 @@ func (r *CloudServerResource) applyServerToState(
 	raw := server.Raw()
 	if raw != nil {
 		if raw.Metadata.LocationResponse != nil && raw.Metadata.LocationResponse.Value != "" {
-			data.Location = types.StringValue(raw.Metadata.LocationResponse.Value)
+			data.Location = types.StringValue(string(raw.Metadata.LocationResponse.Value))
 		}
-		data.Zone = resolveAPIStringRef(raw.Properties.Zone, firstString(originalState, func(s *CloudServerResourceModel) types.String { return s.Zone }))
+		data.Zone = resolveAPIStringRef(string(raw.Properties.Zone), firstString(originalState, func(s *CloudServerResourceModel) types.String { return s.Zone }))
 	}
 
 	if originalState != nil {
@@ -447,7 +447,7 @@ func (r *CloudServerResource) applyServerToState(
 		}
 	}
 	settingsAttrs := map[string]attr.Value{
-		"flavor_name":      types.StringValue(server.Flavor()),
+		"flavor_name":      types.StringValue(string(server.Flavor())),
 		"key_pair_uri_ref": resolveKeyPairUriRef(server.KeyPair(), origSettings.KeyPairUriRef),
 		"user_data":        origSettings.UserData, // write-only; never returned by API
 	}
@@ -624,7 +624,7 @@ func (r *CloudServerResource) Delete(ctx context.Context, req resource.DeleteReq
 	err := DeleteResourceWithRetry(
 		ctx,
 		func() error {
-			_, delErr := r.client.Client.FromCompute().CloudServers().Delete(ctx, ref)
+			delErr := r.client.Client.FromCompute().CloudServers().Delete(ctx, ref)
 			return CheckResponseErr("delete", "CloudServer", delErr)
 		},
 		"CloudServer",

--- a/internal/provider/containerregistry_data_source.go
+++ b/internal/provider/containerregistry_data_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -138,62 +139,31 @@ func (d *ContainerRegistryDataSource) Read(ctx context.Context, req datasource.R
 		return
 	}
 
-	response, err := d.client.Client.FromContainer().ContainerRegistry().Get(ctx, projectID, registryID, nil)
-	if err != nil {
-		resp.Diagnostics.AddError("Error reading container registry", NewTransportError("read", "Containerregistry", err).Error())
-		return
-	}
-	if apiErr := CheckResponse("read", "Containerregistry", response); apiErr != nil {
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
-		return
-	}
-	if response == nil || response.Data == nil {
-		resp.Diagnostics.AddError("No data returned", "Container Registry Get returned no data")
+	registry, err := d.client.Client.FromContainer().ContainerRegistry().Get(ctx,
+		aruba.URI("/projects/"+projectID+"/providers/Aruba.Container/containerRegistries/"+registryID))
+	if provErr := CheckResponseErr("read", "ContainerRegistry", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	registry := response.Data
-	if registry.Metadata.ID != nil {
-		data.Id = types.StringValue(*registry.Metadata.ID)
-	}
-	if registry.Metadata.URI != nil {
-		data.Uri = types.StringValue(*registry.Metadata.URI)
-	} else {
-		data.Uri = types.StringNull()
-	}
-	if registry.Metadata.Name != nil {
-		data.Name = types.StringValue(*registry.Metadata.Name)
-	}
-	if registry.Metadata.LocationResponse != nil {
-		data.Location = types.StringValue(registry.Metadata.LocationResponse.Value)
+	data.Id = types.StringValue(registry.ID())
+	data.Uri = strVal(registry.URI())
+	data.Name = types.StringValue(registry.Name())
+	data.ProjectID = types.StringValue(projectID)
+	if registry.Region() != "" {
+		data.Location = types.StringValue(string(registry.Region()))
 	} else {
 		data.Location = types.StringNull()
 	}
-	data.ProjectID = types.StringValue(projectID)
-
-	if registry.Properties.BillingPlan.BillingPeriod != "" {
-		data.BillingPeriod = types.StringValue(registry.Properties.BillingPlan.BillingPeriod)
-	} else {
-		data.BillingPeriod = types.StringNull()
-	}
-	data.PublicIpUriRef = types.StringValue(registry.Properties.PublicIp.URI)
-	data.VpcUriRef = types.StringValue(registry.Properties.VPC.URI)
-	data.SubnetUriRef = types.StringValue(registry.Properties.Subnet.URI)
-	data.SecurityGroupUriRef = types.StringValue(registry.Properties.SecurityGroup.URI)
-	data.BlockStorageUriRef = types.StringValue(registry.Properties.BlockStorage.URI)
-
-	if registry.Properties.AdminUser.Username != "" {
-		data.AdminUser = types.StringValue(registry.Properties.AdminUser.Username)
-	} else {
-		data.AdminUser = types.StringNull()
-	}
-	if registry.Properties.ConcurrentUsers != nil && *registry.Properties.ConcurrentUsers != "" {
-		data.ConcurrentUsersFlavor = types.StringValue(*registry.Properties.ConcurrentUsers)
-	} else {
-		data.ConcurrentUsersFlavor = types.StringNull()
-	}
-
-	data.Tags = TagsToListPreserveNull(registry.Metadata.Tags, data.Tags)
+	data.Tags = TagsToListPreserveNull(registry.Tags(), data.Tags)
+	data.BillingPeriod = strVal(string(registry.BillingPeriod()))
+	data.PublicIpUriRef = types.StringValue(registry.ElasticIP())
+	data.VpcUriRef = types.StringValue(registry.VPC())
+	data.SubnetUriRef = types.StringValue(registry.Subnet())
+	data.SecurityGroupUriRef = types.StringValue(registry.SecurityGroup())
+	data.BlockStorageUriRef = types.StringValue(registry.BlockStorage())
+	data.AdminUser = strVal(registry.AdminUsername())
+	data.ConcurrentUsersFlavor = strVal(string(registry.SizeFlavor()))
 
 	tflog.Trace(ctx, "read a Container Registry data source", map[string]interface{}{"registry_id": registryID})
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/containerregistry_resource.go
+++ b/internal/provider/containerregistry_resource.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	sdktypes "github.com/Arubacloud/sdk-go/pkg/types"
+	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -105,30 +104,22 @@ func (r *ContainerRegistryResource) Schema(ctx context.Context, req resource.Sch
 					"public_ip_uri_ref": schema.StringAttribute{
 						MarkdownDescription: "URI of the Elastic IP that exposes the registry endpoint (e.g., `arubacloud_elasticip.example.uri`).",
 						Required:            true,
-						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.UseStateForUnknown(),
-						},
+						PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 					},
 					"vpc_uri_ref": schema.StringAttribute{
 						MarkdownDescription: "URI of the VPC that hosts the registry (e.g., `arubacloud_vpc.example.uri`).",
 						Required:            true,
-						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.UseStateForUnknown(),
-						},
+						PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 					},
 					"subnet_uri_ref": schema.StringAttribute{
 						MarkdownDescription: "URI of the subnet within the VPC (e.g., `arubacloud_subnet.example.uri`).",
 						Required:            true,
-						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.UseStateForUnknown(),
-						},
+						PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 					},
 					"security_group_uri_ref": schema.StringAttribute{
 						MarkdownDescription: "URI of the security group controlling registry traffic (e.g., `arubacloud_securitygroup.example.uri`).",
 						Required:            true,
-						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.UseStateForUnknown(),
-						},
+						PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 					},
 				},
 			},
@@ -139,9 +130,7 @@ func (r *ContainerRegistryResource) Schema(ctx context.Context, req resource.Sch
 					"block_storage_uri_ref": schema.StringAttribute{
 						MarkdownDescription: "URI of the block storage volume (e.g., `arubacloud_blockstorage.example.uri`).",
 						Required:            true,
-						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.UseStateForUnknown(),
-						},
+						PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 					},
 				},
 			},
@@ -178,19 +167,63 @@ func (r *ContainerRegistryResource) Configure(ctx context.Context, req resource.
 	r.client = client
 }
 
+func containerRegistryRef(data *ContainerRegistryResourceModel) aruba.Ref {
+	if !data.Uri.IsNull() && data.Uri.ValueString() != "" {
+		return aruba.URI(data.Uri.ValueString())
+	}
+	return aruba.URI("/projects/" + data.ProjectID.ValueString() +
+		"/providers/Aruba.Container/containerRegistries/" + data.Id.ValueString())
+}
+
+func applyContainerRegistryToModel(reg *aruba.ContainerRegistry, data *ContainerRegistryResourceModel) {
+	data.Id = types.StringValue(reg.ID())
+	data.Uri = strVal(reg.URI())
+	data.Name = types.StringValue(reg.Name())
+	data.Tags = TagsToListPreserveNull(reg.Tags(), data.Tags)
+	if reg.Region() != "" {
+		data.Location = types.StringValue(string(reg.Region()))
+	}
+	data.BillingPeriod = strVal(string(reg.BillingPeriod()))
+
+	networkObj, _ := types.ObjectValue(
+		map[string]attr.Type{
+			"public_ip_uri_ref":      types.StringType,
+			"vpc_uri_ref":            types.StringType,
+			"subnet_uri_ref":         types.StringType,
+			"security_group_uri_ref": types.StringType,
+		},
+		map[string]attr.Value{
+			"public_ip_uri_ref":      types.StringValue(reg.ElasticIP()),
+			"vpc_uri_ref":            types.StringValue(reg.VPC()),
+			"subnet_uri_ref":         types.StringValue(reg.Subnet()),
+			"security_group_uri_ref": types.StringValue(reg.SecurityGroup()),
+		},
+	)
+	data.Network = networkObj
+
+	storageObj, _ := types.ObjectValue(
+		map[string]attr.Type{"block_storage_uri_ref": types.StringType},
+		map[string]attr.Value{"block_storage_uri_ref": types.StringValue(reg.BlockStorage())},
+	)
+	data.Storage = storageObj
+
+	settingsObj, _ := types.ObjectValue(
+		map[string]attr.Type{
+			"admin_user":              types.StringType,
+			"concurrent_users_flavor": types.StringType,
+		},
+		map[string]attr.Value{
+			"admin_user":              strVal(reg.AdminUsername()),
+			"concurrent_users_flavor": strVal(string(reg.SizeFlavor())),
+		},
+	)
+	data.Settings = settingsObj
+}
+
 func (r *ContainerRegistryResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data ContainerRegistryResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	projectID := data.ProjectID.ValueString()
-	if projectID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Project ID",
-			"Project ID is required to create a container registry",
-		)
 		return
 	}
 
@@ -199,156 +232,81 @@ func (r *ContainerRegistryResource) Create(ctx context.Context, req resource.Cre
 		return
 	}
 
-	// Extract network configuration
 	var networkModel ContainerRegistryNetworkModel
-	diags := data.Network.As(ctx, &networkModel, basetypes.ObjectAsOptions{})
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(data.Network.As(ctx, &networkModel, basetypes.ObjectAsOptions{})...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Extract storage configuration
 	var storageModel ContainerRegistryStorageModel
-	diags = data.Storage.As(ctx, &storageModel, basetypes.ObjectAsOptions{})
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(data.Storage.As(ctx, &storageModel, basetypes.ObjectAsOptions{})...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Build the create request
-	createRequest := sdktypes.ContainerRegistryRequest{
-		Metadata: sdktypes.RegionalResourceMetadataRequest{
-			ResourceMetadataRequest: sdktypes.ResourceMetadataRequest{
-				Name: data.Name.ValueString(),
-				Tags: tags,
-			},
-			Location: sdktypes.LocationRequest{
-				Value: data.Location.ValueString(),
-			},
-		},
-		Properties: sdktypes.ContainerRegistryPropertiesRequest{
-			PublicIp: sdktypes.ReferenceResource{
-				URI: networkModel.PublicIpUriRef.ValueString(),
-			},
-			VPC: sdktypes.ReferenceResource{
-				URI: networkModel.VpcUriRef.ValueString(),
-			},
-			Subnet: sdktypes.ReferenceResource{
-				URI: networkModel.SubnetUriRef.ValueString(),
-			},
-			SecurityGroup: sdktypes.ReferenceResource{
-				URI: networkModel.SecurityGroupUriRef.ValueString(),
-			},
-			BlockStorage: sdktypes.ReferenceResource{
-				URI: storageModel.BlockStorageUriRef.ValueString(),
-			},
-		},
-	}
+	projectID := data.ProjectID.ValueString()
+	builder := aruba.NewContainerRegistry().
+		Named(data.Name.ValueString()).
+		InProject(aruba.URI("/projects/"+projectID)).
+		InRegion(aruba.Region(data.Location.ValueString())).
+		Tagged(tags...).
+		WithElasticIP(aruba.URI(networkModel.PublicIpUriRef.ValueString())).
+		WithVPC(aruba.URI(networkModel.VpcUriRef.ValueString())).
+		WithSubnet(aruba.URI(networkModel.SubnetUriRef.ValueString())).
+		WithSecurityGroup(aruba.URI(networkModel.SecurityGroupUriRef.ValueString())).
+		WithBlockStorage(aruba.URI(storageModel.BlockStorageUriRef.ValueString()))
 
-	// Add optional fields
 	if !data.BillingPeriod.IsNull() && !data.BillingPeriod.IsUnknown() {
-		createRequest.Properties.BillingPlan = &sdktypes.BillingPeriodResource{
-			BillingPeriod: data.BillingPeriod.ValueString(),
-		}
+		builder = builder.BilledBy(aruba.BillingPeriod(data.BillingPeriod.ValueString()))
 	}
 
-	// Extract settings if provided
 	if !data.Settings.IsNull() && !data.Settings.IsUnknown() {
 		var settingsModel ContainerRegistrySettingsModel
-		diags = data.Settings.As(ctx, &settingsModel, basetypes.ObjectAsOptions{})
-		resp.Diagnostics.Append(diags...)
+		resp.Diagnostics.Append(data.Settings.As(ctx, &settingsModel, basetypes.ObjectAsOptions{})...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
-
 		if !settingsModel.AdminUser.IsNull() && !settingsModel.AdminUser.IsUnknown() {
-			createRequest.Properties.AdminUser = &sdktypes.UserCredential{
-				Username: settingsModel.AdminUser.ValueString(),
-			}
+			builder = builder.WithAdminUsername(settingsModel.AdminUser.ValueString())
 		}
-
 		if !settingsModel.ConcurrentUsersFlavor.IsNull() && !settingsModel.ConcurrentUsersFlavor.IsUnknown() {
-			concurrentUsersFlavor := settingsModel.ConcurrentUsersFlavor.ValueString()
-			createRequest.Properties.ConcurrentUsers = &concurrentUsersFlavor
+			builder = builder.OfSize(aruba.ContainerRegistrySizeFlavor(settingsModel.ConcurrentUsersFlavor.ValueString()))
 		}
 	}
 
-	// Create the container registry using the SDK
-	containerClient := r.client.Client.FromContainer()
-	if containerClient == nil {
-		resp.Diagnostics.AddError(
-			"Container Client Not Available",
-			"Container client is not available",
-		)
+	registry, err := r.client.Client.FromContainer().ContainerRegistry().Create(ctx, builder)
+	if provErr := CheckResponseErr("create", "ContainerRegistry", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	registryClient := containerClient.ContainerRegistry()
-	if registryClient == nil {
-		resp.Diagnostics.AddError(
-			"Container Registry Client Not Available",
-			"Container Registry client is not available",
-		)
+	data.Id = types.StringValue(registry.ID())
+	data.Uri = strVal(registry.URI())
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	response, err := registryClient.Create(ctx, projectID, createRequest, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error creating container registry",
-			NewTransportError("create", "Containerregistry", err).Error(),
-		)
+	// ContainerRegistry can take 20-40 minutes to converge.
+	if waitErr := registry.WaitUntilReady(ctx, aruba.WithTimeout(40*time.Minute)); waitErr != nil {
+		ReportWaitResult(&resp.Diagnostics, waitErr, "ContainerRegistry", data.Id.ValueString())
 		return
 	}
 
-	if apiErr := CheckResponse("create", "Containerregistry", response); apiErr != nil {
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
-		return
-	}
-
-	if response != nil && response.Data != nil {
-		if response.Data.Metadata.ID != nil {
-			data.Id = types.StringValue(*response.Data.Metadata.ID)
-		}
-		if response.Data.Metadata.URI != nil {
-			data.Uri = types.StringValue(*response.Data.Metadata.URI)
-		} else {
-			data.Uri = types.StringNull()
-		}
+	fresh, freshErr := r.client.Client.FromContainer().ContainerRegistry().Get(ctx, containerRegistryRef(&data))
+	if freshErr == nil {
+		projectID := data.ProjectID
+		applyContainerRegistryToModel(fresh, &data)
+		data.ProjectID = projectID
 	} else {
-		resp.Diagnostics.AddError(
-			"Invalid API Response",
-			"Container registry created but no data returned from API",
-		)
-		return
-	}
-
-	// Wait for Container Registry to be active before returning
-	// This ensures Terraform doesn't proceed until Container Registry is ready
-	registryID := data.Id.ValueString()
-	checker := func(ctx context.Context) (string, error) {
-		getResp, err := registryClient.Get(ctx, projectID, registryID, nil)
-		if err != nil {
-			return "", err
-		}
-		if getResp != nil && getResp.Data != nil && getResp.Data.Status.State != nil {
-			return *getResp.Data.Status.State, nil
-		}
-		return "Unknown", nil
-	}
-
-	// Wait for Container Registry to be active - block until ready (using configured timeout)
-	if err := WaitForResourceActive(ctx, checker, "ContainerRegistry", registryID, r.client.ResourceTimeout); err != nil {
-		ReportWaitResult(&resp.Diagnostics, err, "ContainerRegistry", registryID)
-		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-		return
+		tflog.Warn(ctx, fmt.Sprintf("Failed to refresh ContainerRegistry after creation: %v", freshErr))
 	}
 
 	tflog.Trace(ctx, "created a Container Registry resource", map[string]interface{}{
 		"containerregistry_id":   data.Id.ValueString(),
 		"containerregistry_name": data.Name.ValueString(),
 	})
-
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -358,203 +316,42 @@ func (r *ContainerRegistryResource) Read(ctx context.Context, req resource.ReadR
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	projectID := data.ProjectID.ValueString()
-	registryID := data.Id.ValueString()
-
-	if data.Id.IsUnknown() || data.Id.IsNull() || registryID == "" {
-		tflog.Debug(ctx, "Container Registry ID is empty, removing resource from state", map[string]interface{}{"registry_id": registryID})
+	if data.Id.IsNull() || data.Id.ValueString() == "" {
 		resp.State.RemoveResource(ctx)
 		return
 	}
 
-	if projectID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID is required to read the container registry",
-		)
-		return
-	}
-
-	containerClient := r.client.Client.FromContainer()
-	if containerClient == nil {
-		resp.Diagnostics.AddError(
-			"Container Client Not Available",
-			"Container client is not available",
-		)
-		return
-	}
-
-	registryClient := containerClient.ContainerRegistry()
-	if registryClient == nil {
-		resp.Diagnostics.AddError(
-			"Container Registry Client Not Available",
-			"Container Registry client is not available",
-		)
-		return
-	}
-
-	// Get container registry details using the SDK
-	response, err := registryClient.Get(ctx, projectID, registryID, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error reading container registry",
-			NewTransportError("read", "Containerregistry", err).Error(),
-		)
-		return
-	}
-
-	if apiErr := CheckResponse("read", "Containerregistry", response); apiErr != nil {
-		if IsNotFound(apiErr) {
+	registry, err := r.client.Client.FromContainer().ContainerRegistry().Get(ctx, containerRegistryRef(&data))
+	if provErr := CheckResponseErr("read", "ContainerRegistry", err); provErr != nil {
+		if IsNotFound(provErr) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	// If the resource is still provisioning (e.g. after a Create timeout that saved
-	// partial state), resume the wait so the next terraform apply reconciles correctly.
-	if response.Data.Status.State != nil {
-		switch st := *response.Data.Status.State; {
-		case isFailedState(st):
-			resp.Diagnostics.AddWarning(
-				"Resource in Failed State",
-				fmt.Sprintf("ContainerRegistry %q is in a terminal failure state (%s). "+
-					"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", registryID, st),
-			)
-		case IsCreatingState(st):
-			checker := func(ctx context.Context) (string, error) {
-				getResp, err := registryClient.Get(ctx, projectID, registryID, nil)
-				if err != nil {
-					return "", err
-				}
-				if getResp != nil && getResp.Data != nil && getResp.Data.Status.State != nil {
-					return *getResp.Data.Status.State, nil
-				}
-				return "Unknown", nil
-			}
-			if err := WaitForResourceActive(ctx, checker, "ContainerRegistry", registryID, r.client.ResourceTimeout); err != nil {
-				ReportWaitResult(&resp.Diagnostics, err, "ContainerRegistry", registryID)
-				resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-				return
-			}
-			// Re-read to get the final active state.
-			response, err = registryClient.Get(ctx, projectID, registryID, nil)
-			if err != nil {
-				resp.Diagnostics.AddError("Error reading ContainerRegistry after provisioning wait",
-					NewTransportError("read", "Containerregistry", err).Error())
-				return
-			}
-			if apiErr := CheckResponse("read", "Containerregistry", response); apiErr != nil {
-				if IsNotFound(apiErr) {
-					resp.State.RemoveResource(ctx)
-					return
-				}
-				resp.Diagnostics.AddError("API Error", apiErr.Error())
-				return
-			}
+	st := string(registry.State())
+	switch {
+	case isFailedState(st):
+		resp.Diagnostics.AddWarning("Resource in Failed State",
+			fmt.Sprintf("ContainerRegistry %q is in a terminal failure state (%s). "+
+				"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", data.Id.ValueString(), st))
+	case IsCreatingState(st):
+		if waitErr := registry.WaitUntilReady(ctx, aruba.WithTimeout(40*time.Minute)); waitErr != nil {
+			ReportWaitResult(&resp.Diagnostics, waitErr, "ContainerRegistry", data.Id.ValueString())
+			return
+		}
+		registry, err = r.client.Client.FromContainer().ContainerRegistry().Get(ctx, containerRegistryRef(&data))
+		if provErr := CheckResponseErr("read", "ContainerRegistry", err); provErr != nil {
+			resp.Diagnostics.AddError("API Error", provErr.Error())
+			return
 		}
 	}
 
-	if response != nil && response.Data != nil {
-		registry := response.Data
-
-		if registry.Metadata.ID != nil {
-			data.Id = types.StringValue(*registry.Metadata.ID)
-		}
-		if registry.Metadata.URI != nil {
-			data.Uri = types.StringValue(*registry.Metadata.URI)
-		} else {
-			data.Uri = types.StringNull()
-		}
-		if registry.Metadata.Name != nil {
-			data.Name = types.StringValue(*registry.Metadata.Name)
-		}
-		if registry.Metadata.LocationResponse != nil {
-			data.Location = types.StringValue(registry.Metadata.LocationResponse.Value)
-		}
-
-		// Build network object
-		networkAttrs := map[string]attr.Value{
-			"public_ip_uri_ref":      types.StringValue(registry.Properties.PublicIp.URI),
-			"vpc_uri_ref":            types.StringValue(registry.Properties.VPC.URI),
-			"subnet_uri_ref":         types.StringValue(registry.Properties.Subnet.URI),
-			"security_group_uri_ref": types.StringValue(registry.Properties.SecurityGroup.URI),
-		}
-		networkObj, diags := types.ObjectValue(
-			map[string]attr.Type{
-				"public_ip_uri_ref":      types.StringType,
-				"vpc_uri_ref":            types.StringType,
-				"subnet_uri_ref":         types.StringType,
-				"security_group_uri_ref": types.StringType,
-			},
-			networkAttrs,
-		)
-		resp.Diagnostics.Append(diags...)
-		if !resp.Diagnostics.HasError() {
-			data.Network = networkObj
-		}
-
-		// Build storage object
-		storageAttrs := map[string]attr.Value{
-			"block_storage_uri_ref": types.StringValue(registry.Properties.BlockStorage.URI),
-		}
-		storageObj, diags := types.ObjectValue(
-			map[string]attr.Type{
-				"block_storage_uri_ref": types.StringType,
-			},
-			storageAttrs,
-		)
-		resp.Diagnostics.Append(diags...)
-		if !resp.Diagnostics.HasError() {
-			data.Storage = storageObj
-		}
-
-		// Build settings object if there are any settings
-		var settingsAdminUser types.String
-		var settingsConcurrentUsersFlavor types.String
-
-		if registry.Properties.AdminUser.Username != "" {
-			settingsAdminUser = types.StringValue(registry.Properties.AdminUser.Username)
-		} else {
-			settingsAdminUser = types.StringNull()
-		}
-
-		if registry.Properties.ConcurrentUsers != nil && *registry.Properties.ConcurrentUsers != "" {
-			settingsConcurrentUsersFlavor = types.StringValue(*registry.Properties.ConcurrentUsers)
-		} else {
-			settingsConcurrentUsersFlavor = types.StringNull()
-		}
-
-		settingsAttrs := map[string]attr.Value{
-			"admin_user":              settingsAdminUser,
-			"concurrent_users_flavor": settingsConcurrentUsersFlavor,
-		}
-		settingsObj, diags := types.ObjectValue(
-			map[string]attr.Type{
-				"admin_user":              types.StringType,
-				"concurrent_users_flavor": types.StringType,
-			},
-			settingsAttrs,
-		)
-		resp.Diagnostics.Append(diags...)
-		if !resp.Diagnostics.HasError() {
-			data.Settings = settingsObj
-		}
-
-		if registry.Properties.BillingPlan.BillingPeriod != "" {
-			data.BillingPeriod = types.StringValue(registry.Properties.BillingPlan.BillingPeriod)
-		} else {
-			data.BillingPeriod = types.StringNull()
-		}
-
-		data.Tags = TagsToListPreserveNull(registry.Metadata.Tags, data.Tags)
-	} else {
-		resp.State.RemoveResource(ctx)
-		return
-	}
-
+	projectID := data.ProjectID
+	applyContainerRegistryToModel(registry, &data)
+	data.ProjectID = projectID
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -563,75 +360,8 @@ func (r *ContainerRegistryResource) Update(ctx context.Context, req resource.Upd
 	var state ContainerRegistryResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// Get IDs from state (not plan) - IDs are immutable and should always be in state
-	projectID := state.ProjectID.ValueString()
-	registryID := state.Id.ValueString()
-
-	if projectID == "" || registryID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID and Registry ID are required to update the container registry",
-		)
-		return
-	}
-
-	containerClient := r.client.Client.FromContainer()
-	if containerClient == nil {
-		resp.Diagnostics.AddError(
-			"Container Client Not Available",
-			"Container client is not available",
-		)
-		return
-	}
-
-	registryClient := containerClient.ContainerRegistry()
-	if registryClient == nil {
-		resp.Diagnostics.AddError(
-			"Container Registry Client Not Available",
-			"Container Registry client is not available",
-		)
-		return
-	}
-
-	// Get current container registry details
-	getResponse, err := registryClient.Get(ctx, projectID, registryID, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error fetching current container registry",
-			NewTransportError("read", "Containerregistry", err).Error(),
-		)
-		return
-	}
-
-	if getResponse == nil || getResponse.Data == nil {
-		resp.Diagnostics.AddError(
-			"Container Registry Not Found",
-			"Container registry not found or no data returned",
-		)
-		return
-	}
-
-	current := getResponse.Data
-
-	// Get region value
-	regionValue := ""
-	if current.Metadata.LocationResponse != nil {
-		regionValue = current.Metadata.LocationResponse.Value
-	}
-	if regionValue == "" {
-		resp.Diagnostics.AddError(
-			"Missing Region",
-			"Unable to determine region value for container registry",
-		)
 		return
 	}
 
@@ -639,252 +369,71 @@ func (r *ContainerRegistryResource) Update(ctx context.Context, req resource.Upd
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	if tags == nil {
-		tags = current.Metadata.Tags
-	}
 
-	// Extract network configuration from plan
-	var networkModel ContainerRegistryNetworkModel
-	var diags diag.Diagnostics
-	diags = data.Network.As(ctx, &networkModel, basetypes.ObjectAsOptions{})
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
+	registry, err := r.client.Client.FromContainer().ContainerRegistry().Get(ctx, containerRegistryRef(&state))
+	if provErr := CheckResponseErr("read", "ContainerRegistry", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	// Extract storage configuration from plan
-	var storageModel ContainerRegistryStorageModel
-	diags = data.Storage.As(ctx, &storageModel, basetypes.ObjectAsOptions{})
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
+	registry.Named(data.Name.ValueString())
+	if tags != nil {
+		registry.RetaggedAs(tags...)
+	} else {
+		registry.RetaggedAs(registry.Tags()...)
 	}
 
-	// Build update request - use ContainerRegistryRequest for updates (same as create)
-	updateRequest := sdktypes.ContainerRegistryRequest{
-		Metadata: sdktypes.RegionalResourceMetadataRequest{
-			ResourceMetadataRequest: sdktypes.ResourceMetadataRequest{
-				Name: data.Name.ValueString(),
-				Tags: tags,
-			},
-			Location: sdktypes.LocationRequest{
-				Value: regionValue,
-			},
-		},
-		Properties: sdktypes.ContainerRegistryPropertiesRequest{
-			// Use network configuration from plan
-			PublicIp: sdktypes.ReferenceResource{
-				URI: networkModel.PublicIpUriRef.ValueString(),
-			},
-			VPC: sdktypes.ReferenceResource{
-				URI: networkModel.VpcUriRef.ValueString(),
-			},
-			Subnet: sdktypes.ReferenceResource{
-				URI: networkModel.SubnetUriRef.ValueString(),
-			},
-			SecurityGroup: sdktypes.ReferenceResource{
-				URI: networkModel.SecurityGroupUriRef.ValueString(),
-			},
-			BlockStorage: sdktypes.ReferenceResource{
-				URI: storageModel.BlockStorageUriRef.ValueString(),
-			},
-		},
-	}
-
-	// Update billing period if provided, otherwise preserve current
 	if !data.BillingPeriod.IsNull() && !data.BillingPeriod.IsUnknown() {
-		updateRequest.Properties.BillingPlan = &sdktypes.BillingPeriodResource{
-			BillingPeriod: data.BillingPeriod.ValueString(),
-		}
-	} else if current.Properties.BillingPlan.BillingPeriod != "" {
-		updateRequest.Properties.BillingPlan = &sdktypes.BillingPeriodResource{
-			BillingPeriod: current.Properties.BillingPlan.BillingPeriod,
-		}
+		registry.BilledBy(aruba.BillingPeriod(data.BillingPeriod.ValueString()))
 	}
 
-	// Extract and update settings if provided
-	if !data.Settings.IsNull() && !data.Settings.IsUnknown() {
-		var settingsModel ContainerRegistrySettingsModel
-		diags = data.Settings.As(ctx, &settingsModel, basetypes.ObjectAsOptions{})
-		resp.Diagnostics.Append(diags...)
+	if !data.Network.IsNull() && !data.Network.IsUnknown() {
+		var networkModel ContainerRegistryNetworkModel
+		resp.Diagnostics.Append(data.Network.As(ctx, &networkModel, basetypes.ObjectAsOptions{})...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
+		registry.WithElasticIP(aruba.URI(networkModel.PublicIpUriRef.ValueString())).
+			WithVPC(aruba.URI(networkModel.VpcUriRef.ValueString())).
+			WithSubnet(aruba.URI(networkModel.SubnetUriRef.ValueString())).
+			WithSecurityGroup(aruba.URI(networkModel.SecurityGroupUriRef.ValueString()))
+	}
 
-		if !settingsModel.AdminUser.IsNull() && !settingsModel.AdminUser.IsUnknown() {
-			updateRequest.Properties.AdminUser = &sdktypes.UserCredential{
-				Username: settingsModel.AdminUser.ValueString(),
-			}
-		} else if current.Properties.AdminUser.Username != "" {
-			updateRequest.Properties.AdminUser = &sdktypes.UserCredential{
-				Username: current.Properties.AdminUser.Username,
-			}
+	if !data.Storage.IsNull() && !data.Storage.IsUnknown() {
+		var storageModel ContainerRegistryStorageModel
+		resp.Diagnostics.Append(data.Storage.As(ctx, &storageModel, basetypes.ObjectAsOptions{})...)
+		if resp.Diagnostics.HasError() {
+			return
 		}
+		registry.WithBlockStorage(aruba.URI(storageModel.BlockStorageUriRef.ValueString()))
+	}
 
-		if !settingsModel.ConcurrentUsersFlavor.IsNull() && !settingsModel.ConcurrentUsersFlavor.IsUnknown() {
-			concurrentUsersFlavor := settingsModel.ConcurrentUsersFlavor.ValueString()
-			updateRequest.Properties.ConcurrentUsers = &concurrentUsersFlavor
-		} else if current.Properties.ConcurrentUsers != nil {
-			updateRequest.Properties.ConcurrentUsers = current.Properties.ConcurrentUsers
+	if !data.Settings.IsNull() && !data.Settings.IsUnknown() {
+		var settingsModel ContainerRegistrySettingsModel
+		resp.Diagnostics.Append(data.Settings.As(ctx, &settingsModel, basetypes.ObjectAsOptions{})...)
+		if resp.Diagnostics.HasError() {
+			return
 		}
-	} else {
-		// Preserve current settings if not in plan
-		if current.Properties.AdminUser.Username != "" {
-			updateRequest.Properties.AdminUser = &sdktypes.UserCredential{
-				Username: current.Properties.AdminUser.Username,
-			}
+		if !settingsModel.AdminUser.IsNull() {
+			registry.WithAdminUsername(settingsModel.AdminUser.ValueString())
 		}
-		if current.Properties.ConcurrentUsers != nil {
-			updateRequest.Properties.ConcurrentUsers = current.Properties.ConcurrentUsers
+		if !settingsModel.ConcurrentUsersFlavor.IsNull() {
+			registry.OfSize(aruba.ContainerRegistrySizeFlavor(settingsModel.ConcurrentUsersFlavor.ValueString()))
 		}
 	}
 
-	// Update the container registry using the SDK
-	response, err := registryClient.Update(ctx, projectID, registryID, updateRequest, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error updating container registry",
-			NewTransportError("update", "Containerregistry", err).Error(),
-		)
+	updated, err := r.client.Client.FromContainer().ContainerRegistry().Update(ctx, registry)
+	if provErr := CheckResponseErr("update", "ContainerRegistry", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	if apiErr := CheckResponse("update", "Containerregistry", response); apiErr != nil {
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
-		return
-	}
-
-	// Ensure immutable fields are set from state before saving
 	data.Id = state.Id
-	data.Uri = state.Uri // Preserve URI from state
 	data.ProjectID = state.ProjectID
-	data.Network = state.Network
-	data.Storage = state.Storage
-	data.Settings = state.Settings
-
-	if response != nil && response.Data != nil {
-		// Update from response if available (should match state)
-		if response.Data.Metadata.ID != nil {
-			data.Id = types.StringValue(*response.Data.Metadata.ID)
-		}
-		if response.Data.Metadata.URI != nil {
-			data.Uri = types.StringValue(*response.Data.Metadata.URI)
-		}
-	} else {
-		// If no response, re-read the container registry to get the latest state including URI
-		getResp, err := registryClient.Get(ctx, projectID, registryID, nil)
-		if err == nil && getResp != nil && getResp.Data != nil {
-			if getResp.Data.Metadata.URI != nil {
-				data.Uri = types.StringValue(*getResp.Data.Metadata.URI)
-			} else {
-				data.Uri = state.Uri // Fallback to state if not in response
-			}
-		} else {
-			// If re-read fails, preserve from state
-			data.Uri = state.Uri
-		}
-	}
-
-	// Re-read to get the latest state and update all fields
-	getResp, err := registryClient.Get(ctx, projectID, registryID, nil)
-	if err == nil && getResp != nil && getResp.Data != nil {
-		registry := getResp.Data
-		// Update URI if available
-		if registry.Metadata.URI != nil {
-			data.Uri = types.StringValue(*registry.Metadata.URI)
-		} else {
-			data.Uri = state.Uri // Fallback to state if not available
-		}
-
-		// Build network object from response
-		networkAttrs := map[string]attr.Value{
-			"public_ip_uri_ref":      types.StringValue(registry.Properties.PublicIp.URI),
-			"vpc_uri_ref":            types.StringValue(registry.Properties.VPC.URI),
-			"subnet_uri_ref":         types.StringValue(registry.Properties.Subnet.URI),
-			"security_group_uri_ref": types.StringValue(registry.Properties.SecurityGroup.URI),
-		}
-		networkObj, diagsNetwork := types.ObjectValue(
-			map[string]attr.Type{
-				"public_ip_uri_ref":      types.StringType,
-				"vpc_uri_ref":            types.StringType,
-				"subnet_uri_ref":         types.StringType,
-				"security_group_uri_ref": types.StringType,
-			},
-			networkAttrs,
-		)
-		resp.Diagnostics.Append(diagsNetwork...)
-		if !resp.Diagnostics.HasError() {
-			data.Network = networkObj
-		}
-
-		// Build storage object from response
-		storageAttrs := map[string]attr.Value{
-			"block_storage_uri_ref": types.StringValue(registry.Properties.BlockStorage.URI),
-		}
-		storageObj, diagsStorage := types.ObjectValue(
-			map[string]attr.Type{
-				"block_storage_uri_ref": types.StringType,
-			},
-			storageAttrs,
-		)
-		resp.Diagnostics.Append(diagsStorage...)
-		if !resp.Diagnostics.HasError() {
-			data.Storage = storageObj
-		}
-
-		// Build settings object from response
-		var settingsAdminUser types.String
-		var settingsConcurrentUsersFlavor types.String
-
-		if registry.Properties.AdminUser != nil && registry.Properties.AdminUser.Username != "" {
-			settingsAdminUser = types.StringValue(registry.Properties.AdminUser.Username)
-		} else {
-			settingsAdminUser = types.StringNull()
-		}
-
-		if registry.Properties.ConcurrentUsers != nil && *registry.Properties.ConcurrentUsers != "" {
-			settingsConcurrentUsersFlavor = types.StringValue(*registry.Properties.ConcurrentUsers)
-		} else {
-			settingsConcurrentUsersFlavor = types.StringNull()
-		}
-
-		settingsAttrs := map[string]attr.Value{
-			"admin_user":              settingsAdminUser,
-			"concurrent_users_flavor": settingsConcurrentUsersFlavor,
-		}
-		settingsObj, diagsSettings := types.ObjectValue(
-			map[string]attr.Type{
-				"admin_user":              types.StringType,
-				"concurrent_users_flavor": types.StringType,
-			},
-			settingsAttrs,
-		)
-		resp.Diagnostics.Append(diagsSettings...)
-		if !resp.Diagnostics.HasError() {
-			data.Settings = settingsObj
-		}
-
-		// Update other fields from re-read to ensure consistency
-		if registry.Metadata.Name != nil {
-			data.Name = types.StringValue(*registry.Metadata.Name)
-		}
-		if registry.Metadata.LocationResponse != nil {
-			data.Location = types.StringValue(registry.Metadata.LocationResponse.Value)
-		}
-		if registry.Properties.BillingPlan != nil && registry.Properties.BillingPlan.BillingPeriod != "" {
-			data.BillingPeriod = types.StringValue(registry.Properties.BillingPlan.BillingPeriod)
-		} else {
-			data.BillingPeriod = types.StringNull()
-		}
-
-		data.Tags = TagsToListPreserveNull(registry.Metadata.Tags, data.Tags)
-	} else {
-		// If re-read fails, preserve immutable fields from state
-		data.Uri = state.Uri
-		data.Network = state.Network
-		data.Storage = state.Storage
-		data.Settings = state.Settings
-	}
+	projectID := data.ProjectID
+	applyContainerRegistryToModel(updated, &data)
+	data.ProjectID = projectID
+	data.Id = state.Id
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -896,43 +445,12 @@ func (r *ContainerRegistryResource) Delete(ctx context.Context, req resource.Del
 		return
 	}
 
-	projectID := data.ProjectID.ValueString()
+	ref := containerRegistryRef(&data)
 	registryID := data.Id.ValueString()
 
-	if projectID == "" || registryID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID and Registry ID are required to delete the container registry",
-		)
-		return
-	}
-
-	containerClient := r.client.Client.FromContainer()
-	if containerClient == nil {
-		resp.Diagnostics.AddError(
-			"Container Client Not Available",
-			"Container client is not available",
-		)
-		return
-	}
-
-	registryClient := containerClient.ContainerRegistry()
-	if registryClient == nil {
-		resp.Diagnostics.AddError(
-			"Container Registry Client Not Available",
-			"Container Registry client is not available",
-		)
-		return
-	}
-
-	// Delete the container registry using the SDK with retry mechanism
-	// Retry on any error except 404 (Resource Not Found)
 	deletionChecker := func(ctx context.Context) (bool, error) {
-		getResp, getErr := r.client.Client.FromContainer().ContainerRegistry().Get(ctx, projectID, registryID, nil)
-		if getErr != nil {
-			return false, NewTransportError("get", "ContainerRegistry", getErr)
-		}
-		if provErr := CheckResponse("get", "ContainerRegistry", getResp); provErr != nil {
+		_, getErr := r.client.Client.FromContainer().ContainerRegistry().Get(ctx, ref)
+		if provErr := CheckResponseErr("get", "ContainerRegistry", getErr); provErr != nil {
 			if IsNotFound(provErr) {
 				return true, nil
 			}
@@ -942,37 +460,19 @@ func (r *ContainerRegistryResource) Delete(ctx context.Context, req resource.Del
 	}
 
 	deleteStart := time.Now()
-	err := DeleteResourceWithRetry(
-		ctx,
-		func() error {
-			resp, err := registryClient.Delete(ctx, projectID, registryID, nil)
-			if err != nil {
-				return NewTransportError("delete", "ContainerRegistry", err)
-			}
-			return CheckResponse("delete", "ContainerRegistry", resp)
-		},
-		"ContainerRegistry",
-		registryID,
-		r.client.ResourceTimeout,
-		deletionChecker,
-	)
-
+	err := DeleteResourceWithRetry(ctx, func() error {
+		return CheckResponseErr("delete", "ContainerRegistry",
+			r.client.Client.FromContainer().ContainerRegistry().Delete(ctx, ref))
+	}, "ContainerRegistry", registryID, r.client.ResourceTimeout, deletionChecker)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error deleting container registry",
-			NewTransportError("delete", "Containerregistry", err).Error(),
-		)
+		resp.Diagnostics.AddError("Error deleting ContainerRegistry", err.Error())
 		return
 	}
-
 	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "ContainerRegistry", registryID, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
 		resp.Diagnostics.AddError("Error waiting for ContainerRegistry deletion", waitErr.Error())
 		return
 	}
-
-	tflog.Trace(ctx, "deleted a Container Registry resource", map[string]interface{}{
-		"containerregistry_id": registryID,
-	})
+	tflog.Trace(ctx, "deleted a Container Registry resource", map[string]interface{}{"containerregistry_id": registryID})
 }
 
 func (r *ContainerRegistryResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/internal/provider/database_data_source.go
+++ b/internal/provider/database_data_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -85,23 +86,15 @@ func (d *DatabaseDataSource) Read(ctx context.Context, req datasource.ReadReques
 		return
 	}
 
-	response, err := d.client.Client.FromDatabase().Databases().Get(ctx, projectID, dbaasID, databaseName, nil)
-	if err != nil {
-		resp.Diagnostics.AddError("Error reading database", NewTransportError("read", "Database", err).Error())
-		return
-	}
-	if apiErr := CheckResponse("read", "Database", response); apiErr != nil {
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
-		return
-	}
-	if response == nil || response.Data == nil {
-		resp.Diagnostics.AddError("No data returned", "Database Get returned no data")
+	db, err := d.client.Client.FromDatabase().Databases().Get(ctx,
+		aruba.URI("/projects/"+projectID+"/providers/Aruba.Database/dbaas/"+dbaasID+"/databases/"+databaseName))
+	if provErr := CheckResponseErr("read", "Database", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	db := response.Data
-	data.Id = types.StringValue(db.Name)
-	data.Name = types.StringValue(db.Name)
+	data.Id = types.StringValue(db.Name())
+	data.Name = types.StringValue(db.Name())
 	data.ProjectID = types.StringValue(projectID)
 	data.DBaaSID = types.StringValue(dbaasID)
 

--- a/internal/provider/database_resource.go
+++ b/internal/provider/database_resource.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	sdktypes "github.com/Arubacloud/sdk-go/pkg/types"
+	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -79,6 +79,12 @@ func (r *DatabaseResource) Configure(ctx context.Context, req resource.Configure
 	r.client = client
 }
 
+func databaseRef(data *DatabaseResourceModel) aruba.Ref {
+	return aruba.URI("/projects/" + data.ProjectID.ValueString() +
+		"/providers/Aruba.Database/dbaas/" + data.DBaaSID.ValueString() +
+		"/databases/" + data.Id.ValueString())
+}
+
 func (r *DatabaseResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data DatabaseResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
@@ -88,73 +94,41 @@ func (r *DatabaseResource) Create(ctx context.Context, req resource.CreateReques
 
 	projectID := data.ProjectID.ValueString()
 	dbaasID := data.DBaaSID.ValueString()
+	dbaasURI := "/projects/" + projectID + "/providers/Aruba.Database/dbaas/" + dbaasID
 
-	if projectID == "" || dbaasID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID and DBaaS ID are required to create a database",
+	var db *aruba.Database
+	if createErr := CreateWithTransientRetry(ctx, func() error {
+		var err error
+		db, err = r.client.Client.FromDatabase().Databases().Create(ctx,
+			aruba.NewDatabase().
+				Named(data.Name.ValueString()).
+				InDBaaS(aruba.URI(dbaasURI)),
 		)
-		return
-	}
-
-	// Build the create request
-	createRequest := sdktypes.DatabaseRequest{
-		Name: data.Name.ValueString(),
-	}
-
-	// Create the database using the SDK, retrying on transient errors (e.g. when the
-	// parent DBaaS is still in InCreation and returns 400 category:transient).
-	var response *sdktypes.Response[sdktypes.DatabaseResponse]
-	if createErr := CreateWithTransientRetry(
-		ctx,
-		func() error {
-			var err error
-			response, err = r.client.Client.FromDatabase().Databases().Create(ctx, projectID, dbaasID, createRequest, nil)
-			if err != nil {
-				return NewTransportError("create", "Database", err)
-			}
-			return CheckResponse("create", "Database", response)
-		},
-		"Database",
-		data.Name.ValueString(),
-		r.client.ResourceTimeout,
-	); createErr != nil {
+		return CheckResponseErr("create", "Database", err)
+	}, "Database", data.Name.ValueString(), r.client.ResourceTimeout); createErr != nil {
 		resp.Diagnostics.AddError("Error creating database", createErr.Error())
 		return
 	}
 
-	if response != nil && response.Data != nil {
-		// Database uses name as ID
-		data.Id = types.StringValue(response.Data.Name)
-		// Database response doesn't have Metadata.URI
-		data.Uri = types.StringNull()
-	} else {
-		resp.Diagnostics.AddError(
-			"Invalid API Response",
-			"Database created but no data returned from API",
-		)
+	// Database uses name as ID.
+	data.Id = types.StringValue(db.Name())
+	data.Uri = strVal(db.URI())
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Wait for Database to be active before returning
-	// This ensures Terraform doesn't proceed until Database is ready
-	databaseName := data.Id.ValueString()
+	// Databases don't have a status; wait until we can successfully Get.
 	checker := func(ctx context.Context) (string, error) {
-		getResp, err := r.client.Client.FromDatabase().Databases().Get(ctx, projectID, dbaasID, databaseName, nil)
-		if err != nil {
-			return "", err
+		_, getErr := r.client.Client.FromDatabase().Databases().Get(ctx, databaseRef(&data))
+		if provErr := CheckResponseErr("get", "Database", getErr); provErr != nil {
+			return "Unknown", nil
 		}
-		// Databases don't have a status field, so if we can get it, it's ready
-		if getResp != nil && getResp.Data != nil {
-			return "Active", nil
-		}
-		return "Unknown", nil
+		return "Active", nil
 	}
-
-	// Wait for Database to be active - block until ready (using configured timeout)
-	if err := WaitForResourceActive(ctx, checker, "Database", databaseName, r.client.ResourceTimeout); err != nil {
-		ReportWaitResult(&resp.Diagnostics, err, "Database", databaseName)
-		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	if err := WaitForResourceActive(ctx, checker, "Database", data.Id.ValueString(), r.client.ResourceTimeout); err != nil {
+		ReportWaitResult(&resp.Diagnostics, err, "Database", data.Id.ValueString())
 		return
 	}
 
@@ -162,7 +136,6 @@ func (r *DatabaseResource) Create(ctx context.Context, req resource.CreateReques
 		"database_id":   data.Id.ValueString(),
 		"database_name": data.Name.ValueString(),
 	})
-
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -172,54 +145,24 @@ func (r *DatabaseResource) Read(ctx context.Context, req resource.ReadRequest, r
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	projectID := data.ProjectID.ValueString()
-	dbaasID := data.DBaaSID.ValueString()
-	databaseName := data.Id.ValueString()
-
-	if data.Id.IsUnknown() || data.Id.IsNull() || databaseName == "" {
-		tflog.Debug(ctx, "Database ID is empty, removing resource from state", map[string]interface{}{"database_name": databaseName})
+	if data.Id.IsNull() || data.Id.ValueString() == "" {
 		resp.State.RemoveResource(ctx)
 		return
 	}
 
-	if projectID == "" || dbaasID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID and DBaaS ID are required to read the database",
-		)
-		return
-	}
-
-	// Get database details using the SDK
-	response, err := r.client.Client.FromDatabase().Databases().Get(ctx, projectID, dbaasID, databaseName, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error reading database",
-			NewTransportError("read", "Database", err).Error(),
-		)
-		return
-	}
-
-	if apiErr := CheckResponse("read", "Database", response); apiErr != nil {
-		if IsNotFound(apiErr) {
+	db, err := r.client.Client.FromDatabase().Databases().Get(ctx, databaseRef(&data))
+	if provErr := CheckResponseErr("read", "Database", err); provErr != nil {
+		if IsNotFound(provErr) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	if response != nil && response.Data != nil {
-		db := response.Data
-		data.Id = types.StringValue(db.Name)
-		data.Name = types.StringValue(db.Name)
-		// Database response doesn't have Metadata.URI
-		data.Uri = types.StringNull()
-	} else {
-		resp.State.RemoveResource(ctx)
-		return
-	}
+	data.Id = types.StringValue(db.Name())
+	data.Name = types.StringValue(db.Name())
+	data.Uri = strVal(db.URI())
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -229,64 +172,30 @@ func (r *DatabaseResource) Update(ctx context.Context, req resource.UpdateReques
 	var state DatabaseResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Get IDs from state (not plan) - IDs are immutable and should always be in state
-	projectID := state.ProjectID.ValueString()
-	dbaasID := state.DBaaSID.ValueString()
-	oldDatabaseName := state.Id.ValueString()
-
-	if projectID == "" || dbaasID == "" || oldDatabaseName == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID, DBaaS ID, and Database Name are required to update the database",
-		)
+	db, err := r.client.Client.FromDatabase().Databases().Get(ctx, databaseRef(&state))
+	if provErr := CheckResponseErr("read", "Database", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	// Build update request
-	updateRequest := sdktypes.DatabaseRequest{
-		Name: data.Name.ValueString(),
-	}
+	db.Named(data.Name.ValueString())
 
-	// Update the database using the SDK
-	response, err := r.client.Client.FromDatabase().Databases().Update(ctx, projectID, dbaasID, oldDatabaseName, updateRequest, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error updating database",
-			NewTransportError("update", "Database", err).Error(),
-		)
+	updated, err := r.client.Client.FromDatabase().Databases().Update(ctx, db)
+	if provErr := CheckResponseErr("update", "Database", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	if apiErr := CheckResponse("update", "Database", response); apiErr != nil {
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
-		return
-	}
-
-	if response != nil && response.Data != nil {
-		// Update ID to new name
-		data.Id = types.StringValue(response.Data.Name)
-		// Database response doesn't have Metadata.URI
-		data.Uri = types.StringNull()
-	}
-
-	// Ensure immutable fields are set from state before saving
-	data.Id = state.Id
+	data.Id = types.StringValue(updated.Name()) // name can change
 	data.ProjectID = state.ProjectID
 	data.DBaaSID = state.DBaaSID
-
-	if response != nil && response.Data != nil {
-		// Update ID from response (database name can change, so use response)
-		data.Id = types.StringValue(response.Data.Name)
-	}
+	data.Name = types.StringValue(updated.Name())
+	data.Uri = strVal(updated.URI())
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -298,26 +207,12 @@ func (r *DatabaseResource) Delete(ctx context.Context, req resource.DeleteReques
 		return
 	}
 
-	projectID := data.ProjectID.ValueString()
-	dbaasID := data.DBaaSID.ValueString()
+	ref := databaseRef(&data)
 	databaseName := data.Id.ValueString()
 
-	if projectID == "" || dbaasID == "" || databaseName == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID, DBaaS ID, and Database Name are required to delete the database",
-		)
-		return
-	}
-
-	// Delete the database using the SDK with retry mechanism
-	// Retry on any error except 404 (Resource Not Found)
 	deletionChecker := func(ctx context.Context) (bool, error) {
-		getResp, getErr := r.client.Client.FromDatabase().Databases().Get(ctx, projectID, dbaasID, databaseName, nil)
-		if getErr != nil {
-			return false, NewTransportError("get", "Database", getErr)
-		}
-		if provErr := CheckResponse("get", "Database", getResp); provErr != nil {
+		_, getErr := r.client.Client.FromDatabase().Databases().Get(ctx, ref)
+		if provErr := CheckResponseErr("get", "Database", getErr); provErr != nil {
 			if IsNotFound(provErr) {
 				return true, nil
 			}
@@ -327,37 +222,19 @@ func (r *DatabaseResource) Delete(ctx context.Context, req resource.DeleteReques
 	}
 
 	deleteStart := time.Now()
-	err := DeleteResourceWithRetry(
-		ctx,
-		func() error {
-			resp, err := r.client.Client.FromDatabase().Databases().Delete(ctx, projectID, dbaasID, databaseName, nil)
-			if err != nil {
-				return NewTransportError("delete", "Database", err)
-			}
-			return CheckResponse("delete", "Database", resp)
-		},
-		"Database",
-		databaseName,
-		r.client.ResourceTimeout,
-		deletionChecker,
-	)
-
+	err := DeleteResourceWithRetry(ctx, func() error {
+		return CheckResponseErr("delete", "Database",
+			r.client.Client.FromDatabase().Databases().Delete(ctx, ref))
+	}, "Database", databaseName, r.client.ResourceTimeout, deletionChecker)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error deleting database",
-			NewTransportError("delete", "Database", err).Error(),
-		)
+		resp.Diagnostics.AddError("Error deleting database", err.Error())
 		return
 	}
-
 	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "Database", databaseName, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
 		resp.Diagnostics.AddError("Error waiting for Database deletion", waitErr.Error())
 		return
 	}
-
-	tflog.Trace(ctx, "deleted a Database resource", map[string]interface{}{
-		"database_id": databaseName,
-	})
+	tflog.Trace(ctx, "deleted a Database resource", map[string]interface{}{"database_id": databaseName})
 }
 
 func (r *DatabaseResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/internal/provider/databasebackup_data_source.go
+++ b/internal/provider/databasebackup_data_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -110,49 +111,36 @@ func (d *DatabaseBackupDataSource) Read(ctx context.Context, req datasource.Read
 		return
 	}
 
-	response, err := d.client.Client.FromDatabase().Backups().Get(ctx, projectID, backupID, nil)
-	if err != nil {
-		resp.Diagnostics.AddError("Error reading database backup", NewTransportError("read", "Databasebackup", err).Error())
-		return
-	}
-	if apiErr := CheckResponse("read", "Databasebackup", response); apiErr != nil {
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
-		return
-	}
-	if response == nil || response.Data == nil {
-		resp.Diagnostics.AddError("No data returned", "Database Backup Get returned no data")
+	backup, err := d.client.Client.FromDatabase().Backups().Get(ctx,
+		aruba.URI("/projects/"+projectID+"/providers/Aruba.Database/backups/"+backupID))
+	if provErr := CheckResponseErr("read", "DBaaSBackup", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	backup := response.Data
-	if backup.Metadata.ID != nil {
-		data.Id = types.StringValue(*backup.Metadata.ID)
-	}
-	if backup.Metadata.Name != nil {
-		data.Name = types.StringValue(*backup.Metadata.Name)
-	}
-	if backup.Metadata.LocationResponse != nil {
-		data.Location = types.StringValue(backup.Metadata.LocationResponse.Value)
+	data.Id = types.StringValue(backup.ID())
+	data.Name = types.StringValue(backup.Name())
+	data.ProjectID = types.StringValue(projectID)
+	data.Tags = TagsToListPreserveNull(backup.Tags(), data.Tags)
+
+	if backup.Region() != "" {
+		data.Location = types.StringValue(string(backup.Region()))
 	} else {
 		data.Location = types.StringNull()
 	}
-	data.ProjectID = types.StringValue(projectID)
-
-	if backup.Properties.Zone != "" {
-		data.Zone = types.StringValue(backup.Properties.Zone)
+	if z := string(backup.Zone()); z != "" {
+		data.Zone = types.StringValue(z)
 	} else {
 		data.Zone = types.StringNull()
 	}
-	if backup.Properties.BillingPlan.BillingPeriod != "" {
-		data.BillingPeriod = types.StringValue(backup.Properties.BillingPlan.BillingPeriod)
+	if bp := string(backup.BillingPeriod()); bp != "" {
+		data.BillingPeriod = types.StringValue(bp)
 	} else {
 		data.BillingPeriod = types.StringNull()
 	}
-	// DBaaSID and Database are not directly available in the response
+	// DBaaSID and Database are not directly available in the response.
 	data.DBaaSID = types.StringNull()
 	data.Database = types.StringNull()
-
-	data.Tags = TagsToListPreserveNull(backup.Metadata.Tags, data.Tags)
 
 	tflog.Trace(ctx, "read a Database Backup data source", map[string]interface{}{"backup_id": backupID})
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/databasebackup_resource.go
+++ b/internal/provider/databasebackup_resource.go
@@ -5,8 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	sdktypes "github.com/Arubacloud/sdk-go/pkg/types"
-	"github.com/hashicorp/terraform-plugin-framework/attr"
+	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -106,6 +105,14 @@ func (r *DatabaseBackupResource) Configure(ctx context.Context, req resource.Con
 	r.client = client
 }
 
+func databaseBackupRef(data *DatabaseBackupResourceModel) aruba.Ref {
+	if !data.Uri.IsNull() && data.Uri.ValueString() != "" {
+		return aruba.URI(data.Uri.ValueString())
+	}
+	return aruba.URI("/projects/" + data.ProjectID.ValueString() +
+		"/providers/Aruba.Database/backups/" + data.Id.ValueString())
+}
+
 func (r *DatabaseBackupResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data DatabaseBackupResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
@@ -117,114 +124,40 @@ func (r *DatabaseBackupResource) Create(ctx context.Context, req resource.Create
 	dbaasID := data.DBaaSID.ValueString()
 	databaseName := data.Database.ValueString()
 
-	if projectID == "" || dbaasID == "" || databaseName == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID, DBaaS ID, and Database name are required to create a database backup",
-		)
-		return
-	}
-
-	// Get DBaaS instance to get its URI
-	dbaasResp, err := r.client.Client.FromDatabase().DBaaS().Get(ctx, projectID, dbaasID, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error getting DBaaS instance",
-			NewTransportError("read", "Databasebackup", err).Error(),
-		)
-		return
-	}
-
-	if dbaasResp == nil || dbaasResp.Data == nil || dbaasResp.Data.Metadata.URI == nil {
-		resp.Diagnostics.AddError(
-			"DBaaS Instance Not Found",
-			"DBaaS instance not found or missing URI",
-		)
-		return
-	}
-
-	dbaasURI := *dbaasResp.Data.Metadata.URI
-	// Construct database URI
-	databaseURI := fmt.Sprintf("%s/databases/%s", dbaasURI, databaseName)
-
 	tags := ListToTags(ctx, data.Tags, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Build the create request
-	createRequest := sdktypes.BackupRequest{
-		Metadata: sdktypes.RegionalResourceMetadataRequest{
-			ResourceMetadataRequest: sdktypes.ResourceMetadataRequest{
-				Name: data.Name.ValueString(),
-				Tags: tags,
-			},
-			Location: sdktypes.LocationRequest{
-				Value: data.Location.ValueString(),
-			},
-		},
-		Properties: sdktypes.BackupPropertiesRequest{
-			Zone: data.Zone.ValueString(),
-			DBaaS: sdktypes.ReferenceResource{
-				URI: dbaasURI,
-			},
-			Database: sdktypes.ReferenceResource{
-				URI: databaseURI,
-			},
-			BillingPlan: sdktypes.BillingPeriodResource{
-				BillingPeriod: data.BillingPeriod.ValueString(),
-			},
-		},
-	}
+	dbaasURI := "/projects/" + projectID + "/providers/Aruba.Database/dbaas/" + dbaasID
+	databaseURI := dbaasURI + "/databases/" + databaseName
 
-	// Create the backup using the SDK
-	response, err := r.client.Client.FromDatabase().Backups().Create(ctx, projectID, createRequest, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error creating database backup",
-			NewTransportError("create", "Databasebackup", err).Error(),
-		)
+	backup, err := r.client.Client.FromDatabase().Backups().Create(ctx,
+		aruba.NewDBaaSBackup().
+			Named(data.Name.ValueString()).
+			InProject(aruba.URI("/projects/"+projectID)).
+			InRegion(aruba.Region(data.Location.ValueString())).
+			InZone(aruba.Zone(data.Zone.ValueString())).
+			FromDBaaS(aruba.URI(dbaasURI)).
+			FromDatabase(aruba.URI(databaseURI)).
+			BilledBy(aruba.BillingPeriod(data.BillingPeriod.ValueString())).
+			Tagged(tags...),
+	)
+	if provErr := CheckResponseErr("create", "DatabaseBackup", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	if apiErr := CheckResponse("create", "Databasebackup", response); apiErr != nil {
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
+	data.Id = types.StringValue(backup.ID())
+	data.Uri = strVal(backup.URI())
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	if response != nil && response.Data != nil && response.Data.Metadata.ID != nil {
-		data.Id = types.StringValue(*response.Data.Metadata.ID)
-		if response.Data.Metadata.URI != nil {
-			data.Uri = types.StringValue(*response.Data.Metadata.URI)
-		} else {
-			data.Uri = types.StringNull()
-		}
-	} else {
-		resp.Diagnostics.AddError(
-			"Invalid API Response",
-			"Database backup created but no ID returned from API",
-		)
-		return
-	}
-
-	// Wait for Database Backup to be active before returning
-	// This ensures Terraform doesn't proceed until Backup is ready
-	backupID := data.Id.ValueString()
-	checker := func(ctx context.Context) (string, error) {
-		getResp, err := r.client.Client.FromDatabase().Backups().Get(ctx, projectID, backupID, nil)
-		if err != nil {
-			return "", err
-		}
-		if getResp != nil && getResp.Data != nil && getResp.Data.Status.State != nil {
-			return *getResp.Data.Status.State, nil
-		}
-		return "Unknown", nil
-	}
-
-	// Wait for Database Backup to be active - block until ready (using configured timeout)
-	if err := WaitForResourceActive(ctx, checker, "DatabaseBackup", backupID, r.client.ResourceTimeout); err != nil {
-		ReportWaitResult(&resp.Diagnostics, err, "DatabaseBackup", backupID)
-		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	if waitErr := backup.WaitUntilReady(ctx, aruba.WithTimeout(r.client.ResourceTimeout)); waitErr != nil {
+		ReportWaitResult(&resp.Diagnostics, waitErr, "DatabaseBackup", data.Id.ValueString())
 		return
 	}
 
@@ -232,7 +165,6 @@ func (r *DatabaseBackupResource) Create(ctx context.Context, req resource.Create
 		"backup_id":   data.Id.ValueString(),
 		"backup_name": data.Name.ValueString(),
 	})
-
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -242,153 +174,65 @@ func (r *DatabaseBackupResource) Read(ctx context.Context, req resource.ReadRequ
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	projectID := data.ProjectID.ValueString()
-	backupID := data.Id.ValueString()
-
-	if data.Id.IsUnknown() || data.Id.IsNull() || backupID == "" {
-		tflog.Debug(ctx, "Database Backup ID is empty, removing resource from state", map[string]interface{}{"backup_id": backupID})
+	if data.Id.IsNull() || data.Id.ValueString() == "" {
 		resp.State.RemoveResource(ctx)
 		return
 	}
 
-	if projectID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID is required to read the database backup",
-		)
-		return
-	}
-
-	// Get backup details using the SDK
-	response, err := r.client.Client.FromDatabase().Backups().Get(ctx, projectID, backupID, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error reading database backup",
-			NewTransportError("read", "Databasebackup", err).Error(),
-		)
-		return
-	}
-
-	if apiErr := CheckResponse("read", "Databasebackup", response); apiErr != nil {
-		if IsNotFound(apiErr) {
+	backup, err := r.client.Client.FromDatabase().Backups().Get(ctx, databaseBackupRef(&data))
+	if provErr := CheckResponseErr("read", "DatabaseBackup", err); provErr != nil {
+		if IsNotFound(provErr) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	// If the resource is still provisioning (e.g. after a Create timeout that saved
-	// partial state), resume the wait so the next terraform apply reconciles correctly.
-	if response.Data.Status.State != nil {
-		switch st := *response.Data.Status.State; {
-		case isFailedState(st):
-			resp.Diagnostics.AddWarning(
-				"Resource in Failed State",
-				fmt.Sprintf("DatabaseBackup %q is in a terminal failure state (%s). "+
-					"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", backupID, st),
-			)
-		case IsCreatingState(st):
-			checker := func(ctx context.Context) (string, error) {
-				getResp, err := r.client.Client.FromDatabase().Backups().Get(ctx, projectID, backupID, nil)
-				if err != nil {
-					return "", err
-				}
-				if getResp != nil && getResp.Data != nil && getResp.Data.Status.State != nil {
-					return *getResp.Data.Status.State, nil
-				}
-				return "Unknown", nil
-			}
-			if err := WaitForResourceActive(ctx, checker, "DatabaseBackup", backupID, r.client.ResourceTimeout); err != nil {
-				ReportWaitResult(&resp.Diagnostics, err, "DatabaseBackup", backupID)
-				resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-				return
-			}
-			// Re-read to get the final active state.
-			response, err = r.client.Client.FromDatabase().Backups().Get(ctx, projectID, backupID, nil)
-			if err != nil {
-				resp.Diagnostics.AddError("Error reading DatabaseBackup after provisioning wait",
-					NewTransportError("read", "Databasebackup", err).Error())
-				return
-			}
-			if apiErr := CheckResponse("read", "Databasebackup", response); apiErr != nil {
-				if IsNotFound(apiErr) {
-					resp.State.RemoveResource(ctx)
-					return
-				}
-				resp.Diagnostics.AddError("API Error", apiErr.Error())
-				return
-			}
+	st := string(backup.State())
+	switch {
+	case isFailedState(st):
+		resp.Diagnostics.AddWarning("Resource in Failed State",
+			fmt.Sprintf("DatabaseBackup %q is in a terminal failure state (%s). "+
+				"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", data.Id.ValueString(), st))
+	case IsCreatingState(st):
+		if waitErr := backup.WaitUntilReady(ctx, aruba.WithTimeout(r.client.ResourceTimeout)); waitErr != nil {
+			ReportWaitResult(&resp.Diagnostics, waitErr, "DatabaseBackup", data.Id.ValueString())
+			return
+		}
+		backup, err = r.client.Client.FromDatabase().Backups().Get(ctx, databaseBackupRef(&data))
+		if provErr := CheckResponseErr("read", "DatabaseBackup", err); provErr != nil {
+			resp.Diagnostics.AddError("API Error", provErr.Error())
+			return
 		}
 	}
 
-	if response != nil && response.Data != nil {
-		backup := response.Data
-		if backup.Metadata.ID != nil {
-			data.Id = types.StringValue(*backup.Metadata.ID)
-		}
-		if backup.Metadata.URI != nil {
-			data.Uri = types.StringValue(*backup.Metadata.URI)
-		} else {
-			data.Uri = types.StringNull()
-		}
-		if backup.Metadata.Name != nil {
-			data.Name = types.StringValue(*backup.Metadata.Name)
-		}
-		if backup.Metadata.LocationResponse != nil {
-			data.Location = types.StringValue(backup.Metadata.LocationResponse.Value)
-		}
-		if backup.Metadata.Tags != nil {
-			tagValues := make([]attr.Value, len(backup.Metadata.Tags))
-			for i, tag := range backup.Metadata.Tags {
-				tagValues[i] = types.StringValue(tag)
-			}
-			tagsList, diags := types.ListValue(types.StringType, tagValues)
-			resp.Diagnostics.Append(diags...)
-			if !resp.Diagnostics.HasError() {
-				data.Tags = tagsList
-			}
-		} else {
-			data.Tags = types.ListNull(types.StringType)
-		}
-		if backup.Properties.Zone != "" {
-			data.Zone = types.StringValue(backup.Properties.Zone)
-		}
-		if backup.Properties.BillingPlan.BillingPeriod != "" {
-			data.BillingPeriod = types.StringValue(backup.Properties.BillingPlan.BillingPeriod)
-		}
-		// Extract DBaaS ID and Database name from URIs if needed
-		// Note: These may need to be stored separately or extracted from URIs
-	} else {
-		resp.State.RemoveResource(ctx)
-		return
+	data.Id = types.StringValue(backup.ID())
+	data.Uri = strVal(backup.URI())
+	data.Name = types.StringValue(backup.Name())
+	data.Tags = TagsToListPreserveNull(backup.Tags(), data.Tags)
+	if backup.Region() != "" {
+		data.Location = types.StringValue(string(backup.Region()))
 	}
+	if z := string(backup.Zone()); z != "" {
+		data.Zone = types.StringValue(z)
+	}
+	if bp := string(backup.BillingPeriod()); bp != "" {
+		data.BillingPeriod = types.StringValue(bp)
+	}
+	// DBaaSID and Database are preserved from state (not in API response directly).
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
 func (r *DatabaseBackupResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var data DatabaseBackupResourceModel
-	var state DatabaseBackupResourceModel
-
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// Database backups typically don't support updates
-	// If they do, implement update logic here
+	// Database backups do not support updates.
 	resp.Diagnostics.AddWarning(
 		"Update Not Supported",
 		"Database backups do not support updates. Changes will be ignored.",
 	)
-
+	var data DatabaseBackupResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -399,25 +243,12 @@ func (r *DatabaseBackupResource) Delete(ctx context.Context, req resource.Delete
 		return
 	}
 
-	projectID := data.ProjectID.ValueString()
+	ref := databaseBackupRef(&data)
 	backupID := data.Id.ValueString()
 
-	if projectID == "" || backupID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID and Backup ID are required to delete the database backup",
-		)
-		return
-	}
-
-	// Delete the backup using the SDK with retry mechanism
-	// Retry on any error except 404 (Resource Not Found)
 	deletionChecker := func(ctx context.Context) (bool, error) {
-		getResp, getErr := r.client.Client.FromDatabase().Backups().Get(ctx, projectID, backupID, nil)
-		if getErr != nil {
-			return false, NewTransportError("get", "DatabaseBackup", getErr)
-		}
-		if provErr := CheckResponse("get", "DatabaseBackup", getResp); provErr != nil {
+		_, getErr := r.client.Client.FromDatabase().Backups().Get(ctx, ref)
+		if provErr := CheckResponseErr("get", "DatabaseBackup", getErr); provErr != nil {
 			if IsNotFound(provErr) {
 				return true, nil
 			}
@@ -427,37 +258,19 @@ func (r *DatabaseBackupResource) Delete(ctx context.Context, req resource.Delete
 	}
 
 	deleteStart := time.Now()
-	err := DeleteResourceWithRetry(
-		ctx,
-		func() error {
-			resp, err := r.client.Client.FromDatabase().Backups().Delete(ctx, projectID, backupID, nil)
-			if err != nil {
-				return NewTransportError("delete", "DatabaseBackup", err)
-			}
-			return CheckResponse("delete", "DatabaseBackup", resp)
-		},
-		"DatabaseBackup",
-		backupID,
-		r.client.ResourceTimeout,
-		deletionChecker,
-	)
-
+	err := DeleteResourceWithRetry(ctx, func() error {
+		return CheckResponseErr("delete", "DatabaseBackup",
+			r.client.Client.FromDatabase().Backups().Delete(ctx, ref))
+	}, "DatabaseBackup", backupID, r.client.ResourceTimeout, deletionChecker)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error deleting database backup",
-			NewTransportError("delete", "Databasebackup", err).Error(),
-		)
+		resp.Diagnostics.AddError("Error deleting DatabaseBackup", err.Error())
 		return
 	}
-
 	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "DatabaseBackup", backupID, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
 		resp.Diagnostics.AddError("Error waiting for DatabaseBackup deletion", waitErr.Error())
 		return
 	}
-
-	tflog.Trace(ctx, "deleted a Database Backup resource", map[string]interface{}{
-		"backup_id": backupID,
-	})
+	tflog.Trace(ctx, "deleted a Database Backup resource", map[string]interface{}{"backup_id": backupID})
 }
 
 func (r *DatabaseBackupResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/internal/provider/databasegrant_data_source.go
+++ b/internal/provider/databasegrant_data_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -96,17 +97,11 @@ func (d *DatabaseGrantDataSource) Read(ctx context.Context, req datasource.ReadR
 		return
 	}
 
-	response, err := d.client.Client.FromDatabase().Grants().Get(ctx, projectID, dbaasID, database, userID, nil)
-	if err != nil {
-		resp.Diagnostics.AddError("Error reading database grant", NewTransportError("read", "Databasegrant", err).Error())
-		return
-	}
-	if apiErr := CheckResponse("read", "Databasegrant", response); apiErr != nil {
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
-		return
-	}
-	if response == nil || response.Data == nil {
-		resp.Diagnostics.AddError("No data returned", "Database Grant Get returned no data")
+	// Use user ID as the grant lookup key within the database.
+	grant, err := d.client.Client.FromDatabase().Grants().Get(ctx,
+		aruba.URI("/projects/"+projectID+"/providers/Aruba.Database/dbaas/"+dbaasID+"/databases/"+database+"/grants/"+userID))
+	if provErr := CheckResponseErr("read", "DatabaseGrant", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
@@ -115,7 +110,7 @@ func (d *DatabaseGrantDataSource) Read(ctx context.Context, req datasource.ReadR
 	data.DBaaSID = types.StringValue(dbaasID)
 	data.Database = types.StringValue(database)
 	data.UserID = types.StringValue(userID)
-	data.Role = types.StringValue(response.Data.Role.Name)
+	data.Role = types.StringValue(grant.RoleName())
 
 	tflog.Trace(ctx, "read a Database Grant data source", map[string]interface{}{"database": database, "user_id": userID})
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/databasegrant_resource.go
+++ b/internal/provider/databasegrant_resource.go
@@ -3,9 +3,10 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
-	sdktypes "github.com/Arubacloud/sdk-go/pkg/types"
+	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -89,6 +90,24 @@ func (r *DatabaseGrantResource) Configure(ctx context.Context, req resource.Conf
 	r.client = client
 }
 
+// grantCompositeRef constructs a URI using the user ID as the grant key.
+// This matches the legacy behavior where userID was used as the grant identifier.
+func grantCompositeRef(projectID, dbaasID, databaseName, userID string) aruba.Ref {
+	return aruba.URI("/projects/" + projectID +
+		"/providers/Aruba.Database/dbaas/" + dbaasID +
+		"/databases/" + databaseName +
+		"/grants/" + userID)
+}
+
+// grantRefFromModel extracts IDs from the composite stored ID (project/dbaas/db/user).
+func grantRefFromModel(data *DatabaseGrantResourceModel) aruba.Ref {
+	projectID := data.ProjectID.ValueString()
+	dbaasID := data.DBaaSID.ValueString()
+	databaseName := data.Database.ValueString()
+	userID := data.UserID.ValueString()
+	return grantCompositeRef(projectID, dbaasID, databaseName, userID)
+}
+
 func (r *DatabaseGrantResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data DatabaseGrantResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
@@ -101,60 +120,28 @@ func (r *DatabaseGrantResource) Create(ctx context.Context, req resource.CreateR
 	databaseName := data.Database.ValueString()
 	userID := data.UserID.ValueString()
 
-	if projectID == "" || dbaasID == "" || databaseName == "" || userID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID, DBaaS ID, Database name, and User ID are required to create a database grant",
-		)
+	databaseURI := "/projects/" + projectID +
+		"/providers/Aruba.Database/dbaas/" + dbaasID +
+		"/databases/" + databaseName
+
+	grant, err := r.client.Client.FromDatabase().Grants().Create(ctx,
+		aruba.NewGrant().
+			InDatabase(aruba.URI(databaseURI)).
+			ForUser(userID).
+			OfRole(data.Role.ValueString()),
+	)
+	if provErr := CheckResponseErr("create", "DatabaseGrant", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	// Build the create request
-	// GrantRequest requires both User and Role fields
-	createRequest := sdktypes.GrantRequest{
-		User: sdktypes.GrantUser{Username: userID},
-		Role: sdktypes.GrantRole{Name: data.Role.ValueString()},
-	}
+	// Preserve the composite ID pattern for backward compatibility.
+	data.Id = types.StringValue(fmt.Sprintf("%s/%s/%s/%s", projectID, dbaasID, databaseName, userID))
+	data.Uri = strVal(grant.URI())
+	data.Role = types.StringValue(grant.RoleName())
 
-	// Create the grant using the SDK
-	response, err := r.client.Client.FromDatabase().Grants().Create(ctx, projectID, dbaasID, databaseName, createRequest, nil)
-	if err != nil {
-		tflog.Error(ctx, "Database grant create error", map[string]interface{}{
-			"error":      err.Error(),
-			"project_id": projectID,
-			"dbaas_id":   dbaasID,
-			"database":   databaseName,
-			"user_id":    userID,
-		})
-		resp.Diagnostics.AddError(
-			"Error creating database grant",
-			NewTransportError("create", "Databasegrant", err).Error(),
-		)
-		return
-	}
-
-	if apiErr := CheckResponse("create", "Databasegrant", response); apiErr != nil {
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
-		return
-	}
-
-	if response != nil && response.Data != nil {
-		// Set the grant ID - using a composite key
-		data.Id = types.StringValue(fmt.Sprintf("%s/%s/%s/%s", projectID, dbaasID, databaseName, userID))
-		data.Uri = types.StringNull() // Grants don't have URIs
-	} else {
-		resp.Diagnostics.AddError(
-			"Invalid API Response",
-			"Database grant created but no data returned from API",
-		)
-		return
-	}
-
+	tflog.Trace(ctx, "created a Database Grant resource", map[string]interface{}{"grant_id": data.Id.ValueString()})
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-
-	tflog.Trace(ctx, "created a Database Grant resource", map[string]interface{}{
-		"grant_id": data.Id.ValueString(),
-	})
 }
 
 func (r *DatabaseGrantResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -163,71 +150,23 @@ func (r *DatabaseGrantResource) Read(ctx context.Context, req resource.ReadReque
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	projectID := data.ProjectID.ValueString()
-	dbaasID := data.DBaaSID.ValueString()
-	databaseName := data.Database.ValueString()
-	userID := data.UserID.ValueString()
-
-	if data.Id.IsUnknown() || data.Id.IsNull() || data.Id.ValueString() == "" {
-		tflog.Debug(ctx, "Database Grant ID is empty, removing resource from state", map[string]interface{}{"grant_id": data.Id.ValueString()})
+	if data.Id.IsNull() || data.Id.ValueString() == "" {
 		resp.State.RemoveResource(ctx)
 		return
 	}
 
-	if projectID == "" || dbaasID == "" || databaseName == "" || userID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID, DBaaS ID, Database name, and User ID are required to read the database grant",
-		)
-		return
-	}
-
-	// Get grant details using the SDK
-	response, err := r.client.Client.FromDatabase().Grants().Get(ctx, projectID, dbaasID, databaseName, userID, nil)
-	if err != nil {
-		tflog.Error(ctx, "Database grant read error", map[string]interface{}{
-			"error":      err.Error(),
-			"project_id": projectID,
-			"dbaas_id":   dbaasID,
-			"database":   databaseName,
-			"user_id":    userID,
-		})
-		resp.Diagnostics.AddError(
-			"Error reading database grant",
-			NewTransportError("read", "Databasegrant", err).Error(),
-		)
-		return
-	}
-
-	if response != nil && response.IsError() && response.Error != nil {
-		// Handle 404 - Resource no longer exists
-		if response.Error.Status != nil && *response.Error.Status == 404 {
-			tflog.Info(ctx, "Database grant not found, removing from state", map[string]interface{}{
-				"project_id": projectID,
-				"dbaas_id":   dbaasID,
-				"database":   databaseName,
-				"user_id":    userID,
-			})
+	grant, err := r.client.Client.FromDatabase().Grants().Get(ctx, grantRefFromModel(&data))
+	if provErr := CheckResponseErr("read", "DatabaseGrant", err); provErr != nil {
+		if IsNotFound(provErr) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-
-		apiErr := newResponseError("read", "Databasegrant", response.StatusCode, response.Error, response.RawBody)
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	if response != nil && response.Data != nil {
-		// Update state with current grant info
-		data.Role = types.StringValue(response.Data.Role.Name)
-	} else {
-		resp.Diagnostics.AddError(
-			"Invalid API Response",
-			"Database grant not found or no data returned from API",
-		)
-		return
-	}
+	data.Role = types.StringValue(grant.RoleName())
+	data.Uri = strVal(grant.URI())
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -237,73 +176,35 @@ func (r *DatabaseGrantResource) Update(ctx context.Context, req resource.UpdateR
 	var state DatabaseGrantResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Get IDs from state (not plan) - IDs are immutable and should always be in state
-	projectID := state.ProjectID.ValueString()
-	dbaasID := state.DBaaSID.ValueString()
-	databaseName := state.Database.ValueString()
-	userID := state.UserID.ValueString()
-
-	if projectID == "" || dbaasID == "" || databaseName == "" || userID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID, DBaaS ID, Database name, and User ID are required to update the database grant",
-		)
+	grant, err := r.client.Client.FromDatabase().Grants().Get(ctx, grantRefFromModel(&state))
+	if provErr := CheckResponseErr("read", "DatabaseGrant", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	// Build update request
-	updateRequest := sdktypes.GrantRequest{
-		User: sdktypes.GrantUser{Username: userID},
-		Role: sdktypes.GrantRole{Name: data.Role.ValueString()},
-	}
+	grant.OfRole(data.Role.ValueString())
 
-	// Update the grant using the SDK
-	response, err := r.client.Client.FromDatabase().Grants().Update(ctx, projectID, dbaasID, databaseName, userID, updateRequest, nil)
-	if err != nil {
-		tflog.Error(ctx, "Database grant update error", map[string]interface{}{
-			"error":      err.Error(),
-			"project_id": projectID,
-			"dbaas_id":   dbaasID,
-			"database":   databaseName,
-			"user_id":    userID,
-		})
-		resp.Diagnostics.AddError(
-			"Error updating database grant",
-			NewTransportError("update", "Databasegrant", err).Error(),
-		)
+	updated, err := r.client.Client.FromDatabase().Grants().Update(ctx, grant)
+	if provErr := CheckResponseErr("update", "DatabaseGrant", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	if apiErr := CheckResponse("update", "Databasegrant", response); apiErr != nil {
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
-		return
-	}
+	data.Id = state.Id
+	data.ProjectID = state.ProjectID
+	data.DBaaSID = state.DBaaSID
+	data.Database = state.Database
+	data.UserID = state.UserID
+	data.Role = types.StringValue(updated.RoleName())
+	data.Uri = strVal(updated.URI())
 
-	if response != nil && response.Data != nil {
-		// Update state with the response data
-		data.Role = types.StringValue(response.Data.Role.Name)
-	} else {
-		resp.Diagnostics.AddError(
-			"Invalid API Response",
-			"Database grant updated but no data returned from API",
-		)
-		return
-	}
-
+	tflog.Trace(ctx, "updated a Database Grant resource", map[string]interface{}{"grant_id": data.Id.ValueString()})
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-
-	tflog.Trace(ctx, "updated a Database Grant resource", map[string]interface{}{
-		"grant_id": data.Id.ValueString(),
-	})
 }
 
 func (r *DatabaseGrantResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
@@ -313,28 +214,12 @@ func (r *DatabaseGrantResource) Delete(ctx context.Context, req resource.DeleteR
 		return
 	}
 
-	projectID := data.ProjectID.ValueString()
-	dbaasID := data.DBaaSID.ValueString()
-	databaseName := data.Database.ValueString()
-	userID := data.UserID.ValueString()
-
-	if projectID == "" || dbaasID == "" || databaseName == "" || userID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID, DBaaS ID, Database name, and User ID are required to delete the database grant",
-		)
-		return
-	}
-
-	// Delete the grant using the SDK with retry mechanism
-	// Retry on any error except 404 (Resource Not Found)
+	ref := grantRefFromModel(&data)
 	grantID := data.Id.ValueString()
+
 	deletionChecker := func(ctx context.Context) (bool, error) {
-		getResp, getErr := r.client.Client.FromDatabase().Grants().Get(ctx, projectID, dbaasID, databaseName, userID, nil)
-		if getErr != nil {
-			return false, NewTransportError("get", "DatabaseGrant", getErr)
-		}
-		if provErr := CheckResponse("get", "DatabaseGrant", getResp); provErr != nil {
+		_, getErr := r.client.Client.FromDatabase().Grants().Get(ctx, ref)
+		if provErr := CheckResponseErr("get", "DatabaseGrant", getErr); provErr != nil {
 			if IsNotFound(provErr) {
 				return true, nil
 			}
@@ -344,39 +229,35 @@ func (r *DatabaseGrantResource) Delete(ctx context.Context, req resource.DeleteR
 	}
 
 	deleteStart := time.Now()
-	err := DeleteResourceWithRetry(
-		ctx,
-		func() error {
-			resp, err := r.client.Client.FromDatabase().Grants().Delete(ctx, projectID, dbaasID, databaseName, userID, nil)
-			if err != nil {
-				return NewTransportError("delete", "DatabaseGrant", err)
-			}
-			return CheckResponse("delete", "DatabaseGrant", resp)
-		},
-		"DatabaseGrant",
-		grantID,
-		r.client.ResourceTimeout,
-		deletionChecker,
-	)
-
+	err := DeleteResourceWithRetry(ctx, func() error {
+		return CheckResponseErr("delete", "DatabaseGrant",
+			r.client.Client.FromDatabase().Grants().Delete(ctx, ref))
+	}, "DatabaseGrant", grantID, r.client.ResourceTimeout, deletionChecker)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error deleting database grant",
-			NewTransportError("delete", "Databasegrant", err).Error(),
-		)
+		resp.Diagnostics.AddError("Error deleting DatabaseGrant", err.Error())
 		return
 	}
-
 	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "DatabaseGrant", grantID, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
 		resp.Diagnostics.AddError("Error waiting for DatabaseGrant deletion", waitErr.Error())
 		return
 	}
-
-	tflog.Trace(ctx, "deleted a Database Grant resource", map[string]interface{}{
-		"grant_id": grantID,
-	})
+	tflog.Trace(ctx, "deleted a Database Grant resource", map[string]interface{}{"grant_id": grantID})
 }
 
 func (r *DatabaseGrantResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	// Composite ID: project_id/dbaas_id/database/user_id
+	id := req.ID
+	parts := strings.Split(id, "/")
+	if len(parts) != 4 {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			fmt.Sprintf("Expected composite ID in format 'project_id/dbaas_id/database/user_id', got: %q", id),
+		)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("project_id"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("dbaas_id"), parts[1])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("database"), parts[2])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("user_id"), parts[3])...)
 }

--- a/internal/provider/dbaas_data_source.go
+++ b/internal/provider/dbaas_data_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -157,74 +158,63 @@ func (d *DBaaSDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 		return
 	}
 
-	response, err := d.client.Client.FromDatabase().DBaaS().Get(ctx, projectID, dbaasID, nil)
-	if err != nil {
-		resp.Diagnostics.AddError("Error reading DBaaS instance", NewTransportError("read", "Dbaas", err).Error())
-		return
-	}
-	if apiErr := CheckResponse("read", "Dbaas", response); apiErr != nil {
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
-		return
-	}
-	if response == nil || response.Data == nil {
-		resp.Diagnostics.AddError("No data returned", "DBaaS Get returned no data")
+	dbaas, err := d.client.Client.FromDatabase().DBaaS().Get(ctx,
+		aruba.URI("/projects/"+projectID+"/providers/Aruba.Database/dbaas/"+dbaasID))
+	if provErr := CheckResponseErr("read", "DBaaS", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	dbaas := response.Data
-	if dbaas.Metadata.ID != nil {
-		data.Id = types.StringValue(*dbaas.Metadata.ID)
-	}
-	if dbaas.Metadata.URI != nil {
-		data.Uri = types.StringValue(*dbaas.Metadata.URI)
-	} else {
-		data.Uri = types.StringNull()
-	}
-	if dbaas.Metadata.Name != nil {
-		data.Name = types.StringValue(*dbaas.Metadata.Name)
-	}
-	if dbaas.Metadata.LocationResponse != nil {
-		data.Location = types.StringValue(dbaas.Metadata.LocationResponse.Value)
+	data.Id = types.StringValue(dbaas.ID())
+	data.Uri = strVal(dbaas.URI())
+	data.Name = types.StringValue(dbaas.Name())
+	data.ProjectID = types.StringValue(projectID)
+	data.Tags = TagsToListPreserveNull(dbaas.Tags(), data.Tags)
+
+	if dbaas.Region() != "" {
+		data.Location = types.StringValue(string(dbaas.Region()))
 	} else {
 		data.Location = types.StringNull()
 	}
-	data.ProjectID = types.StringValue(projectID)
-	// Zone is not returned by the API
+	// Zone is not reliably returned by the API.
 	data.Zone = types.StringNull()
 
-	if dbaas.Properties.Engine != nil && dbaas.Properties.Engine.ID != nil {
-		data.EngineID = types.StringValue(*dbaas.Properties.Engine.ID)
+	if e := string(dbaas.Engine()); e != "" {
+		data.EngineID = types.StringValue(e)
 	} else {
 		data.EngineID = types.StringNull()
 	}
-	if dbaas.Properties.Flavor != nil && dbaas.Properties.Flavor.Name != nil {
-		data.Flavor = types.StringValue(*dbaas.Properties.Flavor.Name)
+	if f := string(dbaas.Flavor()); f != "" {
+		data.Flavor = types.StringValue(f)
 	} else {
 		data.Flavor = types.StringNull()
 	}
-	if dbaas.Properties.BillingPlan != nil && dbaas.Properties.BillingPlan.BillingPeriod != nil {
-		data.BillingPeriod = types.StringValue(*dbaas.Properties.BillingPlan.BillingPeriod)
+	if bp := string(dbaas.BillingPeriod()); bp != "" {
+		data.BillingPeriod = types.StringValue(bp)
 	} else {
 		data.BillingPeriod = types.StringNull()
 	}
 
-	if dbaas.Properties.Storage != nil && dbaas.Properties.Storage.SizeGB != nil {
-		data.StorageSizeGB = types.Int64Value(int64(*dbaas.Properties.Storage.SizeGB))
+	if s := dbaas.SizeGB(); s > 0 {
+		data.StorageSizeGB = types.Int64Value(int64(s))
 	} else {
 		data.StorageSizeGB = types.Int64Null()
 	}
-	// Autoscaling fields are not reliably returned by the API
-	data.AutoscalingEnabled = types.BoolNull()
-	data.AutoscalingAvailableSpace = types.Int64Null()
-	data.AutoscalingStepSize = types.Int64Null()
+	if dbaas.AutoscalingEnabled() {
+		data.AutoscalingEnabled = types.BoolValue(true)
+		data.AutoscalingAvailableSpace = types.Int64Value(int64(dbaas.AutoscalingAvailableSpaceGB()))
+		data.AutoscalingStepSize = types.Int64Value(int64(dbaas.AutoscalingStepSizeGB()))
+	} else {
+		data.AutoscalingEnabled = types.BoolNull()
+		data.AutoscalingAvailableSpace = types.Int64Null()
+		data.AutoscalingStepSize = types.Int64Null()
+	}
 
-	// Network URIs are not returned by the API
-	data.VpcUriRef = types.StringNull()
-	data.SubnetUriRef = types.StringNull()
-	data.SecurityGroupUriRef = types.StringNull()
-	data.ElasticIpUriRef = types.StringNull()
-
-	data.Tags = TagsToListPreserveNull(dbaas.Metadata.Tags, data.Tags)
+	// Network URIs (may be empty if not in API response).
+	data.VpcUriRef = strVal(dbaas.VPC())
+	data.SubnetUriRef = strVal(dbaas.Subnet())
+	data.SecurityGroupUriRef = strVal(dbaas.SecurityGroup())
+	data.ElasticIpUriRef = strVal(dbaas.ElasticIP())
 
 	tflog.Trace(ctx, "read a DBaaS data source", map[string]interface{}{"dbaas_id": dbaasID})
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/dbaas_resource.go
+++ b/internal/provider/dbaas_resource.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	sdktypes "github.com/Arubacloud/sdk-go/pkg/types"
+	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -123,32 +123,24 @@ func (r *DBaaSResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				Required:            true,
 				Attributes: map[string]schema.Attribute{
 					"vpc_uri_ref": schema.StringAttribute{
-						MarkdownDescription: "URI reference to the VPC resource. References the `uri` attribute of an `arubacloud_vpc` resource (e.g., `arubacloud_vpc.example.uri`).",
+						MarkdownDescription: "URI reference to the VPC resource.",
 						Required:            true,
-						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.UseStateForUnknown(),
-						},
+						PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 					},
 					"subnet_uri_ref": schema.StringAttribute{
-						MarkdownDescription: "URI reference to the Subnet resource. References the `uri` attribute of an `arubacloud_subnet` resource (e.g., `arubacloud_subnet.example.uri`).",
+						MarkdownDescription: "URI reference to the Subnet resource.",
 						Required:            true,
-						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.UseStateForUnknown(),
-						},
+						PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 					},
 					"security_group_uri_ref": schema.StringAttribute{
-						MarkdownDescription: "URI reference to the Security Group resource. References the `uri` attribute of an `arubacloud_securitygroup` resource (e.g., `arubacloud_securitygroup.example.uri`).",
+						MarkdownDescription: "URI reference to the Security Group resource.",
 						Required:            true,
-						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.UseStateForUnknown(),
-						},
+						PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 					},
 					"elastic_ip_uri_ref": schema.StringAttribute{
-						MarkdownDescription: "Optional URI reference to an Elastic IP resource. References the `uri` attribute of an `arubacloud_elasticip` resource (e.g., `arubacloud_elasticip.example.uri`).",
+						MarkdownDescription: "Optional URI reference to an Elastic IP resource.",
 						Optional:            true,
-						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.UseStateForUnknown(),
-						},
+						PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 					},
 				},
 			},
@@ -175,6 +167,74 @@ func (r *DBaaSResource) Configure(ctx context.Context, req resource.ConfigureReq
 	r.client = client
 }
 
+func dbaasRef(data *DBaaSResourceModel) aruba.Ref {
+	if !data.Uri.IsNull() && data.Uri.ValueString() != "" {
+		return aruba.URI(data.Uri.ValueString())
+	}
+	return aruba.URI("/projects/" + data.ProjectID.ValueString() + "/providers/Aruba.Database/dbaas/" + data.Id.ValueString())
+}
+
+// dbaasNetworkAttrTypes returns the attr.Type map for the network object.
+func dbaasNetworkAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"vpc_uri_ref":            types.StringType,
+		"subnet_uri_ref":         types.StringType,
+		"security_group_uri_ref": types.StringType,
+		"elastic_ip_uri_ref":     types.StringType,
+	}
+}
+
+// dbaasStorageAttrTypes returns the attr.Type map for the storage object.
+func dbaasStorageAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"size_gb": types.Int64Type,
+		"autoscaling": types.ObjectType{
+			AttrTypes: map[string]attr.Type{
+				"enabled":         types.BoolType,
+				"available_space": types.Int64Type,
+				"step_size":       types.Int64Type,
+			},
+		},
+	}
+}
+
+// extractNetworkFromModel extracts VPC, subnet, security group, and elastic IP URIs from the model's Network object.
+func extractNetworkFromModel(ctx context.Context, data *DBaaSResourceModel) (vpc, subnet, sg, eip string, ok bool) {
+	if data.Network.IsNull() || data.Network.IsUnknown() {
+		return
+	}
+	attrs := data.Network.Attributes()
+	getStr := func(key string) string {
+		if v, exists := attrs[key]; exists {
+			if s, isStr := v.(types.String); isStr && !s.IsNull() {
+				return s.ValueString()
+			}
+		}
+		return ""
+	}
+	vpc = getStr("vpc_uri_ref")
+	subnet = getStr("subnet_uri_ref")
+	sg = getStr("security_group_uri_ref")
+	eip = getStr("elastic_ip_uri_ref")
+	ok = vpc != "" && subnet != "" && sg != ""
+	return
+}
+
+// buildNetworkObject builds the network types.Object for state from the four URIs.
+func buildNetworkObject(vpc, subnet, sg, eip string) types.Object {
+	eipVal := types.StringNull()
+	if eip != "" {
+		eipVal = types.StringValue(eip)
+	}
+	obj, _ := types.ObjectValue(dbaasNetworkAttrTypes(), map[string]attr.Value{
+		"vpc_uri_ref":            types.StringValue(vpc),
+		"subnet_uri_ref":         types.StringValue(subnet),
+		"security_group_uri_ref": types.StringValue(sg),
+		"elastic_ip_uri_ref":     eipVal,
+	})
+	return obj
+}
+
 func (r *DBaaSResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data DBaaSResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
@@ -183,291 +243,97 @@ func (r *DBaaSResource) Create(ctx context.Context, req resource.CreateRequest, 
 	}
 
 	projectID := data.ProjectID.ValueString()
-	if projectID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Project ID",
-			"Project ID is required to create a DBaaS instance",
-		)
-		return
-	}
-
 	tags := ListToTags(ctx, data.Tags, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	engineID := data.EngineID.ValueString()
-	flavor := data.Flavor.ValueString()
-	zone := data.Zone.ValueString()
-
-	// Extract storage configuration from nested object
+	// Extract storage.
 	if data.Storage.IsNull() || data.Storage.IsUnknown() {
-		resp.Diagnostics.AddError(
-			"Missing Storage Configuration",
-			"Storage configuration is required to create a DBaaS instance",
-		)
+		resp.Diagnostics.AddError("Missing Storage Configuration", "Storage configuration is required to create a DBaaS instance")
+		return
+	}
+	storageAttrs := data.Storage.Attributes()
+	sizeGBAttr, _ := storageAttrs["size_gb"].(types.Int64)
+	if sizeGBAttr.IsNull() || sizeGBAttr.IsUnknown() {
+		resp.Diagnostics.AddError("Missing Storage Size", "Storage size_gb is required")
 		return
 	}
 
-	storageObj, diags := data.Storage.ToObjectValue(ctx)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
+	// Extract network.
+	vpc, subnet, sg, eip, netOK := extractNetworkFromModel(ctx, &data)
+	if !netOK {
+		resp.Diagnostics.AddError("Missing Network Configuration", "vpc_uri_ref, subnet_uri_ref, and security_group_uri_ref are required")
 		return
 	}
 
-	storageAttrs := storageObj.Attributes()
-	sizeGBAttr, ok := storageAttrs["size_gb"].(types.Int64)
-	if !ok || sizeGBAttr.IsNull() || sizeGBAttr.IsUnknown() {
-		resp.Diagnostics.AddError(
-			"Missing Storage Size",
-			"Storage size_gb is required to create a DBaaS instance",
-		)
-		return
+	builder := aruba.NewDBaaS().
+		Named(data.Name.ValueString()).
+		InProject(aruba.URI("/projects/"+projectID)).
+		InRegion(aruba.Region(data.Location.ValueString())).
+		InZone(aruba.Zone(data.Zone.ValueString())).
+		OfEngine(aruba.DatabaseEngine(data.EngineID.ValueString())).
+		OfFlavor(aruba.DBaaSFlavor(data.Flavor.ValueString())).
+		SizedGB(int(sizeGBAttr.ValueInt64())).
+		WithVPC(aruba.URI(vpc)).
+		WithSubnet(aruba.URI(subnet)).
+		WithSecurityGroup(aruba.URI(sg)).
+		Tagged(tags...)
+
+	if eip != "" {
+		builder = builder.WithElasticIP(aruba.URI(eip))
 	}
-	storageSizeGB := int32(sizeGBAttr.ValueInt64())
-	storageSizeGBPtr := &storageSizeGB
 
-	// Extract autoscaling if present
-	var autoscaling *sdktypes.DBaaSAutoscaling
-	if autoscalingAttr, ok := storageAttrs["autoscaling"]; ok && autoscalingAttr != nil {
-		if autoscalingObj, ok := autoscalingAttr.(types.Object); ok && !autoscalingObj.IsNull() && !autoscalingObj.IsUnknown() {
-			autoscalingObjValue, diags := autoscalingObj.ToObjectValue(ctx)
-			resp.Diagnostics.Append(diags...)
-			if !resp.Diagnostics.HasError() {
-				autoscalingAttrs := autoscalingObjValue.Attributes()
-				enabledAttr, _ := autoscalingAttrs["enabled"].(types.Bool)
-				availableSpaceAttr, _ := autoscalingAttrs["available_space"].(types.Int64)
-				stepSizeAttr, _ := autoscalingAttrs["step_size"].(types.Int64)
-
-				if !enabledAttr.IsNull() && !availableSpaceAttr.IsNull() && !stepSizeAttr.IsNull() {
-					enabled := enabledAttr.ValueBool()
-					availableSpace := int32(availableSpaceAttr.ValueInt64())
-					stepSize := int32(stepSizeAttr.ValueInt64())
-					autoscaling = &sdktypes.DBaaSAutoscaling{
-						Enabled:        &enabled,
-						AvailableSpace: &availableSpace,
-						StepSize:       &stepSize,
-					}
-				}
+	// Autoscaling.
+	if autoscalingAttr, ok := storageAttrs["autoscaling"]; ok {
+		if autoscalingObj, ok := autoscalingAttr.(types.Object); ok && !autoscalingObj.IsNull() {
+			asAttrs := autoscalingObj.Attributes()
+			enabledAttr, _ := asAttrs["enabled"].(types.Bool)
+			availableAttr, _ := asAttrs["available_space"].(types.Int64)
+			stepAttr, _ := asAttrs["step_size"].(types.Int64)
+			if !enabledAttr.IsNull() && enabledAttr.ValueBool() {
+				builder = builder.WithAutoscaling(int(availableAttr.ValueInt64()), int(stepAttr.ValueInt64()))
 			}
 		}
 	}
 
-	// Extract network configuration from nested object
-	if data.Network.IsNull() || data.Network.IsUnknown() {
-		resp.Diagnostics.AddError(
-			"Missing Network Configuration",
-			"Network configuration is required to create a DBaaS instance",
-		)
+	if !data.BillingPeriod.IsNull() && !data.BillingPeriod.IsUnknown() {
+		builder = builder.BilledBy(aruba.BillingPeriod(data.BillingPeriod.ValueString()))
+	}
+
+	dbaas, err := r.client.Client.FromDatabase().DBaaS().Create(ctx, builder)
+	if provErr := CheckResponseErr("create", "DBaaS", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	networkObj, diags := data.Network.ToObjectValue(ctx)
-	resp.Diagnostics.Append(diags...)
+	data.Id = types.StringValue(dbaas.ID())
+	data.Uri = strVal(dbaas.URI())
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	networkAttrs := networkObj.Attributes()
-	vpcUriRefAttr, ok := networkAttrs["vpc_uri_ref"].(types.String)
-	if !ok || vpcUriRefAttr.IsNull() || vpcUriRefAttr.IsUnknown() {
-		resp.Diagnostics.AddError(
-			"Missing VPC URI Reference",
-			"VPC URI reference is required in network configuration",
-		)
-		return
-	}
-	vpcUriRef := vpcUriRefAttr.ValueString()
-
-	subnetUriRefAttr, ok := networkAttrs["subnet_uri_ref"].(types.String)
-	if !ok || subnetUriRefAttr.IsNull() || subnetUriRefAttr.IsUnknown() {
-		resp.Diagnostics.AddError(
-			"Missing Subnet URI Reference",
-			"Subnet URI reference is required in network configuration",
-		)
-		return
-	}
-	subnetUriRef := subnetUriRefAttr.ValueString()
-
-	securityGroupUriRefAttr, ok := networkAttrs["security_group_uri_ref"].(types.String)
-	if !ok || securityGroupUriRefAttr.IsNull() || securityGroupUriRefAttr.IsUnknown() {
-		resp.Diagnostics.AddError(
-			"Missing Security Group URI Reference",
-			"Security Group URI reference is required in network configuration",
-		)
-		return
-	}
-	securityGroupUriRef := securityGroupUriRefAttr.ValueString()
-
-	// Elastic IP is optional
-	var elasticIpUriRef string
-	if elasticIpAttr, ok := networkAttrs["elastic_ip_uri_ref"]; ok && elasticIpAttr != nil {
-		if elasticIpStr, ok := elasticIpAttr.(types.String); ok && !elasticIpStr.IsNull() && !elasticIpStr.IsUnknown() {
-			elasticIpUriRef = elasticIpStr.ValueString()
-		}
-	}
-
-	// Build the create request
-	// Network configuration using DBaaSNetworking structure
-	networking := &sdktypes.DBaaSNetworking{
-		VPCURI:           &vpcUriRef,
-		SubnetURI:        &subnetUriRef,
-		SecurityGroupURI: &securityGroupUriRef,
-	}
-
-	// Add optional Elastic IP if provided
-	if elasticIpUriRef != "" {
-		networking.ElasticIPURI = &elasticIpUriRef
-	}
-
-	createRequest := sdktypes.DBaaSRequest{
-		Metadata: sdktypes.RegionalResourceMetadataRequest{
-			ResourceMetadataRequest: sdktypes.ResourceMetadataRequest{
-				Name: data.Name.ValueString(),
-				Tags: tags,
-			},
-			Location: sdktypes.LocationRequest{
-				Value: data.Location.ValueString(),
-			},
-		},
-		Properties: sdktypes.DBaaSPropertiesRequest{
-			Engine: &sdktypes.DBaaSEngine{
-				ID: &engineID,
-			},
-			Flavor: &sdktypes.DBaaSFlavor{
-				Name: &flavor,
-			},
-			Storage: &sdktypes.DBaaSStorage{
-				SizeGB: storageSizeGBPtr,
-			},
-			Autoscaling: autoscaling,
-			Networking:  networking,
-			Zone:        &zone,
-		},
-	}
-
-	// Add optional billing period
-	if !data.BillingPeriod.IsNull() && !data.BillingPeriod.IsUnknown() {
-		billingPeriod := data.BillingPeriod.ValueString()
-		createRequest.Properties.BillingPlan = &sdktypes.DBaaSBillingPlan{
-			BillingPeriod: &billingPeriod,
-		}
-	}
-
-	// Log the full request for debugging
-	debugMap := map[string]interface{}{
-		"project_id":         projectID,
-		"name":               data.Name.ValueString(),
-		"location":           data.Location.ValueString(),
-		"zone":               zone,
-		"engine_id":          engineID,
-		"flavor":             flavor,
-		"storage_size_gb":    storageSizeGB,
-		"vpc_uri":            vpcUriRef,
-		"subnet_uri":         subnetUriRef,
-		"security_group_uri": securityGroupUriRef,
-		"elastic_ip_uri":     elasticIpUriRef,
-		"autoscaling":        autoscaling != nil,
-	}
-	if !data.BillingPeriod.IsNull() && !data.BillingPeriod.IsUnknown() {
-		debugMap["billing_period"] = data.BillingPeriod.ValueString()
-	}
-	tflog.Debug(ctx, "DBaaS create request", debugMap)
-
-	// Create the DBaaS instance using the SDK
-	response, err := r.client.Client.FromDatabase().DBaaS().Create(ctx, projectID, createRequest, nil)
-	if err != nil {
-		tflog.Error(ctx, "DBaaS create error", map[string]interface{}{
-			"error":      err.Error(),
-			"project_id": projectID,
-		})
-		resp.Diagnostics.AddError(
-			"Error creating DBaaS instance",
-			NewTransportError("create", "Dbaas", err).Error(),
-		)
+	if waitErr := dbaas.WaitUntilReady(ctx, aruba.WithTimeout(r.client.ResourceTimeout)); waitErr != nil {
+		ReportWaitResult(&resp.Diagnostics, waitErr, "DBaaS", data.Id.ValueString())
 		return
 	}
 
-	if apiErr := CheckResponse("create", "Dbaas", response); apiErr != nil {
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
-		return
-	}
-
-	if response != nil && response.Data != nil {
-		if response.Data.Metadata.ID != nil {
-			data.Id = types.StringValue(*response.Data.Metadata.ID)
-		}
-		if response.Data.Metadata.URI != nil {
-			data.Uri = types.StringValue(*response.Data.Metadata.URI)
-		} else {
-			data.Uri = types.StringNull()
-		}
+	// Refresh URI from re-read and preserve network from plan.
+	fresh, freshErr := r.client.Client.FromDatabase().DBaaS().Get(ctx, dbaasRef(&data))
+	if freshErr == nil {
+		data.Uri = strVal(fresh.URI())
 	} else {
-		resp.Diagnostics.AddError(
-			"Invalid API Response",
-			"DBaaS instance created but no data returned from API",
-		)
-		return
+		tflog.Warn(ctx, fmt.Sprintf("Failed to refresh DBaaS after creation: %v", freshErr))
 	}
 
-	// Wait for DBaaS to be active before returning
-	// This ensures Terraform doesn't proceed until DBaaS is ready
-	dbaasID := data.Id.ValueString()
-	checker := func(ctx context.Context) (string, error) {
-		getResp, err := r.client.Client.FromDatabase().DBaaS().Get(ctx, projectID, dbaasID, nil)
-		if err != nil {
-			return "", err
-		}
-		if getResp != nil && getResp.Data != nil && getResp.Data.Status.State != nil {
-			return *getResp.Data.Status.State, nil
-		}
-		return "Unknown", nil
-	}
-
-	// Wait for DBaaS to be active - block until ready (using configured timeout)
-	if err := WaitForResourceActive(ctx, checker, "DBaaS", dbaasID, r.client.ResourceTimeout); err != nil {
-		ReportWaitResult(&resp.Diagnostics, err, "DBaaS", dbaasID)
-		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-		return
-	}
-
-	// Re-read the DBaaS instance to populate URI
-	getResp, err := r.client.Client.FromDatabase().DBaaS().Get(ctx, projectID, dbaasID, nil)
-	if err == nil && getResp != nil && getResp.Data != nil {
-		dbaas := getResp.Data
-		if dbaas.Metadata.URI != nil {
-			data.Uri = types.StringValue(*dbaas.Metadata.URI)
-		}
-
-		// Build network object from extracted values
-		networkAttrTypes := map[string]attr.Type{
-			"vpc_uri_ref":            types.StringType,
-			"subnet_uri_ref":         types.StringType,
-			"security_group_uri_ref": types.StringType,
-			"elastic_ip_uri_ref":     types.StringType,
-		}
-		networkAttrs := map[string]attr.Value{
-			"vpc_uri_ref":            types.StringValue(vpcUriRef),
-			"subnet_uri_ref":         types.StringValue(subnetUriRef),
-			"security_group_uri_ref": types.StringValue(securityGroupUriRef),
-		}
-		if elasticIpUriRef != "" {
-			networkAttrs["elastic_ip_uri_ref"] = types.StringValue(elasticIpUriRef)
-		} else {
-			networkAttrs["elastic_ip_uri_ref"] = types.StringNull()
-		}
-		networkObj, diags := types.ObjectValue(networkAttrTypes, networkAttrs)
-		resp.Diagnostics.Append(diags...)
-		if !resp.Diagnostics.HasError() {
-			data.Network = networkObj
-		}
-	}
+	data.Network = buildNetworkObject(vpc, subnet, sg, eip)
 
 	tflog.Trace(ctx, "created a DBaaS resource", map[string]interface{}{
 		"dbaas_id":   data.Id.ValueString(),
 		"dbaas_name": data.Name.ValueString(),
 	})
-
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -477,237 +343,109 @@ func (r *DBaaSResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	projectID := data.ProjectID.ValueString()
-	dbaasID := data.Id.ValueString()
-
-	if data.Id.IsUnknown() || data.Id.IsNull() || dbaasID == "" {
-		tflog.Debug(ctx, "DBaaS ID is empty, removing resource from state", map[string]interface{}{"dbaas_id": dbaasID})
+	if data.Id.IsNull() || data.Id.ValueString() == "" {
 		resp.State.RemoveResource(ctx)
 		return
 	}
 
-	if projectID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID is required to read the DBaaS instance",
-		)
-		return
-	}
-
-	// Get DBaaS instance details using the SDK
-	response, err := r.client.Client.FromDatabase().DBaaS().Get(ctx, projectID, dbaasID, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error reading DBaaS instance",
-			NewTransportError("read", "Dbaas", err).Error(),
-		)
-		return
-	}
-
-	if apiErr := CheckResponse("read", "Dbaas", response); apiErr != nil {
-		if IsNotFound(apiErr) {
+	dbaas, err := r.client.Client.FromDatabase().DBaaS().Get(ctx, dbaasRef(&data))
+	if provErr := CheckResponseErr("read", "DBaaS", err); provErr != nil {
+		if IsNotFound(provErr) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	// If the resource is still provisioning (e.g. after a Create timeout that saved
-	// partial state), resume the wait so the next terraform apply reconciles correctly.
-	if response.Data.Status.State != nil {
-		switch st := *response.Data.Status.State; {
-		case isFailedState(st):
-			resp.Diagnostics.AddWarning(
-				"Resource in Failed State",
-				fmt.Sprintf("DBaaS %q is in a terminal failure state (%s). "+
-					"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", dbaasID, st),
-			)
-		case IsCreatingState(st):
-			checker := func(ctx context.Context) (string, error) {
-				getResp, err := r.client.Client.FromDatabase().DBaaS().Get(ctx, projectID, dbaasID, nil)
-				if err != nil {
-					return "", err
-				}
-				if getResp != nil && getResp.Data != nil && getResp.Data.Status.State != nil {
-					return *getResp.Data.Status.State, nil
-				}
-				return "Unknown", nil
-			}
-			if err := WaitForResourceActive(ctx, checker, "DBaaS", dbaasID, r.client.ResourceTimeout); err != nil {
-				ReportWaitResult(&resp.Diagnostics, err, "DBaaS", dbaasID)
-				resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-				return
-			}
-			// Re-read to get the final active state.
-			response, err = r.client.Client.FromDatabase().DBaaS().Get(ctx, projectID, dbaasID, nil)
-			if err != nil {
-				resp.Diagnostics.AddError("Error reading DBaaS after provisioning wait",
-					NewTransportError("read", "Dbaas", err).Error())
-				return
-			}
-			if apiErr := CheckResponse("read", "Dbaas", response); apiErr != nil {
-				if IsNotFound(apiErr) {
-					resp.State.RemoveResource(ctx)
-					return
-				}
-				resp.Diagnostics.AddError("API Error", apiErr.Error())
-				return
-			}
+	st := string(dbaas.State())
+	switch {
+	case isFailedState(st):
+		resp.Diagnostics.AddWarning("Resource in Failed State",
+			fmt.Sprintf("DBaaS %q is in a terminal failure state (%s). "+
+				"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", data.Id.ValueString(), st))
+	case IsCreatingState(st):
+		if waitErr := dbaas.WaitUntilReady(ctx, aruba.WithTimeout(r.client.ResourceTimeout)); waitErr != nil {
+			ReportWaitResult(&resp.Diagnostics, waitErr, "DBaaS", data.Id.ValueString())
+			return
+		}
+		dbaas, err = r.client.Client.FromDatabase().DBaaS().Get(ctx, dbaasRef(&data))
+		if provErr := CheckResponseErr("read", "DBaaS", err); provErr != nil {
+			resp.Diagnostics.AddError("API Error", provErr.Error())
+			return
 		}
 	}
 
-	if response != nil && response.Data != nil {
-		dbaas := response.Data
+	// Preserve immutable fields from state.
+	projectID := data.ProjectID
+	zone := data.Zone
+	engineID := data.EngineID
+	flavor := data.Flavor
+	network := data.Network
+	storage := data.Storage
 
-		if dbaas.Metadata.ID != nil {
-			data.Id = types.StringValue(*dbaas.Metadata.ID)
-		}
-		if dbaas.Metadata.URI != nil {
-			data.Uri = types.StringValue(*dbaas.Metadata.URI)
-		} else {
-			data.Uri = types.StringNull()
-		}
-		if dbaas.Metadata.Name != nil {
-			data.Name = types.StringValue(*dbaas.Metadata.Name)
-		}
-		if dbaas.Metadata.LocationResponse != nil {
-			data.Location = types.StringValue(dbaas.Metadata.LocationResponse.Value)
-		}
-		// Zone is not in the response, preserve from state
-		// data.Zone is already set from state in Read function
-		if dbaas.Properties.Engine != nil && dbaas.Properties.Engine.ID != nil {
-			data.EngineID = types.StringValue(*dbaas.Properties.Engine.ID)
-		}
-		if dbaas.Properties.Flavor != nil && dbaas.Properties.Flavor.Name != nil {
-			data.Flavor = types.StringValue(*dbaas.Properties.Flavor.Name)
-		}
-		if dbaas.Properties.BillingPlan != nil && dbaas.Properties.BillingPlan.BillingPeriod != nil {
-			data.BillingPeriod = types.StringValue(*dbaas.Properties.BillingPlan.BillingPeriod)
-		} else {
-			data.BillingPeriod = types.StringNull()
-		}
+	data.Id = types.StringValue(dbaas.ID())
+	data.Uri = strVal(dbaas.URI())
+	data.Name = types.StringValue(dbaas.Name())
+	data.Tags = TagsToListPreserveNull(dbaas.Tags(), data.Tags)
+	data.ProjectID = projectID
+	data.Zone = zone // zone not returned by API
 
-		// Build nested storage object from API response
-		storageAttrs := make(map[string]attr.Value)
-		storageAttrTypes := map[string]attr.Type{
-			"size_gb": types.Int64Type,
-			"autoscaling": types.ObjectType{
-				AttrTypes: map[string]attr.Type{
-					"enabled":         types.BoolType,
-					"available_space": types.Int64Type,
-					"step_size":       types.Int64Type,
-				},
-			},
-		}
+	if dbaas.Region() != "" {
+		data.Location = types.StringValue(string(dbaas.Region()))
+	}
 
-		// Set storage size_gb
-		if dbaas.Properties.Storage != nil && dbaas.Properties.Storage.SizeGB != nil {
-			storageAttrs["size_gb"] = types.Int64Value(int64(*dbaas.Properties.Storage.SizeGB))
-		} else {
-			// If not in API response, preserve from state
-			if !data.Storage.IsNull() && !data.Storage.IsUnknown() {
-				storageObj, diags := data.Storage.ToObjectValue(ctx)
-				if !diags.HasError() {
-					existingAttrs := storageObj.Attributes()
-					if sizeGB, ok := existingAttrs["size_gb"]; ok {
-						storageAttrs["size_gb"] = sizeGB
-					}
-				}
-			}
-		}
-
-		// Set autoscaling - preserve from state since API response structure may differ
-		// DBaaSAutoscalingResponse has a different structure than DBaaSAutoscaling
-		// We'll preserve autoscaling from state to maintain consistency
-		if !data.Storage.IsNull() && !data.Storage.IsUnknown() {
-			storageObj, diags := data.Storage.ToObjectValue(ctx)
-			if !diags.HasError() {
-				storageAttrsFromState := storageObj.Attributes()
-				if autoscalingAttr, ok := storageAttrsFromState["autoscaling"]; ok && autoscalingAttr != nil {
-					storageAttrs["autoscaling"] = autoscalingAttr
-				} else {
-					// If no autoscaling in state, set to null
-					storageAttrs["autoscaling"] = types.ObjectNull(map[string]attr.Type{
-						"enabled":         types.BoolType,
-						"available_space": types.Int64Type,
-						"step_size":       types.Int64Type,
-					})
-				}
-			}
-		} else {
-			// If not in API response, preserve from state
-			if !data.Storage.IsNull() && !data.Storage.IsUnknown() {
-				storageObj, diags := data.Storage.ToObjectValue(ctx)
-				if !diags.HasError() {
-					existingAttrs := storageObj.Attributes()
-					if autoscaling, ok := existingAttrs["autoscaling"]; ok {
-						storageAttrs["autoscaling"] = autoscaling
-					}
-				}
-			}
-			// If no autoscaling in state either, set to null
-			if _, ok := storageAttrs["autoscaling"]; !ok {
-				storageAttrs["autoscaling"] = types.ObjectNull(map[string]attr.Type{
-					"enabled":         types.BoolType,
-					"available_space": types.Int64Type,
-					"step_size":       types.Int64Type,
-				})
-			}
-		}
-
-		// Build storage object
-		storageObj, diags := types.ObjectValue(storageAttrTypes, storageAttrs)
-		resp.Diagnostics.Append(diags...)
-		if !resp.Diagnostics.HasError() {
-			data.Storage = storageObj
-		}
-
-		// Build nested network object from state
-		// Network configuration is preserved from state since it's not in API response
-		networkAttrs := make(map[string]attr.Value)
-		networkAttrTypes := map[string]attr.Type{
-			"vpc_uri_ref":            types.StringType,
-			"subnet_uri_ref":         types.StringType,
-			"security_group_uri_ref": types.StringType,
-			"elastic_ip_uri_ref":     types.StringType,
-		}
-
-		// Preserve network configuration from state
-		if !data.Network.IsNull() && !data.Network.IsUnknown() {
-			networkObj, diags := data.Network.ToObjectValue(ctx)
-			if !diags.HasError() {
-				existingNetworkAttrs := networkObj.Attributes()
-				networkAttrs["vpc_uri_ref"] = existingNetworkAttrs["vpc_uri_ref"]
-				networkAttrs["subnet_uri_ref"] = existingNetworkAttrs["subnet_uri_ref"]
-				networkAttrs["security_group_uri_ref"] = existingNetworkAttrs["security_group_uri_ref"]
-				if elasticIp, ok := existingNetworkAttrs["elastic_ip_uri_ref"]; ok {
-					networkAttrs["elastic_ip_uri_ref"] = elasticIp
-				} else {
-					networkAttrs["elastic_ip_uri_ref"] = types.StringNull()
-				}
-			}
-		} else {
-			// If network not in state, set to null (should not happen)
-			networkAttrs["vpc_uri_ref"] = types.StringNull()
-			networkAttrs["subnet_uri_ref"] = types.StringNull()
-			networkAttrs["security_group_uri_ref"] = types.StringNull()
-			networkAttrs["elastic_ip_uri_ref"] = types.StringNull()
-		}
-
-		// Build network object
-		networkObj, diags := types.ObjectValue(networkAttrTypes, networkAttrs)
-		resp.Diagnostics.Append(diags...)
-		if !resp.Diagnostics.HasError() {
-			data.Network = networkObj
-		}
-
-		data.Tags = TagsToListPreserveNull(dbaas.Metadata.Tags, data.Tags)
+	// EngineID and Flavor: use API values if available, else preserve state.
+	if e := string(dbaas.Engine()); e != "" {
+		data.EngineID = types.StringValue(e)
 	} else {
-		resp.State.RemoveResource(ctx)
-		return
+		data.EngineID = engineID
 	}
+	if f := string(dbaas.Flavor()); f != "" {
+		data.Flavor = types.StringValue(f)
+	} else {
+		data.Flavor = flavor
+	}
+	if bp := string(dbaas.BillingPeriod()); bp != "" {
+		data.BillingPeriod = types.StringValue(bp)
+	} else {
+		data.BillingPeriod = types.StringNull()
+	}
+
+	// Storage: update size_gb from API, preserve autoscaling from state.
+	storageAttrTypes := dbaasStorageAttrTypes()
+	storageAttrs := map[string]attr.Value{}
+	if s := dbaas.SizeGB(); s > 0 {
+		storageAttrs["size_gb"] = types.Int64Value(int64(s))
+	} else if !storage.IsNull() {
+		if existingAttrs := storage.Attributes(); existingAttrs != nil {
+			if v, ok := existingAttrs["size_gb"]; ok {
+				storageAttrs["size_gb"] = v
+			}
+		}
+	}
+	if _, ok := storageAttrs["size_gb"]; !ok {
+		storageAttrs["size_gb"] = types.Int64Null()
+	}
+	// Preserve autoscaling from state.
+	if !storage.IsNull() {
+		existingAttrs := storage.Attributes()
+		if v, ok := existingAttrs["autoscaling"]; ok {
+			storageAttrs["autoscaling"] = v
+		} else {
+			storageAttrs["autoscaling"] = types.ObjectNull(storageAttrTypes["autoscaling"].(types.ObjectType).AttrTypes)
+		}
+	} else {
+		storageAttrs["autoscaling"] = types.ObjectNull(storageAttrTypes["autoscaling"].(types.ObjectType).AttrTypes)
+	}
+	storageObj, diags := types.ObjectValue(storageAttrTypes, storageAttrs)
+	resp.Diagnostics.Append(diags...)
+	if !resp.Diagnostics.HasError() {
+		data.Storage = storageObj
+	}
+
+	// Network: preserve from state (not returned by API reliably).
+	data.Network = network
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -717,57 +455,8 @@ func (r *DBaaSResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	var state DBaaSResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// Get IDs from state (not plan) - IDs are immutable and should always be in state
-	projectID := state.ProjectID.ValueString()
-	dbaasID := state.Id.ValueString()
-
-	if projectID == "" || dbaasID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID and DBaaS ID are required to update the DBaaS instance",
-		)
-		return
-	}
-
-	// Get current DBaaS instance details
-	getResponse, err := r.client.Client.FromDatabase().DBaaS().Get(ctx, projectID, dbaasID, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error fetching current DBaaS instance",
-			NewTransportError("read", "Dbaas", err).Error(),
-		)
-		return
-	}
-
-	if getResponse == nil || getResponse.Data == nil {
-		resp.Diagnostics.AddError(
-			"DBaaS Instance Not Found",
-			"DBaaS instance not found or no data returned",
-		)
-		return
-	}
-
-	current := getResponse.Data
-
-	// Get region value
-	regionValue := ""
-	if current.Metadata.LocationResponse != nil {
-		regionValue = current.Metadata.LocationResponse.Value
-	}
-	if regionValue == "" {
-		resp.Diagnostics.AddError(
-			"Missing Region",
-			"Unable to determine region value for DBaaS instance",
-		)
 		return
 	}
 
@@ -775,233 +464,63 @@ func (r *DBaaSResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	if tags == nil {
-		tags = current.Metadata.Tags
+
+	dbaas, err := r.client.Client.FromDatabase().DBaaS().Get(ctx, dbaasRef(&state))
+	if provErr := CheckResponseErr("read", "DBaaS", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
+		return
 	}
 
-	// Extract storage configuration from plan's nested storage object
-	var storageSizeGBPtr *int32
-	var autoscaling *sdktypes.DBaaSAutoscaling
-
-	if !data.Storage.IsNull() && !data.Storage.IsUnknown() {
-		storageObj, diags := data.Storage.ToObjectValue(ctx)
-		if !diags.HasError() {
-			storageAttrs := storageObj.Attributes()
-
-			// Extract size_gb
-			if sizeGBAttr, ok := storageAttrs["size_gb"].(types.Int64); ok && !sizeGBAttr.IsNull() && !sizeGBAttr.IsUnknown() {
-				storageSizeGB := int32(sizeGBAttr.ValueInt64())
-				storageSizeGBPtr = &storageSizeGB
-			} else if current.Properties.Storage != nil && current.Properties.Storage.SizeGB != nil {
-				// Fallback to current if not in plan
-				sizeGB := *current.Properties.Storage.SizeGB
-				storageSizeGBPtr = &sizeGB
-			}
-
-			// Extract autoscaling if present
-			if autoscalingAttr, ok := storageAttrs["autoscaling"]; ok && autoscalingAttr != nil {
-				if autoscalingObj, ok := autoscalingAttr.(types.Object); ok && !autoscalingObj.IsNull() && !autoscalingObj.IsUnknown() {
-					autoscalingObjValue, diags := autoscalingObj.ToObjectValue(ctx)
-					if !diags.HasError() {
-						autoscalingAttrs := autoscalingObjValue.Attributes()
-						enabledAttr, _ := autoscalingAttrs["enabled"].(types.Bool)
-						availableSpaceAttr, _ := autoscalingAttrs["available_space"].(types.Int64)
-						stepSizeAttr, _ := autoscalingAttrs["step_size"].(types.Int64)
-
-						if !enabledAttr.IsNull() && !availableSpaceAttr.IsNull() && !stepSizeAttr.IsNull() {
-							enabled := enabledAttr.ValueBool()
-							availableSpace := int32(availableSpaceAttr.ValueInt64())
-							stepSize := int32(stepSizeAttr.ValueInt64())
-							autoscaling = &sdktypes.DBaaSAutoscaling{
-								Enabled:        &enabled,
-								AvailableSpace: &availableSpace,
-								StepSize:       &stepSize,
-							}
-						}
-					}
-				}
-			} else if current.Properties.Autoscaling != nil {
-				// Fallback to current if not in plan
-				// Convert from DBaaSAutoscalingResponse to DBaaSAutoscaling
-				// Note: Response type may have different structure, extract what we can
-				availableSpace := int32(0)
-				stepSize := int32(0)
-				if current.Properties.Autoscaling.AvailableSpace != nil {
-					availableSpace = *current.Properties.Autoscaling.AvailableSpace
-				}
-				if current.Properties.Autoscaling.StepSize != nil {
-					stepSize = *current.Properties.Autoscaling.StepSize
-				}
-				// Default enabled to true if autoscaling exists (we can't determine from response)
-				enabled := true
-				autoscaling = &sdktypes.DBaaSAutoscaling{
-					Enabled:        &enabled,
-					AvailableSpace: &availableSpace,
-					StepSize:       &stepSize,
-				}
-			}
-		}
+	dbaas.Named(data.Name.ValueString())
+	if tags != nil {
+		dbaas.RetaggedAs(tags...)
 	} else {
-		// If storage not in plan, use current values
-		if current.Properties.Storage != nil && current.Properties.Storage.SizeGB != nil {
-			sizeGB := *current.Properties.Storage.SizeGB
-			storageSizeGBPtr = &sizeGB
+		dbaas.RetaggedAs(dbaas.Tags()...)
+	}
+
+	// Update storage size if changed.
+	if !data.Storage.IsNull() {
+		storageAttrs := data.Storage.Attributes()
+		if sizeAttr, ok := storageAttrs["size_gb"].(types.Int64); ok && !sizeAttr.IsNull() {
+			dbaas.SizedGB(int(sizeAttr.ValueInt64()))
 		}
-		if current.Properties.Autoscaling != nil {
-			// Convert from DBaaSAutoscalingResponse to DBaaSAutoscaling
-			availableSpace := int32(0)
-			stepSize := int32(0)
-			if current.Properties.Autoscaling.AvailableSpace != nil {
-				availableSpace = *current.Properties.Autoscaling.AvailableSpace
-			}
-			if current.Properties.Autoscaling.StepSize != nil {
-				stepSize = *current.Properties.Autoscaling.StepSize
-			}
-			// Default enabled to true if autoscaling exists
-			enabled := true
-			autoscaling = &sdktypes.DBaaSAutoscaling{
-				Enabled:        &enabled,
-				AvailableSpace: &availableSpace,
-				StepSize:       &stepSize,
+		// Update autoscaling if provided.
+		if asAttr, ok := storageAttrs["autoscaling"]; ok {
+			if asObj, ok := asAttr.(types.Object); ok && !asObj.IsNull() {
+				asAttrs := asObj.Attributes()
+				enabledAttr, _ := asAttrs["enabled"].(types.Bool)
+				availableAttr, _ := asAttrs["available_space"].(types.Int64)
+				stepAttr, _ := asAttrs["step_size"].(types.Int64)
+				if !enabledAttr.IsNull() && enabledAttr.ValueBool() {
+					dbaas.WithAutoscaling(int(availableAttr.ValueInt64()), int(stepAttr.ValueInt64()))
+				} else {
+					dbaas.WithoutAutoscaling()
+				}
 			}
 		}
 	}
 
-	// Build update request - only name and tags can be updated
-	updateRequest := sdktypes.DBaaSRequest{
-		Metadata: sdktypes.RegionalResourceMetadataRequest{
-			ResourceMetadataRequest: sdktypes.ResourceMetadataRequest{
-				Name: data.Name.ValueString(),
-				Tags: tags,
-			},
-			Location: sdktypes.LocationRequest{
-				Value: regionValue,
-			},
-		},
-		Properties: sdktypes.DBaaSPropertiesRequest{
-			// Preserve current engine if it exists
-			Engine: func() *sdktypes.DBaaSEngine {
-				if current.Properties.Engine != nil {
-					return &sdktypes.DBaaSEngine{
-						ID: current.Properties.Engine.ID,
-					}
-				}
-				return nil
-			}(),
-			// Preserve current flavor if it exists
-			Flavor: func() *sdktypes.DBaaSFlavor {
-				if current.Properties.Flavor != nil {
-					return &sdktypes.DBaaSFlavor{
-						Name: current.Properties.Flavor.Name,
-					}
-				}
-				return nil
-			}(),
-			// Use storage from plan or current
-			Storage: func() *sdktypes.DBaaSStorage {
-				if storageSizeGBPtr != nil {
-					return &sdktypes.DBaaSStorage{
-						SizeGB: storageSizeGBPtr,
-					}
-				}
-				return nil
-			}(),
-			Autoscaling: autoscaling,
-			// Preserve zone from plan or state (zone is immutable)
-			Zone: func() *string {
-				if !data.Zone.IsNull() && !data.Zone.IsUnknown() {
-					zone := data.Zone.ValueString()
-					return &zone
-				}
-				// Preserve from state if not in plan
-				if !state.Zone.IsNull() && !state.Zone.IsUnknown() {
-					zone := state.Zone.ValueString()
-					return &zone
-				}
-				return nil
-			}(),
-			// Preserve networking from Terraform state (networking is immutable)
-			// Extract from state since response type structure may differ
-			Networking: func() *sdktypes.DBaaSNetworking {
-				if !state.Network.IsNull() && !state.Network.IsUnknown() {
-					networkObj, diags := state.Network.ToObjectValue(ctx)
-					if !diags.HasError() {
-						networkAttrs := networkObj.Attributes()
-						vpcUriAttr, _ := networkAttrs["vpc_uri_ref"].(types.String)
-						subnetUriAttr, _ := networkAttrs["subnet_uri_ref"].(types.String)
-						securityGroupUriAttr, _ := networkAttrs["security_group_uri_ref"].(types.String)
-						elasticIpUriAttr, _ := networkAttrs["elastic_ip_uri_ref"].(types.String)
-
-						networking := &sdktypes.DBaaSNetworking{}
-						if !vpcUriAttr.IsNull() && !vpcUriAttr.IsUnknown() {
-							vpcUri := vpcUriAttr.ValueString()
-							networking.VPCURI = &vpcUri
-						}
-						if !subnetUriAttr.IsNull() && !subnetUriAttr.IsUnknown() {
-							subnetUri := subnetUriAttr.ValueString()
-							networking.SubnetURI = &subnetUri
-						}
-						if !securityGroupUriAttr.IsNull() && !securityGroupUriAttr.IsUnknown() {
-							securityGroupUri := securityGroupUriAttr.ValueString()
-							networking.SecurityGroupURI = &securityGroupUri
-						}
-						if !elasticIpUriAttr.IsNull() && !elasticIpUriAttr.IsUnknown() {
-							elasticIpUri := elasticIpUriAttr.ValueString()
-							networking.ElasticIPURI = &elasticIpUri
-						}
-						return networking
-					}
-				}
-				return nil
-			}(),
-		},
-	}
-
-	// Add billing period if provided, otherwise preserve from current
 	if !data.BillingPeriod.IsNull() && !data.BillingPeriod.IsUnknown() {
-		billingPeriod := data.BillingPeriod.ValueString()
-		updateRequest.Properties.BillingPlan = &sdktypes.DBaaSBillingPlan{
-			BillingPeriod: &billingPeriod,
-		}
-	} else if current.Properties.BillingPlan != nil && current.Properties.BillingPlan.BillingPeriod != nil {
-		updateRequest.Properties.BillingPlan = &sdktypes.DBaaSBillingPlan{
-			BillingPeriod: current.Properties.BillingPlan.BillingPeriod,
-		}
+		dbaas.BilledBy(aruba.BillingPeriod(data.BillingPeriod.ValueString()))
 	}
 
-	// Update the DBaaS instance using the SDK
-	response, err := r.client.Client.FromDatabase().DBaaS().Update(ctx, projectID, dbaasID, updateRequest, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error updating DBaaS instance",
-			NewTransportError("update", "Dbaas", err).Error(),
-		)
+	updated, err := r.client.Client.FromDatabase().DBaaS().Update(ctx, dbaas)
+	if provErr := CheckResponseErr("update", "DBaaS", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	if apiErr := CheckResponse("update", "Dbaas", response); apiErr != nil {
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
-		return
-	}
-
-	// Preserve immutable fields from state
+	// Preserve immutable fields.
 	data.Id = state.Id
 	data.ProjectID = state.ProjectID
 	data.Uri = state.Uri
-	// Preserve network configuration from state
-	// Network configuration is immutable, so we preserve it from state
-	data.Network = state.Network
-	// Storage is preserved from plan (which includes autoscaling)
+	data.Zone = state.Zone
+	data.EngineID = state.EngineID
+	data.Flavor = state.Flavor
+	data.Network = state.Network // network is immutable
 
-	// Re-read the DBaaS instance to get the latest state
-	getResp, err := r.client.Client.FromDatabase().DBaaS().Get(ctx, projectID, dbaasID, nil)
-	if err == nil && getResp != nil && getResp.Data != nil {
-		dbaas := getResp.Data
-		if dbaas.Metadata.URI != nil {
-			data.Uri = types.StringValue(*dbaas.Metadata.URI)
-		}
-		// Note: Network URI references are preserved from state
-		// They are not yet available in the SDK response structure
+	if updated.URI() != "" {
+		data.Uri = types.StringValue(updated.URI())
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -1014,25 +533,12 @@ func (r *DBaaSResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 		return
 	}
 
-	projectID := data.ProjectID.ValueString()
+	ref := dbaasRef(&data)
 	dbaasID := data.Id.ValueString()
 
-	if projectID == "" || dbaasID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID and DBaaS ID are required to delete the DBaaS instance",
-		)
-		return
-	}
-
-	// Delete the DBaaS instance using the SDK with retry mechanism
-	// Retry on any error except 404 (Resource Not Found)
 	deletionChecker := func(ctx context.Context) (bool, error) {
-		getResp, getErr := r.client.Client.FromDatabase().DBaaS().Get(ctx, projectID, dbaasID, nil)
-		if getErr != nil {
-			return false, NewTransportError("get", "DBaaS", getErr)
-		}
-		if provErr := CheckResponse("get", "DBaaS", getResp); provErr != nil {
+		_, getErr := r.client.Client.FromDatabase().DBaaS().Get(ctx, ref)
+		if provErr := CheckResponseErr("get", "DBaaS", getErr); provErr != nil {
 			if IsNotFound(provErr) {
 				return true, nil
 			}
@@ -1042,37 +548,19 @@ func (r *DBaaSResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 	}
 
 	deleteStart := time.Now()
-	err := DeleteResourceWithRetry(
-		ctx,
-		func() error {
-			resp, err := r.client.Client.FromDatabase().DBaaS().Delete(ctx, projectID, dbaasID, nil)
-			if err != nil {
-				return NewTransportError("delete", "DBaaS", err)
-			}
-			return CheckResponse("delete", "DBaaS", resp)
-		},
-		"DBaaS",
-		dbaasID,
-		r.client.ResourceTimeout,
-		deletionChecker,
-	)
-
+	err := DeleteResourceWithRetry(ctx, func() error {
+		return CheckResponseErr("delete", "DBaaS",
+			r.client.Client.FromDatabase().DBaaS().Delete(ctx, ref))
+	}, "DBaaS", dbaasID, r.client.ResourceTimeout, deletionChecker)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error deleting DBaaS instance",
-			NewTransportError("delete", "Dbaas", err).Error(),
-		)
+		resp.Diagnostics.AddError("Error deleting DBaaS", err.Error())
 		return
 	}
-
 	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "DBaaS", dbaasID, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
 		resp.Diagnostics.AddError("Error waiting for DBaaS deletion", waitErr.Error())
 		return
 	}
-
-	tflog.Trace(ctx, "deleted a DBaaS resource", map[string]interface{}{
-		"dbaas_id": dbaasID,
-	})
+	tflog.Trace(ctx, "deleted a DBaaS resource", map[string]interface{}{"dbaas_id": dbaasID})
 }
 
 func (r *DBaaSResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/internal/provider/dbaasuser_data_source.go
+++ b/internal/provider/dbaasuser_data_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -91,27 +92,18 @@ func (d *DBaaSUserDataSource) Read(ctx context.Context, req datasource.ReadReque
 		return
 	}
 
-	response, err := d.client.Client.FromDatabase().Users().Get(ctx, projectID, dbaasID, username, nil)
-	if err != nil {
-		resp.Diagnostics.AddError("Error reading DBaaS user", NewTransportError("read", "Dbaasuser", err).Error())
-		return
-	}
-	if apiErr := CheckResponse("read", "Dbaasuser", response); apiErr != nil {
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
-		return
-	}
-	if response == nil || response.Data == nil {
-		resp.Diagnostics.AddError("No data returned", "DBaaS User Get returned no data")
+	user, err := d.client.Client.FromDatabase().Users().Get(ctx,
+		aruba.URI("/projects/"+projectID+"/providers/Aruba.Database/dbaas/"+dbaasID+"/users/"+username))
+	if provErr := CheckResponseErr("read", "DBaaSUser", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	user := response.Data
-	data.Id = types.StringValue(user.Username)
-	data.Username = types.StringValue(user.Username)
+	data.Id = types.StringValue(user.Username())
+	data.Username = types.StringValue(user.Username())
 	data.ProjectID = types.StringValue(projectID)
 	data.DBaaSID = types.StringValue(dbaasID)
-	// Password is not returned by the API
-	data.Password = types.StringNull()
+	data.Password = types.StringNull() // password is write-only
 
 	tflog.Trace(ctx, "read a DBaaS User data source", map[string]interface{}{"username": username})
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/dbaasuser_resource.go
+++ b/internal/provider/dbaasuser_resource.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	sdktypes "github.com/Arubacloud/sdk-go/pkg/types"
+	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -86,6 +86,12 @@ func (r *DBaaSUserResource) Configure(ctx context.Context, req resource.Configur
 	r.client = client
 }
 
+func dbaasUserRef(data *DBaaSUserResourceModel) aruba.Ref {
+	return aruba.URI("/projects/" + data.ProjectID.ValueString() +
+		"/providers/Aruba.Database/dbaas/" + data.DBaaSID.ValueString() +
+		"/users/" + data.Id.ValueString())
+}
+
 func (r *DBaaSUserResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data DBaaSUserResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
@@ -95,76 +101,44 @@ func (r *DBaaSUserResource) Create(ctx context.Context, req resource.CreateReque
 
 	projectID := data.ProjectID.ValueString()
 	dbaasID := data.DBaaSID.ValueString()
-
-	if projectID == "" || dbaasID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID and DBaaS ID are required to create a DBaaS user",
-		)
-		return
-	}
-
-	// Build the create request
-	// Password must be base64 encoded for the API
+	username := data.Username.ValueString()
 	passwordBase64 := base64.StdEncoding.EncodeToString([]byte(data.Password.ValueString()))
-	createRequest := sdktypes.UserRequest{
-		Username: data.Username.ValueString(),
-		Password: passwordBase64,
-	}
 
-	// Create the user using the SDK, retrying on transient errors (e.g. when the
-	// parent DBaaS is still in InCreation and returns 400 category:transient).
-	var response *sdktypes.Response[sdktypes.UserResponse]
-	if createErr := CreateWithTransientRetry(
-		ctx,
-		func() error {
-			var err error
-			response, err = r.client.Client.FromDatabase().Users().Create(ctx, projectID, dbaasID, createRequest, nil)
-			if err != nil {
-				return NewTransportError("create", "Dbaasuser", err)
-			}
-			return CheckResponse("create", "Dbaasuser", response)
-		},
-		"DBaaSUser",
-		data.Username.ValueString(),
-		r.client.ResourceTimeout,
-	); createErr != nil {
+	dbaasURI := "/projects/" + projectID + "/providers/Aruba.Database/dbaas/" + dbaasID
+
+	var user *aruba.User
+	if createErr := CreateWithTransientRetry(ctx, func() error {
+		var err error
+		user, err = r.client.Client.FromDatabase().Users().Create(ctx,
+			aruba.NewUser().
+				WithUsername(username).
+				WithPassword(passwordBase64).
+				InDBaaS(aruba.URI(dbaasURI)),
+		)
+		return CheckResponseErr("create", "DBaaSUser", err)
+	}, "DBaaSUser", username, r.client.ResourceTimeout); createErr != nil {
 		resp.Diagnostics.AddError("Error creating DBaaS user", createErr.Error())
 		return
 	}
 
-	if response != nil && response.Data != nil {
-		// User uses username as ID
-		data.Id = types.StringValue(response.Data.Username)
-		// UserResponse doesn't have Metadata.URI
-		data.Uri = types.StringNull()
-	} else {
-		resp.Diagnostics.AddError(
-			"Invalid API Response",
-			"DBaaS user created but no data returned from API",
-		)
+	data.Id = types.StringValue(user.Username())
+	data.Uri = strVal(user.URI())
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Wait for DBaaS User to be active before returning
-	// This ensures Terraform doesn't proceed until User is ready
-	username := data.Id.ValueString()
+	// Users don't have a status field; wait until we can successfully Get the user.
 	checker := func(ctx context.Context) (string, error) {
-		getResp, err := r.client.Client.FromDatabase().Users().Get(ctx, projectID, dbaasID, username, nil)
-		if err != nil {
-			return "", err
+		_, getErr := r.client.Client.FromDatabase().Users().Get(ctx, dbaasUserRef(&data))
+		if provErr := CheckResponseErr("get", "DBaaSUser", getErr); provErr != nil {
+			return "Unknown", nil
 		}
-		// Users don't have a status field, so if we can get it, it's ready
-		if getResp != nil && getResp.Data != nil {
-			return "Active", nil
-		}
-		return "Unknown", nil
+		return "Active", nil
 	}
-
-	// Wait for DBaaS User to be active - block until ready (using configured timeout)
 	if err := WaitForResourceActive(ctx, checker, "DBaaSUser", username, r.client.ResourceTimeout); err != nil {
 		ReportWaitResult(&resp.Diagnostics, err, "DBaaSUser", username)
-		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 		return
 	}
 
@@ -172,7 +146,6 @@ func (r *DBaaSUserResource) Create(ctx context.Context, req resource.CreateReque
 		"user_id":  data.Id.ValueString(),
 		"username": data.Username.ValueString(),
 	})
-
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -182,55 +155,25 @@ func (r *DBaaSUserResource) Read(ctx context.Context, req resource.ReadRequest, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	projectID := data.ProjectID.ValueString()
-	dbaasID := data.DBaaSID.ValueString()
-	username := data.Id.ValueString()
-
-	if data.Id.IsUnknown() || data.Id.IsNull() || username == "" {
-		tflog.Debug(ctx, "DBaaS User ID is empty, removing resource from state", map[string]interface{}{"username": username})
+	if data.Id.IsNull() || data.Id.ValueString() == "" {
 		resp.State.RemoveResource(ctx)
 		return
 	}
 
-	if projectID == "" || dbaasID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID and DBaaS ID are required to read the DBaaS user",
-		)
-		return
-	}
-
-	// Get user details using the SDK
-	response, err := r.client.Client.FromDatabase().Users().Get(ctx, projectID, dbaasID, username, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error reading DBaaS user",
-			NewTransportError("read", "Dbaasuser", err).Error(),
-		)
-		return
-	}
-
-	if apiErr := CheckResponse("read", "Dbaasuser", response); apiErr != nil {
-		if IsNotFound(apiErr) {
+	user, err := r.client.Client.FromDatabase().Users().Get(ctx, dbaasUserRef(&data))
+	if provErr := CheckResponseErr("read", "DBaaSUser", err); provErr != nil {
+		if IsNotFound(provErr) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	if response != nil && response.Data != nil {
-		user := response.Data
-		data.Id = types.StringValue(user.Username)
-		// UserResponse doesn't have Metadata.URI
-		data.Uri = types.StringNull()
-		data.Username = types.StringValue(user.Username)
-		// Password is not returned from API, so we keep the existing value
-	} else {
-		resp.State.RemoveResource(ctx)
-		return
-	}
+	data.Id = types.StringValue(user.Username())
+	data.Uri = strVal(user.URI())
+	data.Username = types.StringValue(user.Username())
+	// Password is not returned from API; preserve existing state value.
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -240,68 +183,32 @@ func (r *DBaaSUserResource) Update(ctx context.Context, req resource.UpdateReque
 	var state DBaaSUserResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Get IDs from state (not plan) - IDs are immutable and should always be in state
-	projectID := state.ProjectID.ValueString()
-	dbaasID := state.DBaaSID.ValueString()
-	username := state.Id.ValueString()
-
-	if projectID == "" || dbaasID == "" || username == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID, DBaaS ID, and Username are required to update the DBaaS user",
-		)
-		return
-	}
-
-	// Only password can be updated
-	// Password must be base64 encoded for the API
 	passwordBase64 := base64.StdEncoding.EncodeToString([]byte(data.Password.ValueString()))
-	updateRequest := sdktypes.UserRequest{
-		Username: username,
-		Password: passwordBase64,
-	}
 
-	// Update the user using the SDK
-	response, err := r.client.Client.FromDatabase().Users().Update(ctx, projectID, dbaasID, username, updateRequest, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error updating DBaaS user",
-			NewTransportError("update", "Dbaasuser", err).Error(),
-		)
+	user, err := r.client.Client.FromDatabase().Users().Get(ctx, dbaasUserRef(&state))
+	if provErr := CheckResponseErr("read", "DBaaSUser", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	if apiErr := CheckResponse("update", "Dbaasuser", response); apiErr != nil {
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
+	user.WithPassword(passwordBase64)
+
+	updated, err := r.client.Client.FromDatabase().Users().Update(ctx, user)
+	if provErr := CheckResponseErr("update", "DBaaSUser", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	if response != nil && response.Data != nil {
-		data.Id = types.StringValue(response.Data.Username)
-		// UserResponse doesn't have Metadata.URI
-		data.Uri = types.StringNull()
-		data.Username = types.StringValue(response.Data.Username)
-	}
-
-	// Ensure immutable fields are set from state before saving
 	data.Id = state.Id
 	data.ProjectID = state.ProjectID
 	data.DBaaSID = state.DBaaSID
-
-	if response != nil && response.Data != nil {
-		// Update ID from response (username can change, so use response)
-		data.Id = types.StringValue(response.Data.Username)
-		data.Username = types.StringValue(response.Data.Username)
-	}
+	data.Username = types.StringValue(updated.Username())
+	data.Uri = strVal(updated.URI())
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -313,26 +220,12 @@ func (r *DBaaSUserResource) Delete(ctx context.Context, req resource.DeleteReque
 		return
 	}
 
-	projectID := data.ProjectID.ValueString()
-	dbaasID := data.DBaaSID.ValueString()
+	ref := dbaasUserRef(&data)
 	username := data.Id.ValueString()
 
-	if projectID == "" || dbaasID == "" || username == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID, DBaaS ID, and Username are required to delete the DBaaS user",
-		)
-		return
-	}
-
-	// Delete the user using the SDK with retry mechanism
-	// Retry on any error except 404 (Resource Not Found)
 	deletionChecker := func(ctx context.Context) (bool, error) {
-		getResp, getErr := r.client.Client.FromDatabase().Users().Get(ctx, projectID, dbaasID, username, nil)
-		if getErr != nil {
-			return false, NewTransportError("get", "DBaaSUser", getErr)
-		}
-		if provErr := CheckResponse("get", "DBaaSUser", getResp); provErr != nil {
+		_, getErr := r.client.Client.FromDatabase().Users().Get(ctx, ref)
+		if provErr := CheckResponseErr("get", "DBaaSUser", getErr); provErr != nil {
 			if IsNotFound(provErr) {
 				return true, nil
 			}
@@ -342,37 +235,19 @@ func (r *DBaaSUserResource) Delete(ctx context.Context, req resource.DeleteReque
 	}
 
 	deleteStart := time.Now()
-	err := DeleteResourceWithRetry(
-		ctx,
-		func() error {
-			resp, err := r.client.Client.FromDatabase().Users().Delete(ctx, projectID, dbaasID, username, nil)
-			if err != nil {
-				return NewTransportError("delete", "DBaaSUser", err)
-			}
-			return CheckResponse("delete", "DBaaSUser", resp)
-		},
-		"DBaaSUser",
-		username,
-		r.client.ResourceTimeout,
-		deletionChecker,
-	)
-
+	err := DeleteResourceWithRetry(ctx, func() error {
+		return CheckResponseErr("delete", "DBaaSUser",
+			r.client.Client.FromDatabase().Users().Delete(ctx, ref))
+	}, "DBaaSUser", username, r.client.ResourceTimeout, deletionChecker)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error deleting DBaaS user",
-			NewTransportError("delete", "Dbaasuser", err).Error(),
-		)
+		resp.Diagnostics.AddError("Error deleting DBaaS user", err.Error())
 		return
 	}
-
 	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "DBaaSUser", username, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
 		resp.Diagnostics.AddError("Error waiting for DBaaSUser deletion", waitErr.Error())
 		return
 	}
-
-	tflog.Trace(ctx, "deleted a DBaaS User resource", map[string]interface{}{
-		"user_id": username,
-	})
+	tflog.Trace(ctx, "deleted a DBaaS User resource", map[string]interface{}{"user_id": username})
 }
 
 func (r *DBaaSUserResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/internal/provider/elasticip_data_source.go
+++ b/internal/provider/elasticip_data_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -96,59 +97,30 @@ func (d *ElasticIPDataSource) Read(ctx context.Context, req datasource.ReadReque
 	projectID := data.ProjectId.ValueString()
 	eipID := data.Id.ValueString()
 	if projectID == "" || eipID == "" {
-		resp.Diagnostics.AddError(
-			"Missing Required Fields",
-			"Project ID and Elastic IP ID (id) are required to read the Elastic IP",
-		)
+		resp.Diagnostics.AddError("Missing Required Fields", "Project ID and Elastic IP ID (id) are required to read the Elastic IP")
 		return
 	}
 
-	response, err := d.client.Client.FromNetwork().ElasticIPs().Get(ctx, projectID, eipID, nil)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error reading Elastic IP",
-			NewTransportError("read", "Elasticip", err).Error(),
-		)
-		return
-	}
-	if apiErr := CheckResponse("read", "Elasticip", response); apiErr != nil {
-		resp.Diagnostics.AddError("API Error", apiErr.Error())
-		return
-	}
-	if response == nil || response.Data == nil {
-		resp.Diagnostics.AddError(
-			"No data returned",
-			"Elastic IP Get returned no data",
-		)
+	eip, err := d.client.Client.FromNetwork().ElasticIPs().Get(ctx,
+		aruba.URI("/projects/"+projectID+"/network/elasticIPs/"+eipID))
+	if provErr := CheckResponseErr("read", "ElasticIP", err); provErr != nil {
+		resp.Diagnostics.AddError("API Error", provErr.Error())
 		return
 	}
 
-	eip := response.Data
+	data.Id = types.StringValue(eip.ID())
+	data.Name = types.StringValue(eip.Name())
+	data.ProjectId = types.StringValue(projectID)
+	data.Tags = TagsToListPreserveNull(eip.Tags(), data.Tags)
+	data.Address = strVal(eip.Address())
+	data.BillingPeriod = strVal(string(eip.BillingPeriod()))
 
-	if eip.Metadata.ID != nil {
-		data.Id = types.StringValue(*eip.Metadata.ID)
-	}
-	if eip.Metadata.Name != nil {
-		data.Name = types.StringValue(*eip.Metadata.Name)
-	}
-	if eip.Metadata.LocationResponse != nil {
-		data.Location = types.StringValue(eip.Metadata.LocationResponse.Value)
+	raw := eip.Raw()
+	if raw != nil && raw.Metadata.LocationResponse != nil {
+		data.Location = types.StringValue(string(raw.Metadata.LocationResponse.Value))
 	} else {
 		data.Location = types.StringNull()
 	}
-	data.ProjectId = types.StringValue(projectID)
-	if eip.Properties.Address != nil {
-		data.Address = types.StringValue(*eip.Properties.Address)
-	} else {
-		data.Address = types.StringNull()
-	}
-	if eip.Properties.BillingPlan.BillingPeriod != "" {
-		data.BillingPeriod = types.StringValue(billingPeriodFromAPI(eip.Properties.BillingPlan.BillingPeriod))
-	} else {
-		data.BillingPeriod = types.StringNull()
-	}
-
-	data.Tags = TagsToListPreserveNull(eip.Metadata.Tags, data.Tags)
 
 	tflog.Trace(ctx, "read an Elastic IP data source", map[string]interface{}{"eip_id": eipID})
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/elasticip_resource.go
+++ b/internal/provider/elasticip_resource.go
@@ -170,7 +170,7 @@ func applyEIPToModel(eip *aruba.ElasticIP, data *ElasticIPResourceModel) {
 	data.Address = strVal(eip.Address())
 	raw := eip.Raw()
 	if raw != nil && raw.Metadata.LocationResponse != nil {
-		data.Location = types.StringValue(raw.Metadata.LocationResponse.Value)
+		data.Location = types.StringValue(string(raw.Metadata.LocationResponse.Value))
 	}
 }
 
@@ -288,7 +288,7 @@ func (r *ElasticIPResource) Delete(ctx context.Context, req resource.DeleteReque
 
 	deleteStart := time.Now()
 	err := DeleteResourceWithRetry(ctx, func() error {
-		_, delErr := r.client.Client.FromNetwork().ElasticIPs().Delete(ctx, ref)
+		delErr := r.client.Client.FromNetwork().ElasticIPs().Delete(ctx, ref)
 		return CheckResponseErr("delete", "ElasticIP", delErr)
 	}, "ElasticIP", eipID, r.client.ResourceTimeout, deletionChecker)
 	if err != nil {


### PR DESCRIPTION
## Summary

Migrates DBaaS, Database, DBaaSUser, DBaaSBackup, and DatabaseGrant (resources + data sources) to the sdk-go v1.0.4 builder/wrapper API. Eliminates all `pkg/types` imports from these 10 files. Also fixes pre-existing compile errors in `elasticip_resource.go` and `elasticip_data_source.go` that were hidden by the Go compiler's 10-error limit.

## Pattern applied

| Before | After |
|---|---|
| `sdktypes.DBaaSRequest{...}` | `aruba.NewDBaaS()...OfEngine(...).OfFlavor(...).SizedGB(...).WithVPC(...)` |
| `sdktypes.UserRequest{Username, Password}` | `aruba.NewUser().WithUsername(...).WithPassword(base64pw).InDBaaS(ref)` |
| `sdktypes.DatabaseRequest{Name}` | `aruba.NewDatabase().Named(...).InDBaaS(ref)` |
| `sdktypes.BackupRequest{...}` | `aruba.NewDBaaSBackup()...FromDBaaS(dbaasRef).FromDatabase(dbRef).BilledBy(...)` |
| `sdktypes.GrantRequest{User, Role}` | `aruba.NewGrant().InDatabase(dbRef).ForUser(username).OfRole(role)` |
| `DBaaS().Create(ctx, projectID, request, nil)` | `DBaaS().Create(ctx, builder)` |
| `CheckResponse("op", "res", response)` | `CheckResponseErr("op", "res", err)` |
| Explicit `var response *sdktypes.Response[T]` | Eliminated — wrapper returned directly |
| `WaitForResourceActive()` custom checker | `dbaas.WaitUntilReady()` for DBaaS/DBaaSBackup; custom checker for User/Database |

## Notes
- DBaaS and DBaaSBackup embed `statusMixin` and support `WaitUntilReady()`; User, Database, Grant are Family B types without status
- Grant resource keeps composite ID pattern (`project_id/dbaas_id/database/user_id`) for backward compatibility; `userID` is used as the grant key in the URI
- DBaaSBackup does not support updates (warning preserved from prior behavior)
- Network URIs for DBaaS are preserved from state on Read (not returned reliably by API)
- `CreateWithTransientRetry` preserved for DBaaSUser and Database (parent DBaaS may still be in creation)
- ElasticIP compile fixes: Region type cast, Delete return-value assignment, old Get signature

## Test plan
- [ ] Acceptance test `TestAccDBaaSResource` passes
- [ ] Acceptance test `TestAccDatabaseResource` passes
- [ ] Acceptance test `TestAccDBaaSUserResource` passes
- [ ] Acceptance test `TestAccDatabaseBackupResource` passes
- [ ] Acceptance test `TestAccDatabaseGrantResource` passes

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)