### PR TITLE
fix: add ImportStateIdFunc and ImportStateVerifyIgnore to all acceptance tests

### DIFF
--- a/internal/provider/backup_resource_test.go
+++ b/internal/provider/backup_resource_test.go
@@ -55,6 +55,7 @@ func TestAccBackupResource(t *testing.T) {
 				ResourceName:      "arubacloud_backup.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateIdFunc: importIDFromAttrs("arubacloud_backup.test", "project_id", "id"),
 			},
 			// Update and Read testing
 			{

--- a/internal/provider/blockstorage_resource_test.go
+++ b/internal/provider/blockstorage_resource_test.go
@@ -60,6 +60,7 @@ func TestAccBlockStorageResource(t *testing.T) {
 				ResourceName:      "arubacloud_blockstorage.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateIdFunc: importIDFromAttrs("arubacloud_blockstorage.test", "project_id", "id"),
 			},
 			// Update and Read testing
 			{

--- a/internal/provider/cloudserver_resource_test.go
+++ b/internal/provider/cloudserver_resource_test.go
@@ -48,9 +48,11 @@ func TestAccCloudserverResource(t *testing.T) {
 			},
 			// ImportState testing
 			{
-				ResourceName:      "arubacloud_cloudserver.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "arubacloud_cloudserver.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"settings.user_data"},
+				ImportStateIdFunc:       importIDFromAttrs("arubacloud_cloudserver.test", "project_id", "id"),
 			},
 			// Update and Read testing
 			{

--- a/internal/provider/containerregistry_resource_test.go
+++ b/internal/provider/containerregistry_resource_test.go
@@ -45,6 +45,7 @@ func TestAccContainerregistryResource(t *testing.T) {
 				ResourceName:      "arubacloud_containerregistry.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateIdFunc: importIDFromAttrs("arubacloud_containerregistry.test", "project_id", "id"),
 			},
 			// Update and Read testing
 			{

--- a/internal/provider/database_resource_test.go
+++ b/internal/provider/database_resource_test.go
@@ -45,6 +45,7 @@ func TestAccDatabaseResource(t *testing.T) {
 				ResourceName:      "arubacloud_database.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateIdFunc: importIDFromAttrs("arubacloud_database.test", "project_id", "dbaas_id", "id"),
 			},
 			// Update and Read testing
 			{

--- a/internal/provider/databasebackup_resource_test.go
+++ b/internal/provider/databasebackup_resource_test.go
@@ -45,6 +45,7 @@ func TestAccDatabasebackupResource(t *testing.T) {
 				ResourceName:      "arubacloud_databasebackup.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateIdFunc: importIDFromAttrs("arubacloud_databasebackup.test", "project_id", "id"),
 			},
 			// Update and Read testing
 			{

--- a/internal/provider/databasegrant_resource_test.go
+++ b/internal/provider/databasegrant_resource_test.go
@@ -45,6 +45,7 @@ func TestAccDatabasegrantResource(t *testing.T) {
 				ResourceName:      "arubacloud_databasegrant.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateIdFunc: importIDFromAttrs("arubacloud_databasegrant.test", "project_id", "dbaas_id", "database", "user_id"),
 			},
 			// Update and Read testing
 			{

--- a/internal/provider/dbaas_resource_test.go
+++ b/internal/provider/dbaas_resource_test.go
@@ -45,6 +45,7 @@ func TestAccDbaasResource(t *testing.T) {
 				ResourceName:      "arubacloud_dbaas.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateIdFunc: importIDFromAttrs("arubacloud_dbaas.test", "project_id", "id"),
 			},
 			// Update and Read testing
 			{

--- a/internal/provider/dbaasuser_resource_test.go
+++ b/internal/provider/dbaasuser_resource_test.go
@@ -42,9 +42,11 @@ func TestAccDbaasuserResource(t *testing.T) {
 			},
 			// ImportState testing
 			{
-				ResourceName:      "arubacloud_dbaasuser.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "arubacloud_dbaasuser.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+				ImportStateIdFunc:       importIDFromAttrs("arubacloud_dbaasuser.test", "project_id", "dbaas_id", "id"),
 			},
 			// Update and Read testing
 			{

--- a/internal/provider/elasticip_resource_test.go
+++ b/internal/provider/elasticip_resource_test.go
@@ -45,6 +45,7 @@ func TestAccElasticipResource(t *testing.T) {
 				ResourceName:      "arubacloud_elasticip.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateIdFunc: importIDFromAttrs("arubacloud_elasticip.test", "project_id", "id"),
 			},
 			// Update and Read testing
 			{

--- a/internal/provider/kaas_resource_test.go
+++ b/internal/provider/kaas_resource_test.go
@@ -42,9 +42,11 @@ func TestAccKaasResource(t *testing.T) {
 			},
 			// ImportState testing
 			{
-				ResourceName:      "arubacloud_kaas.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "arubacloud_kaas.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"kubeconfig"},
+				ImportStateIdFunc:       importIDFromAttrs("arubacloud_kaas.test", "project_id", "id"),
 			},
 			// Update and Read testing
 			{

--- a/internal/provider/keypair_resource_test.go
+++ b/internal/provider/keypair_resource_test.go
@@ -37,9 +37,11 @@ func TestAccKeypairResource(t *testing.T) {
 			},
 			// ImportState testing
 			{
-				ResourceName:      "arubacloud_keypair.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "arubacloud_keypair.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"value"},
+				ImportStateIdFunc:       importIDFromAttrs("arubacloud_keypair.test", "project_id", "id"),
 			},
 			// Update and Read testing
 			{

--- a/internal/provider/kms_resource_test.go
+++ b/internal/provider/kms_resource_test.go
@@ -27,7 +27,12 @@ func TestAccKmsResource(t *testing.T) {
 					statecheck.ExpectKnownValue("arubacloud_kms.test", tfjsonpath.New("location"), knownvalue.NotNull()),
 				},
 			},
-			{ResourceName: "arubacloud_kms.test", ImportState: true, ImportStateVerify: true},
+			{
+				ResourceName:      "arubacloud_kms.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: importIDFromAttrs("arubacloud_kms.test", "project_id", "id"),
+			},
 			{
 				Config: testAccKmsResourceConfig("test-kms-updated"),
 				ConfigStateChecks: []statecheck.StateCheck{

--- a/internal/provider/project_resource_test.go
+++ b/internal/provider/project_resource_test.go
@@ -42,6 +42,7 @@ func TestAccProjectResource(t *testing.T) {
 				ResourceName:      "arubacloud_project.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateIdFunc: importIDFromAttrs("arubacloud_project.test", "id"),
 			},
 			// Update and Read testing
 			{

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -3,12 +3,15 @@ package provider
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
 	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 // testAccProtoV6ProviderFactories is used to instantiate a provider during acceptance testing.
@@ -24,6 +27,38 @@ func testAccPreCheck(t *testing.T) {
 		if os.Getenv(env) == "" {
 			t.Fatalf("acceptance tests require %s to be set", env)
 		}
+	}
+}
+
+// importIDFromAttrs builds an ImportStateIdFunc that constructs the composite import ID
+// for a resource by joining the named attributes from state with "/".
+// Use "id" to include the resource's primary ID (rs.Primary.ID).
+// Use any tfsdk attribute name (e.g. "project_id", "vpc_id") for other fields.
+//
+// Example:
+//
+//	ImportStateIdFunc: importIDFromAttrs("arubacloud_backup.test", "project_id", "id")
+//	ImportStateIdFunc: importIDFromAttrs("arubacloud_subnet.test", "project_id", "vpc_id", "id")
+func importIDFromAttrs(resourceAddr string, attrs ...string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceAddr]
+		if !ok {
+			return "", fmt.Errorf("resource %q not found in state", resourceAddr)
+		}
+		parts := make([]string, 0, len(attrs))
+		for _, attr := range attrs {
+			var v string
+			if attr == "id" {
+				v = rs.Primary.ID
+			} else {
+				v = rs.Primary.Attributes[attr]
+			}
+			if v == "" {
+				return "", fmt.Errorf("resource %q: attribute %q is empty in state", resourceAddr, attr)
+			}
+			parts = append(parts, v)
+		}
+		return strings.Join(parts, "/"), nil
 	}
 }
 

--- a/internal/provider/restore_resource_test.go
+++ b/internal/provider/restore_resource_test.go
@@ -45,6 +45,7 @@ func TestAccRestoreResource(t *testing.T) {
 				ResourceName:      "arubacloud_restore.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateIdFunc: importIDFromAttrs("arubacloud_restore.test", "project_id", "backup_id", "id"),
 			},
 			// Update and Read testing
 			{

--- a/internal/provider/schedulejob_resource_test.go
+++ b/internal/provider/schedulejob_resource_test.go
@@ -45,6 +45,7 @@ func TestAccSchedulejobResource(t *testing.T) {
 				ResourceName:      "arubacloud_schedulejob.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateIdFunc: importIDFromAttrs("arubacloud_schedulejob.test", "project_id", "id"),
 			},
 			// Update and Read testing
 			{

--- a/internal/provider/securitygroup_resource_test.go
+++ b/internal/provider/securitygroup_resource_test.go
@@ -45,6 +45,7 @@ func TestAccSecuritygroupResource(t *testing.T) {
 				ResourceName:      "arubacloud_securitygroup.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateIdFunc: importIDFromAttrs("arubacloud_securitygroup.test", "project_id", "vpc_id", "id"),
 			},
 			// Update and Read testing
 			{

--- a/internal/provider/securityrule_resource_test.go
+++ b/internal/provider/securityrule_resource_test.go
@@ -160,6 +160,7 @@ func TestAccSecurityruleResource(t *testing.T) {
 				ResourceName:      "arubacloud_securityrule.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateIdFunc: importIDFromAttrs("arubacloud_securityrule.test", "project_id", "vpc_id", "security_group_id", "id"),
 			},
 			// Update and Read testing
 			{

--- a/internal/provider/snapshot_resource_test.go
+++ b/internal/provider/snapshot_resource_test.go
@@ -45,6 +45,7 @@ func TestAccSnapshotResource(t *testing.T) {
 				ResourceName:      "arubacloud_snapshot.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateIdFunc: importIDFromAttrs("arubacloud_snapshot.test", "project_id", "id"),
 			},
 			// Update and Read testing
 			{

--- a/internal/provider/subnet_resource_test.go
+++ b/internal/provider/subnet_resource_test.go
@@ -51,6 +51,7 @@ func TestAccSubnetResource(t *testing.T) {
 				ResourceName:      "arubacloud_subnet.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateIdFunc: importIDFromAttrs("arubacloud_subnet.test", "project_id", "vpc_id", "id"),
 			},
 			// Update and Read testing
 			{

--- a/internal/provider/vpc_resource_test.go
+++ b/internal/provider/vpc_resource_test.go
@@ -50,6 +50,7 @@ func TestAccVpcResource(t *testing.T) {
 				ResourceName:      "arubacloud_vpc.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateIdFunc: importIDFromAttrs("arubacloud_vpc.test", "project_id", "id"),
 			},
 			// Update and Read testing
 			{

--- a/internal/provider/vpcpeering_resource_test.go
+++ b/internal/provider/vpcpeering_resource_test.go
@@ -45,6 +45,7 @@ func TestAccVpcpeeringResource(t *testing.T) {
 				ResourceName:      "arubacloud_vpcpeering.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateIdFunc: importIDFromAttrs("arubacloud_vpcpeering.test", "project_id", "vpc_id", "id"),
 			},
 			// Update and Read testing
 			{

--- a/internal/provider/vpcpeeringroute_resource_test.go
+++ b/internal/provider/vpcpeeringroute_resource_test.go
@@ -45,6 +45,7 @@ func TestAccVpcpeeringrouteResource(t *testing.T) {
 				ResourceName:      "arubacloud_vpcpeeringroute.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateIdFunc: importIDFromAttrs("arubacloud_vpcpeeringroute.test", "project_id", "vpc_id", "vpc_peering_id", "id"),
 			},
 			// Update and Read testing
 			{

--- a/internal/provider/vpnroute_resource_test.go
+++ b/internal/provider/vpnroute_resource_test.go
@@ -45,6 +45,7 @@ func TestAccVpnrouteResource(t *testing.T) {
 				ResourceName:      "arubacloud_vpnroute.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateIdFunc: importIDFromAttrs("arubacloud_vpnroute.test", "project_id", "vpn_tunnel_id", "id"),
 			},
 			// Update and Read testing
 			{

--- a/internal/provider/vpntunnel_resource_test.go
+++ b/internal/provider/vpntunnel_resource_test.go
@@ -45,6 +45,7 @@ func TestAccVpntunnelResource(t *testing.T) {
 				ResourceName:      "arubacloud_vpntunnel.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateIdFunc: importIDFromAttrs("arubacloud_vpntunnel.test", "project_id", "id"),
 			},
 			// Update and Read testing
 			{


### PR DESCRIPTION
## Summary

Closes #165

Every `ImportState: true, ImportStateVerify: true` acceptance test step now supplies a correct composite import ID via `ImportStateIdFunc`. Previously these steps used the default primary ID (`rs.Primary.ID`) which is only the `id` field — without `project_id` and other required keys the post-import Read returned 404 and the test could never pass.

## Changes

**`provider_test.go`** — adds `importIDFromAttrs(resourceAddr, attrs...)` helper:
- Reads named attributes from state and joins them with `/`
- Returns an `ImportStateIdFunc` compatible with `resource.TestStep`
- Use `"id"` for the primary ID, any tfsdk attribute name for other fields

**All 25 resource test files** — import step updated:
- `ImportStateIdFunc` added with the correct attribute list per resource
- `ImportStateVerifyIgnore` added for write-only fields:

| Resource | Ignored field | Reason |
|---|---|---|
| `cloudserver` | `settings.user_data` | write-only, never returned by API |
| `kaas` | `kubeconfig` | computed sensitive, may differ after re-read |
| `keypair` | `value` | public key write-only, not returned by API |
| `dbaasuser` | `password` | write-only, never returned by API |

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/provider/ -run "^Test[^Acc]"` — all pass
- [x] `gofmt -l ./internal/provider/` — no files need formatting
- [ ] `TF_ACC=1 go test ./internal/provider/ -run TestAccBackupResource` — verify ImportState step passes against real API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
