### PR TITLE
refactor: eliminate pkg/types import from production code (#143)

### DIFF
--- a/internal/provider/provider_error.go
+++ b/internal/provider/provider_error.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
-	sdktypes "github.com/Arubacloud/sdk-go/pkg/types"
 )
 
 // ProviderErrorCategory classifies an API error as semantic, transient, or technical.
@@ -146,63 +145,18 @@ func NewTransportError(operation, resource string, err error) *ProviderError {
 	}
 }
 
-// newResponseError creates a ProviderError from a non-success HTTP response.
-// For HTTP 4xx: Semantic when ErrorResponse.Errors is non-empty (field-level validation
+// newResponseError creates a ProviderError from pre-extracted HTTP response fields.
+// For HTTP 4xx: Semantic when hasValidationErrors is true (field-level validation
 // failures), Transient otherwise. For everything else: Technical.
-func newResponseError(operation, resource string, statusCode int, errResp *sdktypes.ErrorResponse, rawBody []byte) *ProviderError {
+func newResponseError(operation, resource string, statusCode int, title, detail, instance string, hasValidationErrors bool) *ProviderError {
 	category := ProviderErrorCategoryTechnical
 	if statusCode >= 400 && statusCode < 500 {
-		if errResp != nil && len(errResp.Errors) > 0 {
+		if hasValidationErrors {
 			category = ProviderErrorCategorySemantic
 		} else {
 			category = ProviderErrorCategoryTransient
 		}
 	}
-
-	title, detail, instance := "", "", ""
-	if errResp != nil {
-		if errResp.Title != nil {
-			title = sanitizeAPIString(*errResp.Title)
-		}
-		if errResp.Detail != nil {
-			detail = sanitizeAPIString(*errResp.Detail)
-		}
-		if errResp.Instance != nil {
-			instance = sanitizeAPIString(*errResp.Instance)
-		}
-		if len(errResp.Errors) > 0 {
-			parts := make([]string, 0, len(errResp.Errors))
-			for _, ve := range errResp.Errors {
-				switch {
-				case ve.Field != "" && ve.Message != "":
-					parts = append(parts, ve.Field+": "+ve.Message)
-				case ve.Message != "":
-					parts = append(parts, ve.Message)
-				case ve.Field != "":
-					parts = append(parts, ve.Field+": invalid")
-				}
-			}
-			if len(parts) > 0 {
-				validationDetail := sanitizeAPIString(strings.Join(parts, "; "))
-				if detail != "" {
-					detail = detail + " | Validation: " + validationDetail
-				} else {
-					detail = "Validation: " + validationDetail
-				}
-			} else {
-				// Typed Field/Message extraction produced nothing; fall back to raw body.
-				rawDetail := formatRawValidationErrors(rawBody)
-				if rawDetail != "" {
-					if detail != "" {
-						detail = detail + " | Validation: " + rawDetail
-					} else {
-						detail = "Validation: " + rawDetail
-					}
-				}
-			}
-		}
-	}
-
 	return &ProviderError{
 		Category:   category,
 		StatusCode: statusCode,
@@ -224,7 +178,51 @@ func CheckResponseErr(operation, resource string, err error) *ProviderError {
 	}
 	var httpErr *aruba.HTTPError
 	if errors.As(err, &httpErr) {
-		return newResponseError(operation, resource, httpErr.StatusCode, httpErr.ErrResp, httpErr.Body)
+		title, detail, instance := "", "", ""
+		hasValidationErrors := false
+		if httpErr.ErrResp != nil {
+			if httpErr.ErrResp.Title != nil {
+				title = sanitizeAPIString(*httpErr.ErrResp.Title)
+			}
+			if httpErr.ErrResp.Detail != nil {
+				detail = sanitizeAPIString(*httpErr.ErrResp.Detail)
+			}
+			if httpErr.ErrResp.Instance != nil {
+				instance = sanitizeAPIString(*httpErr.ErrResp.Instance)
+			}
+			if len(httpErr.ErrResp.Errors) > 0 {
+				hasValidationErrors = true
+				parts := make([]string, 0, len(httpErr.ErrResp.Errors))
+				for _, ve := range httpErr.ErrResp.Errors {
+					switch {
+					case ve.Field != "" && ve.Message != "":
+						parts = append(parts, ve.Field+": "+ve.Message)
+					case ve.Message != "":
+						parts = append(parts, ve.Message)
+					case ve.Field != "":
+						parts = append(parts, ve.Field+": invalid")
+					}
+				}
+				if len(parts) > 0 {
+					validationDetail := sanitizeAPIString(strings.Join(parts, "; "))
+					if detail != "" {
+						detail = detail + " | Validation: " + validationDetail
+					} else {
+						detail = "Validation: " + validationDetail
+					}
+				} else {
+					rawDetail := formatRawValidationErrors(httpErr.Body)
+					if rawDetail != "" {
+						if detail != "" {
+							detail = detail + " | Validation: " + rawDetail
+						} else {
+							detail = "Validation: " + rawDetail
+						}
+					}
+				}
+			}
+		}
+		return newResponseError(operation, resource, httpErr.StatusCode, title, detail, instance, hasValidationErrors)
 	}
 	return NewTransportError(operation, resource, err)
 }

--- a/internal/provider/provider_error_test.go
+++ b/internal/provider/provider_error_test.go
@@ -104,7 +104,7 @@ func contains(s, sub string) bool {
 		}())
 }
 
-func TestNewResponseError_TypedExtractionWorks(t *testing.T) {
+func TestCheckResponseErr_TypedExtractionWorks(t *testing.T) {
 	errResp := &sdktypes.ErrorResponse{
 		Title: strPtr("One or more validation errors occurred."),
 		Errors: []sdktypes.ValidationError{
@@ -112,8 +112,9 @@ func TestNewResponseError_TypedExtractionWorks(t *testing.T) {
 		},
 	}
 	rawBody := []byte(`{"title":"One or more validation errors occurred.","errors":[{"propertyName":"Tag","errorMessage":"length must be at least 4"}]}`)
+	httpErr := &aruba.HTTPError{StatusCode: 400, ErrResp: errResp, Body: rawBody}
 
-	err := newResponseError("create", "Schedulejob", 400, errResp, rawBody)
+	err := CheckResponseErr("create", "Schedulejob", httpErr)
 
 	if err.Category != ProviderErrorCategorySemantic {
 		t.Errorf("expected semantic, got %v", err.Category)
@@ -127,7 +128,7 @@ func TestNewResponseError_TypedExtractionWorks(t *testing.T) {
 	}
 }
 
-func TestNewResponseError_FallbackToRawBody(t *testing.T) {
+func TestCheckResponseErr_FallbackToRawBody(t *testing.T) {
 	// Errors array has entries but Field/Message are empty (API uses different keys).
 	errResp := &sdktypes.ErrorResponse{
 		Title: strPtr("One or more validation errors occurred."),
@@ -136,8 +137,9 @@ func TestNewResponseError_FallbackToRawBody(t *testing.T) {
 		},
 	}
 	rawBody := []byte(`{"title":"One or more validation errors occurred.","errors":[{"propertyName":"CronExpression","errorMessage":"invalid cron format"}]}`)
+	httpErr := &aruba.HTTPError{StatusCode: 400, ErrResp: errResp, Body: rawBody}
 
-	err := newResponseError("create", "Schedulejob", 400, errResp, rawBody)
+	err := CheckResponseErr("create", "Schedulejob", httpErr)
 
 	if err.Category != ProviderErrorCategorySemantic {
 		t.Errorf("expected semantic, got %v", err.Category)
@@ -147,13 +149,14 @@ func TestNewResponseError_FallbackToRawBody(t *testing.T) {
 	}
 }
 
-func TestNewResponseError_NilRawBodyDoesNotPanic(t *testing.T) {
+func TestCheckResponseErr_NilBodyDoesNotPanic(t *testing.T) {
 	errResp := &sdktypes.ErrorResponse{
 		Title:  strPtr("One or more validation errors occurred."),
 		Errors: []sdktypes.ValidationError{{}},
 	}
+	httpErr := &aruba.HTTPError{StatusCode: 400, ErrResp: errResp, Body: nil}
 
-	err := newResponseError("create", "Schedulejob", 400, errResp, nil)
+	err := CheckResponseErr("create", "Schedulejob", httpErr)
 
 	if err.Category != ProviderErrorCategorySemantic {
 		t.Errorf("expected semantic, got %v", err.Category)
@@ -162,14 +165,15 @@ func TestNewResponseError_NilRawBodyDoesNotPanic(t *testing.T) {
 	_ = err.Error()
 }
 
-func TestNewResponseError_TransientNotConsultingRawBody(t *testing.T) {
+func TestCheckResponseErr_TransientNotConsultingRawBody(t *testing.T) {
 	errResp := &sdktypes.ErrorResponse{
 		Title:  strPtr("Conflict"),
 		Errors: []sdktypes.ValidationError{}, // empty → transient
 	}
 	rawBody := []byte(`{"title":"Conflict","errors":[{"propertyName":"Name","errorMessage":"must be unique"}]}`)
+	httpErr := &aruba.HTTPError{StatusCode: 409, ErrResp: errResp, Body: rawBody}
 
-	err := newResponseError("create", "Resource", 409, errResp, rawBody)
+	err := CheckResponseErr("create", "Resource", httpErr)
 
 	if err.Category != ProviderErrorCategoryTransient {
 		t.Errorf("expected transient, got %v", err.Category)
@@ -180,8 +184,8 @@ func TestNewResponseError_TransientNotConsultingRawBody(t *testing.T) {
 	}
 }
 
-func TestNewResponseError_NilErrResp(t *testing.T) {
-	err := newResponseError("create", "Resource", 500, nil, nil)
+func TestCheckResponseErr_NilErrResp(t *testing.T) {
+	err := CheckResponseErr("create", "Resource", &aruba.HTTPError{StatusCode: 500, ErrResp: nil})
 	if err.Category != ProviderErrorCategoryTechnical {
 		t.Errorf("expected technical, got %v", err.Category)
 	}

--- a/internal/provider/resource_wait_extra_test.go
+++ b/internal/provider/resource_wait_extra_test.go
@@ -21,7 +21,7 @@ import (
 // starts the sleep (5 s for attempt=1) — but the context cancels at 10 ms and
 // the ctx.Done() case fires, covering the sleep select branch.
 func TestCreateWithTransientRetry_ContextCancelDuringRetryWait(t *testing.T) {
-	transient := newResponseError("create", "vpc", 400, nil, nil)
+	transient := newResponseError("create", "vpc", 400, "", "", "", false)
 	if !ErrorIsTransient(transient) {
 		t.Fatal("test setup: expected 400 with no validation errors to be transient")
 	}
@@ -52,7 +52,7 @@ func TestCreateWithTransientRetry_ContextCancelDuringRetryWait(t *testing.T) {
 // We achieve this by cancelling the context from inside createFunc so the
 // context is already done when the loop iterates for the second time.
 func TestCreateWithTransientRetry_ContextCancelAtLoopTop(t *testing.T) {
-	transient := newResponseError("create", "vpc", 400, nil, nil)
+	transient := newResponseError("create", "vpc", 400, "", "", "", false)
 
 	ctx, cancel := context.WithCancel(context.Background())
 

--- a/internal/provider/resource_wait_test.go
+++ b/internal/provider/resource_wait_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	sdktypes "github.com/Arubacloud/sdk-go/pkg/types"
 	tfdiag "github.com/hashicorp/terraform-plugin-framework/diag"
 )
@@ -312,7 +313,7 @@ func TestDeleteResourceWithRetry_SucceedsOnFirstAttempt(t *testing.T) {
 func TestDeleteResourceWithRetry_NotFoundTreatedAsSuccess(t *testing.T) {
 	withFastDeleteRetry(t)
 
-	notFound := newResponseError("delete", "kaas", 404, nil, nil)
+	notFound := newResponseError("delete", "kaas", 404, "", "", "", false)
 	deleteFunc := func() error { return notFound }
 
 	if err := DeleteResourceWithRetry(context.Background(), deleteFunc, "kaas", "abc", time.Second); err != nil {
@@ -323,7 +324,7 @@ func TestDeleteResourceWithRetry_NotFoundTreatedAsSuccess(t *testing.T) {
 func TestDeleteResourceWithRetry_SucceedsAfterRetry(t *testing.T) {
 	withFastDeleteRetry(t)
 
-	boom := newResponseError("delete", "kaas", 500, nil, nil)
+	boom := newResponseError("delete", "kaas", 500, "", "", "", false)
 	var calls int32
 	deleteFunc := func() error {
 		n := atomic.AddInt32(&calls, 1)
@@ -344,7 +345,7 @@ func TestDeleteResourceWithRetry_SucceedsAfterRetry(t *testing.T) {
 func TestDeleteResourceWithRetry_TimeoutReturnsError(t *testing.T) {
 	withFastDeleteRetry(t)
 
-	boom := newResponseError("delete", "kaas", 500, nil, nil)
+	boom := newResponseError("delete", "kaas", 500, "", "", "", false)
 	deleteFunc := func() error { return boom }
 
 	err := DeleteResourceWithRetry(context.Background(), deleteFunc, "kaas", "abc", 20*time.Millisecond)
@@ -356,7 +357,7 @@ func TestDeleteResourceWithRetry_TimeoutReturnsError(t *testing.T) {
 func TestDeleteResourceWithRetry_ContextCancelledReturnsError(t *testing.T) {
 	withFastDeleteRetry(t)
 
-	boom := newResponseError("delete", "kaas", 500, nil, nil)
+	boom := newResponseError("delete", "kaas", 500, "", "", "", false)
 	deleteFunc := func() error { return boom }
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -371,7 +372,7 @@ func TestDeleteResourceWithRetry_ContextCancelledReturnsError(t *testing.T) {
 func TestDeleteResourceWithRetry_ExistsCheckerShortCircuitsAfterFailedDelete(t *testing.T) {
 	withFastDeleteRetry(t)
 
-	boom := newResponseError("delete", "kaas", 400, nil, nil)
+	boom := newResponseError("delete", "kaas", 400, "", "", "", false)
 	var deleteCalls, checkerCalls int32
 
 	deleteFunc := func() error {
@@ -469,7 +470,7 @@ func TestReportWaitResult_OtherErrorAddsError(t *testing.T) {
 func TestWaitForResourceDeleted_RecognisesNotFoundPattern(t *testing.T) {
 	withFastPoll(t)
 
-	notFound := newResponseError("get", "kaas", 404, nil, nil)
+	notFound := newResponseError("get", "kaas", 404, "", "", "", false)
 	if !IsNotFound(notFound) {
 		t.Fatalf("test setup: expected IsNotFound to recognise 404 ProviderError")
 	}
@@ -587,9 +588,12 @@ func TestCreateWithTransientRetry_SucceedsImmediately(t *testing.T) {
 }
 
 func TestCreateWithTransientRetry_NonTransientErrorReturnedImmediately(t *testing.T) {
-	semantic := newResponseError("create", "vpc", 400, &sdktypes.ErrorResponse{
-		Errors: []sdktypes.ValidationError{{Field: "name", Message: "required"}},
-	}, nil)
+	semantic := CheckResponseErr("create", "vpc", &aruba.HTTPError{
+		StatusCode: 400,
+		ErrResp: &sdktypes.ErrorResponse{
+			Errors: []sdktypes.ValidationError{{Field: "name", Message: "required"}},
+		},
+	})
 	var calls int32
 	createFunc := func() error {
 		atomic.AddInt32(&calls, 1)
@@ -605,7 +609,7 @@ func TestCreateWithTransientRetry_NonTransientErrorReturnedImmediately(t *testin
 }
 
 func TestCreateWithTransientRetry_TransientErrorTimesOut(t *testing.T) {
-	transient := newResponseError("create", "vpc", 400, nil, nil)
+	transient := newResponseError("create", "vpc", 400, "", "", "", false)
 	if !ErrorIsTransient(transient) {
 		t.Fatal("test setup: expected 400 with no validation errors to be transient")
 	}


### PR DESCRIPTION
## Summary

- Removes the last direct \pkg/types\ import from production code (closes #143)
- Refactors ewResponseError\ to take only primitive args, moving all \ruba.HTTPError.ErrResp\ field access into \CheckResponseErr\ using Go type inference (no explicit \sdktypes.*\ type names needed)
- Updates all test call sites to match the new ewResponseError\ signature

## Audit result

| Scope | Before | After |
|-------|--------|-------|
| Production files (\*.go\ excl. \*_test.go\) | 1 (provider_error.go) | **0** |
| Test files | 2 | 2 (necessary for \ruba.HTTPError.ErrResp\ fixtures) |

\go.mod\ shows a single \github.com/Arubacloud/sdk-go v1.0.4\ entry (direct dep); \pkg/types\ is a sub-package of the same module, not a separate go.mod entry.

## Test plan

- [x] \go build ./...\ passes clean
- [x] \TestCheckResponseErr*\, \TestDeleteResourceWithRetry*\, \TestCreateWithTransientRetry*\ all pass
- [ ] Full acceptance test run in CI

Part of #146 (v0.2.0 migration tracking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)