### PR TITLE
fix: RequiresReplace, UseStateForUnknown, billingPeriodFromAPI normalization

### DIFF
--- a/docs/resources/backup.md
+++ b/docs/resources/backup.md
@@ -37,11 +37,11 @@ The following arguments are supported:
 
 #### Required
 
-- `location` (String) Region identifier (e.g., `ITBG-Bergamo`). See the [available locations and zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center).
+- `location` (String) Region identifier (e.g., `ITBG-Bergamo`). See the [available locations and zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center). (Immutable — changing this value forces the resource to be destroyed and re-created.)
 - `name` (String) Display name for the backup.
-- `project_id` (String) ID of the project that owns this resource.
-- `type` (String) Backup type. Accepted values: `Full`, `Incremental`.
-- `volume_id` (String) ID of the block storage volume to back up.
+- `project_id` (String) ID of the project that owns this resource. (Immutable — changing this value forces the resource to be destroyed and re-created.)
+- `type` (String) Backup type. Accepted values: `Full`, `Incremental`. (Immutable — changing this value forces the resource to be destroyed and re-created.)
+- `volume_id` (String) ID of the block storage volume to back up. (Immutable — changing this value forces the resource to be destroyed and re-created.)
 
 #### Optional
 

--- a/docs/resources/dbaas.md
+++ b/docs/resources/dbaas.md
@@ -56,14 +56,14 @@ The following arguments are supported:
 
 #### Required
 
-- `engine_id` (String) Database engine type and version identifier (e.g., `mysql-8.0` for MySQL 8.0, `postgresql-15` for PostgreSQL 15). See the [available engines](https://api.arubacloud.com/docs/metadata/#dbaas-engines).
+- `engine_id` (String) Database engine type and version identifier (e.g., `mysql-8.0` for MySQL 8.0, `postgresql-15` for PostgreSQL 15). See the [available engines](https://api.arubacloud.com/docs/metadata/#dbaas-engines). (Immutable — changing this value forces the resource to be destroyed and re-created.)
 - `flavor` (String) Compute flavour for the DBaaS cluster nodes. See [available flavours](https://api.arubacloud.com/docs/metadata/#dbaas-flavors). For example, `DBO2A4` means 2 vCPU and 4 GB RAM.
-- `location` (String) Region identifier (e.g., `ITBG-Bergamo`). See the [available locations and zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center).
+- `location` (String) Region identifier (e.g., `ITBG-Bergamo`). See the [available locations and zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center). (Immutable — changing this value forces the resource to be destroyed and re-created.)
 - `name` (String) Display name for the DBaaS cluster.
 - `network` (Attributes) Network configuration for the DBaaS instance. All URI references are immutable after creation. (see [below for nested schema](#nestedatt--network))
-- `project_id` (String) ID of the project that owns this resource.
+- `project_id` (String) ID of the project that owns this resource. (Immutable — changing this value forces the resource to be destroyed and re-created.)
 - `storage` (Attributes) Storage configuration for the DBaaS instance. (see [below for nested schema](#nestedatt--storage))
-- `zone` (String) Availability zone within the region where the DBaaS cluster is deployed.
+- `zone` (String) Availability zone within the region where the DBaaS cluster is deployed. (Immutable — changing this value forces the resource to be destroyed and re-created.)
 
 #### Optional
 

--- a/docs/resources/kaas.md
+++ b/docs/resources/kaas.md
@@ -81,10 +81,10 @@ The following arguments are supported:
 
 #### Required
 
-- `location` (String) Region identifier (e.g., `ITBG-Bergamo`). See the [available locations and zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center).
+- `location` (String) Region identifier (e.g., `ITBG-Bergamo`). See the [available locations and zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center). (Immutable — changing this value forces the resource to be destroyed and re-created.)
 - `name` (String) Display name for the KaaS cluster.
 - `network` (Attributes) Network configuration for the KaaS cluster. (see [below for nested schema](#nestedatt--network))
-- `project_id` (String) ID of the project that owns this resource.
+- `project_id` (String) ID of the project that owns this resource. (Immutable — changing this value forces the resource to be destroyed and re-created.)
 - `settings` (Attributes) Kubernetes version and node-pool configuration. (see [below for nested schema](#nestedatt--settings))
 
 #### Optional
@@ -110,8 +110,8 @@ Required:
 
 - `node_cidr` (Attributes) CIDR block assigned to cluster nodes. (see [below for nested schema](#nestedatt--network--node_cidr))
 - `security_group_name` (String) Name of the security group applied to cluster nodes.
-- `subnet_uri_ref` (String) URI of the subnet within the VPC (e.g., `arubacloud_subnet.example.uri`).
-- `vpc_uri_ref` (String) URI of the VPC that hosts the cluster (e.g., `arubacloud_vpc.example.uri`).
+- `subnet_uri_ref` (String) URI of the subnet within the VPC (e.g., `arubacloud_subnet.example.uri`). (Immutable — changing this value forces the resource to be destroyed and re-created.)
+- `vpc_uri_ref` (String) URI of the VPC that hosts the cluster (e.g., `arubacloud_vpc.example.uri`). (Immutable — changing this value forces the resource to be destroyed and re-created.)
 
 Optional:
 

--- a/docs/resources/restore.md
+++ b/docs/resources/restore.md
@@ -28,11 +28,11 @@ The following arguments are supported:
 
 #### Required
 
-- `backup_id` (String) ID of the backup to restore from.
-- `location` (String) Region identifier (e.g., `ITBG-Bergamo`). See the [available locations and zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center).
+- `backup_id` (String) ID of the backup to restore from. (Immutable — changing this value forces the resource to be destroyed and re-created.)
+- `location` (String) Region identifier (e.g., `ITBG-Bergamo`). See the [available locations and zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center). (Immutable — changing this value forces the resource to be destroyed and re-created.)
 - `name` (String) Display name for the restore operation.
-- `project_id` (String) ID of the project that owns this resource.
-- `volume_id` (String) ID of the target block storage volume to restore the backup onto.
+- `project_id` (String) ID of the project that owns this resource. (Immutable — changing this value forces the resource to be destroyed and re-created.)
+- `volume_id` (String) ID of the target block storage volume to restore the backup onto. (Immutable — changing this value forces the resource to be destroyed and re-created.)
 
 #### Optional
 

--- a/internal/provider/backup_resource.go
+++ b/internal/provider/backup_resource.go
@@ -10,6 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -49,18 +51,27 @@ func (r *BackupResource) Schema(ctx context.Context, req resource.SchemaRequest,
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Computed by the API. Unique identifier for the resource.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"uri": schema.StringAttribute{
 				MarkdownDescription: "Computed by the API. Full resource URI used as a reference value in other resources.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: "Display name for the backup.",
 				Required:            true,
 			},
 			"location": schema.StringAttribute{
-				MarkdownDescription: "Region identifier (e.g., `ITBG-Bergamo`). See the [available locations and zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center).",
+				MarkdownDescription: "Region identifier (e.g., `ITBG-Bergamo`). See the [available locations and zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center). (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"tags": schema.ListAttribute{
 				ElementType:         types.StringType,
@@ -68,16 +79,25 @@ func (r *BackupResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				Optional:            true,
 			},
 			"project_id": schema.StringAttribute{
-				MarkdownDescription: "ID of the project that owns this resource.",
+				MarkdownDescription: "ID of the project that owns this resource. (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"type": schema.StringAttribute{
-				MarkdownDescription: "Backup type. Accepted values: `Full`, `Incremental`.",
+				MarkdownDescription: "Backup type. Accepted values: `Full`, `Incremental`. (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"volume_id": schema.StringAttribute{
-				MarkdownDescription: "ID of the block storage volume to back up.",
+				MarkdownDescription: "ID of the block storage volume to back up. (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"retention_days": schema.Int64Attribute{
 				MarkdownDescription: "Number of days to retain the backup before automatic deletion. Optional — if omitted, the backup is retained indefinitely.",
@@ -240,7 +260,7 @@ func (r *BackupResource) Read(ctx context.Context, req resource.ReadRequest, res
 	if days := backup.RetentionDays(); days > 0 {
 		data.RetentionDays = types.Int64Value(int64(days))
 	}
-	if bp := string(backup.BillingPeriod()); bp != "" {
+	if bp := billingPeriodFromAPI(string(backup.BillingPeriod())); bp != "" {
 		data.BillingPeriod = types.StringValue(bp)
 	}
 

--- a/internal/provider/databasebackup_resource.go
+++ b/internal/provider/databasebackup_resource.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -48,10 +50,16 @@ func (r *DatabaseBackupResource) Schema(ctx context.Context, req resource.Schema
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Computed by the API. Unique identifier for the resource.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"uri": schema.StringAttribute{
 				MarkdownDescription: "Computed by the API. Full resource URI used as a reference value in other resources.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"project_id": schema.StringAttribute{
 				MarkdownDescription: "ID of the project that owns this resource.",
@@ -217,7 +225,7 @@ func (r *DatabaseBackupResource) Read(ctx context.Context, req resource.ReadRequ
 	if z := string(backup.Zone()); z != "" {
 		data.Zone = types.StringValue(z)
 	}
-	if bp := string(backup.BillingPeriod()); bp != "" {
+	if bp := billingPeriodFromAPI(string(backup.BillingPeriod())); bp != "" {
 		data.BillingPeriod = types.StringValue(bp)
 	}
 	// DBaaSID and Database are preserved from state (not in API response directly).

--- a/internal/provider/dbaas_resource.go
+++ b/internal/provider/dbaas_resource.go
@@ -69,12 +69,18 @@ func (r *DBaaSResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				Required:            true,
 			},
 			"location": schema.StringAttribute{
-				MarkdownDescription: "Region identifier (e.g., `ITBG-Bergamo`). See the [available locations and zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center).",
+				MarkdownDescription: "Region identifier (e.g., `ITBG-Bergamo`). See the [available locations and zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center). (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"zone": schema.StringAttribute{
-				MarkdownDescription: "Availability zone within the region where the DBaaS cluster is deployed.",
+				MarkdownDescription: "Availability zone within the region where the DBaaS cluster is deployed. (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"tags": schema.ListAttribute{
 				ElementType:         types.StringType,
@@ -82,12 +88,18 @@ func (r *DBaaSResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				Optional:            true,
 			},
 			"project_id": schema.StringAttribute{
-				MarkdownDescription: "ID of the project that owns this resource.",
+				MarkdownDescription: "ID of the project that owns this resource. (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"engine_id": schema.StringAttribute{
-				MarkdownDescription: "Database engine type and version identifier (e.g., `mysql-8.0` for MySQL 8.0, `postgresql-15` for PostgreSQL 15). See the [available engines](https://api.arubacloud.com/docs/metadata/#dbaas-engines).",
+				MarkdownDescription: "Database engine type and version identifier (e.g., `mysql-8.0` for MySQL 8.0, `postgresql-15` for PostgreSQL 15). See the [available engines](https://api.arubacloud.com/docs/metadata/#dbaas-engines). (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"flavor": schema.StringAttribute{
 				MarkdownDescription: "Compute flavour for the DBaaS cluster nodes. See [available flavours](https://api.arubacloud.com/docs/metadata/#dbaas-flavors). For example, `DBO2A4` means 2 vCPU and 4 GB RAM.",
@@ -406,7 +418,7 @@ func (r *DBaaSResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	} else {
 		data.Flavor = flavor
 	}
-	if bp := string(dbaas.BillingPeriod()); bp != "" {
+	if bp := billingPeriodFromAPI(string(dbaas.BillingPeriod())); bp != "" {
 		data.BillingPeriod = types.StringValue(bp)
 	} else {
 		data.BillingPeriod = types.StringNull()

--- a/internal/provider/error_helper.go
+++ b/internal/provider/error_helper.go
@@ -1,17 +1,1 @@
 package provider
-
-// billingPeriodFromAPI converts legacy API billing period values (hourly, monthly, yearly)
-// to the canonical Terraform form (Hour, Month, Year).
-// Values already in canonical form are returned unchanged.
-func billingPeriodFromAPI(s string) string {
-	switch s {
-	case "hourly":
-		return "Hour"
-	case "monthly":
-		return "Month"
-	case "yearly":
-		return "Year"
-	default:
-		return s
-	}
-}

--- a/internal/provider/kaas_resource.go
+++ b/internal/provider/kaas_resource.go
@@ -95,8 +95,9 @@ func (r *KaaSResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				Required:            true,
 			},
 			"location": schema.StringAttribute{
-				MarkdownDescription: "Region identifier (e.g., `ITBG-Bergamo`). See the [available locations and zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center).",
+				MarkdownDescription: "Region identifier (e.g., `ITBG-Bergamo`). See the [available locations and zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center). (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 				Required:            true,
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"tags": schema.ListAttribute{
 				ElementType:         types.StringType,
@@ -104,8 +105,9 @@ func (r *KaaSResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				Optional:            true,
 			},
 			"project_id": schema.StringAttribute{
-				MarkdownDescription: "ID of the project that owns this resource.",
+				MarkdownDescription: "ID of the project that owns this resource. (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 				Required:            true,
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"billing_period": schema.StringAttribute{
 				MarkdownDescription: "Billing cycle. Accepted values: `Hour`, `Month`, `Year`.",
@@ -125,14 +127,14 @@ func (r *KaaSResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				Required:            true,
 				Attributes: map[string]schema.Attribute{
 					"vpc_uri_ref": schema.StringAttribute{
-						MarkdownDescription: "URI of the VPC that hosts the cluster (e.g., `arubacloud_vpc.example.uri`).",
+						MarkdownDescription: "URI of the VPC that hosts the cluster (e.g., `arubacloud_vpc.example.uri`). (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 						Required:            true,
-						PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+						PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown(), stringplanmodifier.RequiresReplace()},
 					},
 					"subnet_uri_ref": schema.StringAttribute{
-						MarkdownDescription: "URI of the subnet within the VPC (e.g., `arubacloud_subnet.example.uri`).",
+						MarkdownDescription: "URI of the subnet within the VPC (e.g., `arubacloud_subnet.example.uri`). (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 						Required:            true,
-						PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+						PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown(), stringplanmodifier.RequiresReplace()},
 					},
 					"node_cidr": schema.SingleNestedAttribute{
 						MarkdownDescription: "CIDR block assigned to cluster nodes.",
@@ -547,7 +549,7 @@ func (r *KaaSResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	if kaas.Region() != "" {
 		data.Location = types.StringValue(string(kaas.Region()))
 	}
-	if bp := string(kaas.BillingPeriod()); bp != "" {
+	if bp := billingPeriodFromAPI(string(kaas.BillingPeriod())); bp != "" {
 		data.BillingPeriod = types.StringValue(bp)
 	}
 	if raw.Properties.ManagementIP != nil && *raw.Properties.ManagementIP != "" {
@@ -733,7 +735,7 @@ func (r *KaaSResource) Update(ctx context.Context, req resource.UpdateRequest, r
 			} else {
 				data.ManagementIP = types.StringNull()
 			}
-			if bp := string(fresh.BillingPeriod()); bp != "" {
+			if bp := billingPeriodFromAPI(string(fresh.BillingPeriod())); bp != "" {
 				data.BillingPeriod = types.StringValue(bp)
 			}
 		}

--- a/internal/provider/kms_resource.go
+++ b/internal/provider/kms_resource.go
@@ -118,7 +118,7 @@ func applyKMSToModel(kms *aruba.KMS, data *KMSResourceModel) {
 	if r := string(kms.Region()); r != "" {
 		data.Location = types.StringValue(r)
 	}
-	if bp := string(kms.BillingPeriod()); bp != "" {
+	if bp := billingPeriodFromAPI(string(kms.BillingPeriod())); bp != "" {
 		data.BillingPeriod = types.StringValue(bp)
 	}
 }

--- a/internal/provider/restore_resource.go
+++ b/internal/provider/restore_resource.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -46,18 +48,27 @@ func (r *RestoreResource) Schema(ctx context.Context, req resource.SchemaRequest
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Computed by the API. Unique identifier for the resource.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"uri": schema.StringAttribute{
 				MarkdownDescription: "Computed by the API. Full resource URI used as a reference value in other resources.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: "Display name for the restore operation.",
 				Required:            true,
 			},
 			"location": schema.StringAttribute{
-				MarkdownDescription: "Region identifier (e.g., `ITBG-Bergamo`). See the [available locations and zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center).",
+				MarkdownDescription: "Region identifier (e.g., `ITBG-Bergamo`). See the [available locations and zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center). (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"tags": schema.ListAttribute{
 				ElementType:         types.StringType,
@@ -65,16 +76,25 @@ func (r *RestoreResource) Schema(ctx context.Context, req resource.SchemaRequest
 				Optional:            true,
 			},
 			"project_id": schema.StringAttribute{
-				MarkdownDescription: "ID of the project that owns this resource.",
+				MarkdownDescription: "ID of the project that owns this resource. (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"backup_id": schema.StringAttribute{
-				MarkdownDescription: "ID of the backup to restore from.",
+				MarkdownDescription: "ID of the backup to restore from. (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"volume_id": schema.StringAttribute{
-				MarkdownDescription: "ID of the target block storage volume to restore the backup onto.",
+				MarkdownDescription: "ID of the target block storage volume to restore the backup onto. (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 		},
 	}

--- a/internal/provider/schedulejob_resource.go
+++ b/internal/provider/schedulejob_resource.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -47,10 +49,16 @@ func (r *ScheduleJobResource) Schema(ctx context.Context, req resource.SchemaReq
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Computed by the API. Unique identifier for the resource.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"uri": schema.StringAttribute{
 				MarkdownDescription: "Computed by the API. Full resource URI used as a reference value in other resources.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: "Display name for the scheduled job.",

--- a/internal/provider/snapshot_resource.go
+++ b/internal/provider/snapshot_resource.go
@@ -51,10 +51,16 @@ func (r *SnapshotResource) Schema(ctx context.Context, req resource.SchemaReques
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Computed by the API. Unique identifier for the resource.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"uri": schema.StringAttribute{
 				MarkdownDescription: "Computed by the API. Full resource URI used as a reference value in other resources.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: "Display name for the snapshot.",

--- a/internal/provider/tag_helpers.go
+++ b/internal/provider/tag_helpers.go
@@ -41,3 +41,20 @@ func ListToTags(ctx context.Context, list types.List, diags *diag.Diagnostics) [
 	diags.Append(list.ElementsAs(ctx, &tags, false)...)
 	return tags
 }
+
+// billingPeriodFromAPI normalizes legacy API billing period values to their
+// canonical Terraform form. The API has historically returned lowercase variants
+// ("hourly", "monthly", "yearly") that differ from the accepted input values
+// ("Hour", "Month", "Year"). Values already in canonical form pass through unchanged.
+func billingPeriodFromAPI(s string) string {
+	switch s {
+	case "hourly":
+		return "Hour"
+	case "monthly":
+		return "Month"
+	case "yearly":
+		return "Year"
+	default:
+		return s
+	}
+}

--- a/internal/provider/vpcpeering_resource.go
+++ b/internal/provider/vpcpeering_resource.go
@@ -10,6 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -47,10 +49,16 @@ func (r *VpcPeeringResource) Schema(ctx context.Context, req resource.SchemaRequ
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Computed by the API. Unique identifier for the resource.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"uri": schema.StringAttribute{
 				MarkdownDescription: "Computed by the API. Full resource URI used as a reference value in other resources (e.g., as a `*_uri_ref` attribute).",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: "Display name for the VPC peering.",

--- a/internal/provider/vpcpeeringroute_resource.go
+++ b/internal/provider/vpcpeeringroute_resource.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -48,10 +50,16 @@ func (r *VpcPeeringRouteResource) Schema(ctx context.Context, req resource.Schem
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Computed by the API. Unique identifier for the resource.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"uri": schema.StringAttribute{
 				MarkdownDescription: "Computed by the API. Full resource URI used as a reference value in other resources (e.g., as a `*_uri_ref` attribute).",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: "Display name for the VPC peering route.",
@@ -129,8 +137,8 @@ func applyVPCPeeringRouteToModel(route *aruba.VPCPeeringRoute, data *VpcPeeringR
 	if route.RemoteCIDR() != "" {
 		data.RemoteNetworkAddress = types.StringValue(route.RemoteCIDR())
 	}
-	if route.BillingPeriod() != "" {
-		data.BillingPeriod = types.StringValue(string(route.BillingPeriod()))
+	if bp := billingPeriodFromAPI(string(route.BillingPeriod())); bp != "" {
+		data.BillingPeriod = types.StringValue(bp)
 	}
 }
 

--- a/internal/provider/vpnroute_resource.go
+++ b/internal/provider/vpnroute_resource.go
@@ -10,6 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -47,10 +49,16 @@ func (r *VPNRouteResource) Schema(ctx context.Context, req resource.SchemaReques
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Computed by the API. Unique identifier for the resource.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"uri": schema.StringAttribute{
 				MarkdownDescription: "Computed by the API. Full resource URI used as a reference value in other resources (e.g., as a `*_uri_ref` attribute).",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: "Display name for the VPN route.",

--- a/internal/provider/vpntunnel_resource.go
+++ b/internal/provider/vpntunnel_resource.go
@@ -10,6 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -46,10 +48,16 @@ func (r *VPNTunnelResource) Schema(ctx context.Context, req resource.SchemaReque
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Computed by the API. Unique identifier for the resource.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"uri": schema.StringAttribute{
 				MarkdownDescription: "Computed by the API. Full resource URI used as a reference value in other resources (e.g., as a `*_uri_ref` attribute).",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: "Display name for the VPN tunnel.",


### PR DESCRIPTION
## Summary

- **Closes #161** — Adds `RequiresReplace()` to all immutable fields that were silently accepting in-place updates and corrupting state: `backup` (location, project_id, type, volume_id), `restore` (location, project_id, backup_id, volume_id), `dbaas` (location, zone, project_id, engine_id), `kaas` (location, project_id, network.vpc_uri_ref, network.subnet_uri_ref)
- **Closes #162** — Adds `UseStateForUnknown()` to `id` and `uri` on 9 resources that were missing it: `backup`, `restore`, `snapshot`, `databasebackup`, `vpcpeeringroute`, `vpnroute`, `vpntunnel`, `schedulejob`, `vpcpeering`. Prevents `(known after apply)` on every update plan.
- **Closes #163** — Applies `billingPeriodFromAPI()` normalization in all Read paths that read `billing_period` from the API. Moves the function from `error_helper.go` to `tag_helpers.go`. Eliminates perpetual plan diffs for resources with legacy billing period values.

## Files changed

| File | Change |
|---|---|
| `tag_helpers.go` | Add `billingPeriodFromAPI()` (moved from error_helper.go) |
| `error_helper.go` | Remove `billingPeriodFromAPI()` (now in tag_helpers.go) |
| `backup_resource.go` | UseStateForUnknown on id/uri; RequiresReplace on location/project_id/type/volume_id; billing normalization in Read |
| `restore_resource.go` | UseStateForUnknown on id/uri; RequiresReplace on location/project_id/backup_id/volume_id |
| `dbaas_resource.go` | RequiresReplace on location/zone/project_id/engine_id; billing normalization in Read |
| `kaas_resource.go` | RequiresReplace on location/project_id/vpc_uri_ref/subnet_uri_ref; billing normalization in Read x2 |
| `snapshot_resource.go` | UseStateForUnknown on id/uri |
| `databasebackup_resource.go` | UseStateForUnknown on id/uri; billing normalization in Read |
| `vpcpeeringroute_resource.go` | UseStateForUnknown on id/uri; billing normalization in Read |
| `vpnroute_resource.go` | UseStateForUnknown on id/uri |
| `vpntunnel_resource.go` | UseStateForUnknown on id/uri |
| `schedulejob_resource.go` | UseStateForUnknown on id/uri |
| `vpcpeering_resource.go` | UseStateForUnknown on id/uri |
| `kms_resource.go` | Billing normalization in Read |

## Test plan

- [x] `go build ./...` passes cleanly
- [x] `go test ./internal/provider/ -run "^Test[^Acc]"` — all unit tests pass
- [ ] Acceptance test: change an immutable field on a backup/restore/dbaas/kaas — verify plan shows `# forces replacement`
- [ ] Acceptance test: update name only on a backup — verify `id` and `uri` show current values in plan, not `(known after apply)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
