### PR TITLE
fix: add RequiresReplace to SecurityRule properties; remove runtime Update guard

### DIFF
--- a/docs/resources/securityrule.md
+++ b/docs/resources/securityrule.md
@@ -65,7 +65,7 @@ The following arguments are supported:
 - `location` (String) Region identifier for the resource (e.g., `ITBG-Bergamo`). See the [available locations and zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center). (Immutable — changing this value forces the resource to be destroyed and re-created.)
 - `name` (String) Display name for the security rule.
 - `project_id` (String) ID of the project that owns this resource. (Immutable — changing this value forces the resource to be destroyed and re-created.)
-- `properties` (Attributes) Traffic-matching properties of the security rule. Most fields are immutable after creation. (see [below for nested schema](#nestedatt--properties))
+- `properties` (Attributes) Traffic-matching properties of the security rule. All fields are immutable after creation — to change any of them, destroy and re-create the rule. (see [below for nested schema](#nestedatt--properties))
 - `security_group_id` (String) ID of the security group this rule belongs to. (Immutable — changing this value forces the resource to be destroyed and re-created.)
 - `vpc_id` (String) ID of the VPC this security rule belongs to. (Immutable — changing this value forces the resource to be destroyed and re-created.)
 
@@ -88,20 +88,20 @@ In addition to all arguments above, the following attributes are exported:
 Required:
 
 - `direction` (String) Traffic direction the rule applies to. Accepted values: `Ingress`, `Egress`. (Immutable — changing this value forces the resource to be destroyed and re-created.)
-- `protocol` (String) IP protocol. Accepted values: `TCP`, `UDP`, `ICMP`, `ANY` (case-insensitive).
-- `target` (Attributes) Source (inbound) or destination (outbound) endpoint for this rule. (see [below for nested schema](#nestedatt--properties--target))
+- `protocol` (String) IP protocol. Accepted values: `TCP`, `UDP`, `ICMP`, `ANY` (case-insensitive). (Immutable — changing this value forces the resource to be destroyed and re-created.)
+- `target` (Attributes) Source (inbound) or destination (outbound) endpoint for this rule. (Immutable — changing this value forces the resource to be destroyed and re-created.) (see [below for nested schema](#nestedatt--properties--target))
 
 Optional:
 
-- `port` (String) Port or port range for TCP/UDP (e.g., `80` or `8080-8090`). Use `0` for ICMP or ANY.
+- `port` (String) Port or port range for TCP/UDP (e.g., `80` or `8080-8090`). Use `0` for ICMP or ANY. (Immutable — changing this value forces the resource to be destroyed and re-created.)
 
 <a id="nestedatt--properties--target"></a>
 ### Nested Schema for `properties.target`
 
 Required:
 
-- `kind` (String) Type of the target endpoint. Accepted values: `IP`, `SecurityGroup`.
-- `value` (String) Source (inbound) or destination (outbound) CIDR in notation like `0.0.0.0/0`, or SecurityGroup URI.
+- `kind` (String) Type of the target endpoint. Accepted values: `IP`, `SecurityGroup`. (Immutable — changing this value forces the resource to be destroyed and re-created.)
+- `value` (String) Source (inbound) or destination (outbound) CIDR in notation like `0.0.0.0/0`, or SecurityGroup URI. (Immutable — changing this value forces the resource to be destroyed and re-created.)
 
 
 

--- a/internal/provider/securityrule_resource.go
+++ b/internal/provider/securityrule_resource.go
@@ -158,7 +158,7 @@ func (r *SecurityRuleResource) Schema(ctx context.Context, req resource.SchemaRe
 				Optional:            true,
 			},
 			"properties": schema.SingleNestedAttribute{
-				MarkdownDescription: "Traffic-matching properties of the security rule. Most fields are immutable after creation.",
+				MarkdownDescription: "Traffic-matching properties of the security rule. All fields are immutable after creation — to change any of them, destroy and re-create the rule.",
 				Required:            true,
 				Attributes: map[string]schema.Attribute{
 					"direction": schema.StringAttribute{
@@ -167,29 +167,42 @@ func (r *SecurityRuleResource) Schema(ctx context.Context, req resource.SchemaRe
 						Validators: []validator.String{
 							stringvalidator.OneOf("Ingress", "Egress"),
 						},
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.RequiresReplace(),
+						},
 					},
 					"protocol": schema.StringAttribute{
-						MarkdownDescription: "IP protocol. Accepted values: `TCP`, `UDP`, `ICMP`, `ANY` (case-insensitive).",
+						MarkdownDescription: "IP protocol. Accepted values: `TCP`, `UDP`, `ICMP`, `ANY` (case-insensitive). (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 						Required:            true,
 						PlanModifiers: []planmodifier.String{
 							protocolNormalizePlanModifier{},
+							stringplanmodifier.RequiresReplace(),
 						},
 					},
 					"port": schema.StringAttribute{
-						MarkdownDescription: "Port or port range for TCP/UDP (e.g., `80` or `8080-8090`). Use `0` for ICMP or ANY.",
+						MarkdownDescription: "Port or port range for TCP/UDP (e.g., `80` or `8080-8090`). Use `0` for ICMP or ANY. (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 						Optional:            true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.RequiresReplace(),
+						},
 					},
 					"target": schema.SingleNestedAttribute{
-						MarkdownDescription: "Source (inbound) or destination (outbound) endpoint for this rule.",
+						MarkdownDescription: "Source (inbound) or destination (outbound) endpoint for this rule. (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 						Required:            true,
 						Attributes: map[string]schema.Attribute{
 							"kind": schema.StringAttribute{
-								MarkdownDescription: "Type of the target endpoint. Accepted values: `IP`, `SecurityGroup`.",
+								MarkdownDescription: "Type of the target endpoint. Accepted values: `IP`, `SecurityGroup`. (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 								Required:            true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.RequiresReplace(),
+								},
 							},
 							"value": schema.StringAttribute{
-								MarkdownDescription: "Source (inbound) or destination (outbound) CIDR in notation like `0.0.0.0/0`, or SecurityGroup URI.",
+								MarkdownDescription: "Source (inbound) or destination (outbound) CIDR in notation like `0.0.0.0/0`, or SecurityGroup URI. (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 								Required:            true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.RequiresReplace(),
+								},
 							},
 						},
 					},
@@ -486,32 +499,6 @@ func (r *SecurityRuleResource) Update(ctx context.Context, req resource.UpdateRe
 	rule, err := r.client.Client.FromNetwork().SecurityGroupRules().Get(ctx, sgRuleRef(&state))
 	if provErr := CheckResponseErr("read", "SecurityRule", err); provErr != nil {
 		resp.Diagnostics.AddError("API Error", provErr.Error())
-		return
-	}
-
-	// Properties are immutable; reject if they differ from current.
-	planDirection, planProtocol, planPort, planTargetKind, planTargetValue, _ := extractRuleProperties(ctx, &data)
-	var propertiesChanged bool
-	if planDirection != "" && string(rule.Direction()) != planDirection {
-		propertiesChanged = true
-	}
-	if planProtocol != "" && !strings.EqualFold(string(rule.Protocol()), planProtocol) {
-		propertiesChanged = true
-	}
-	if planPort != "" && rule.Port() != planPort {
-		propertiesChanged = true
-	}
-	if planTargetKind != "" && normalizeTargetKind(string(rule.TargetKind())) != planTargetKind {
-		propertiesChanged = true
-	}
-	if planTargetValue != "" && rule.TargetValue() != planTargetValue {
-		propertiesChanged = true
-	}
-	if propertiesChanged {
-		resp.Diagnostics.AddError(
-			"Cannot Update Security Rule Properties",
-			"Security rule properties (direction, protocol, port, target) cannot be updated. To change properties, delete and recreate the security rule.",
-		)
 		return
 	}
 


### PR DESCRIPTION
## Summary

Closes #164

`arubacloud_securityrule` properties (`direction`, `protocol`, `port`, `target.kind`, `target.value`) are immutable after creation — the API does not allow them to be changed in-place. Previously the provider only enforced this at **apply time** via a runtime error in `Update()`, which broke the plan-apply contract: `terraform plan` showed a clean update while `terraform apply` would fail.

## Changes

**`securityrule_resource.go`**
- Added `RequiresReplace()` to `properties.direction`, `properties.protocol`, `properties.port`, `properties.target.kind`, `properties.target.value`
- Removed the `propertiesChanged` runtime guard from `Update()` — it is now unreachable dead code since Terraform will never call `Update()` for these fields
- Updated `MarkdownDescription` on all affected fields to note immutability

**`docs/resources/securityrule.md`**
- Regenerated via `make generate`

## Before / After

**Before:** changing `direction = "Egress"` to `direction = "Ingress"` produced:
```
~ resource "arubacloud_securityrule" "allow_http" {
    ~ properties = {
        ~ direction = "Egress" -> "Ingress"
      }
}
# Plan shows update — apply fails with "Cannot Update Security Rule Properties"
```

**After:**
```
-/+ resource "arubacloud_securityrule" "allow_http" {
    ~ properties = {
        ~ direction = "Egress" -> "Ingress" # forces replacement
      }
}
# Plan correctly shows destroy + create
```

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/provider/ -run "^Test[^Acc]"` — all pass
- [ ] Acceptance: change `properties.direction` on existing rule → verify plan shows `# forces replacement`
- [ ] Acceptance: confirm `Update()` only fires for name/tag changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
