### PR TITLE
fix: URI last-segment guard, remainingTimeout floor, WaitForResourceDeleted initial tolerance

### DIFF
--- a/internal/provider/backup_data_source.go
+++ b/internal/provider/backup_data_source.go
@@ -134,7 +134,11 @@ func (d *BackupDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	}
 	if originURI := backup.OriginURI(); originURI != "" {
 		parts := strings.Split(originURI, "/")
-		data.VolumeID = types.StringValue(parts[len(parts)-1])
+		if last := parts[len(parts)-1]; last != "" {
+			data.VolumeID = types.StringValue(last)
+		} else {
+			data.VolumeID = types.StringNull()
+		}
 	} else {
 		data.VolumeID = types.StringNull()
 	}

--- a/internal/provider/backup_resource.go
+++ b/internal/provider/backup_resource.go
@@ -253,8 +253,8 @@ func (r *BackupResource) Read(ctx context.Context, req resource.ReadRequest, res
 	// Extract volume ID from origin URI.
 	if originURI := backup.OriginURI(); originURI != "" {
 		parts := strings.Split(originURI, "/")
-		if len(parts) > 0 {
-			data.VolumeID = types.StringValue(parts[len(parts)-1])
+		if last := parts[len(parts)-1]; last != "" {
+			data.VolumeID = types.StringValue(last)
 		}
 	}
 	if days := backup.RetentionDays(); days > 0 {

--- a/internal/provider/resource_wait.go
+++ b/internal/provider/resource_wait.go
@@ -229,10 +229,10 @@ func WaitForResourceDeleted(ctx context.Context, checker ResourceDeletedChecker,
 		return false, nil
 	}
 
-	// Immediate check — returns promptly if the resource is already gone.
-	if deleted, err := checkDeletion(); err != nil {
-		return err
-	} else if deleted {
+	// Immediate check — returns promptly if already gone.
+	// A single transient error on this first call does NOT abort; fall through
+	// to the ticker loop where the 3-consecutive-error tolerance applies.
+	if deleted, err := checkDeletion(); err == nil && deleted {
 		return nil
 	}
 
@@ -325,14 +325,20 @@ func CreateWithTransientRetry(
 	}
 }
 
+// minRemainingTimeout is the floor applied by remainingTimeout so that
+// WaitForResourceDeleted always has enough budget to run at least the
+// initial immediate check, even when DeleteResourceWithRetry has exhausted
+// nearly all of the ResourceTimeout budget through retries.
+const minRemainingTimeout = 10 * time.Second
+
 // remainingTimeout returns how much of the original timeout budget is left
-// since start, clamped to zero. Pass this as the timeout to WaitForResourceDeleted
-// so that DeleteResourceWithRetry and WaitForResourceDeleted share a single
-// overall budget instead of each consuming the full ResourceTimeout.
+// since start, floored at minRemainingTimeout. Pass this as the timeout to
+// WaitForResourceDeleted so that DeleteResourceWithRetry and WaitForResourceDeleted
+// share a single overall budget instead of each consuming the full ResourceTimeout.
 func remainingTimeout(start time.Time, total time.Duration) time.Duration {
 	r := total - time.Since(start)
-	if r < 0 {
-		r = 0
+	if r < minRemainingTimeout {
+		return minRemainingTimeout
 	}
 	return r
 }

--- a/internal/provider/resource_wait_test.go
+++ b/internal/provider/resource_wait_test.go
@@ -575,11 +575,11 @@ func TestRemainingTimeout(t *testing.T) {
 		t.Errorf("remainingTimeout for fresh start = %v, expected (0, %v]", got, total)
 	}
 
-	// Start was 20 minutes ago, total is 10 minutes: budget exhausted → 0.
+	// Start was 20 minutes ago, total is 10 minutes: budget exhausted → floor (minRemainingTimeout).
 	old := time.Now().Add(-20 * time.Minute)
 	got2 := remainingTimeout(old, total)
-	if got2 != 0 {
-		t.Errorf("remainingTimeout for exhausted budget = %v, expected 0", got2)
+	if got2 != minRemainingTimeout {
+		t.Errorf("remainingTimeout for exhausted budget = %v, expected minRemainingTimeout (%v)", got2, minRemainingTimeout)
 	}
 }
 

--- a/internal/provider/snapshot_data_source.go
+++ b/internal/provider/snapshot_data_source.go
@@ -116,7 +116,11 @@ func (d *SnapshotDataSource) Read(ctx context.Context, req datasource.ReadReques
 	// Extract volume ID from volume URI.
 	if volURI := snap.VolumeURI(); volURI != "" {
 		parts := strings.Split(volURI, "/")
-		data.VolumeId = types.StringValue(parts[len(parts)-1])
+		if last := parts[len(parts)-1]; last != "" {
+			data.VolumeId = types.StringValue(last)
+		} else {
+			data.VolumeId = types.StringNull()
+		}
 	} else {
 		data.VolumeId = types.StringNull()
 	}


### PR DESCRIPTION
## Summary

Three small bug fixes in deletion wait logic and URI parsing.

---

### Closes #169 — strings.Split empty-URI guard

`backup_resource.go`, `backup_data_source.go`, and `snapshot_data_source.go` all parsed a URI with `strings.Split(uri, "/")` and used the last segment as a volume ID without checking whether that segment is empty. A URI ending in `/` (e.g. `/foo/bar/`) produces `["foo", "bar", ""]` — the guard `len(parts) > 0` (always true) was silently writing `""` to `volume_id` in state.

**Fix:** Check `parts[len(parts)-1] != ""` before storing.

---

### Closes #172 — remainingTimeout minimum floor

`remainingTimeout()` previously returned `0` when the timeout budget was exhausted. A zero timeout passed to `WaitForResourceDeleted` created a timer that fired immediately — the deletion confirmation would fail before the initial pre-ticker check could detect an already-deleted resource.

**Fix:** Return `minRemainingTimeout` (10 s) as a floor. Updated the existing assertion in `resource_wait_test.go` to match.

---

### Closes #168 — WaitForResourceDeleted initial-check transient tolerance

The initial pre-ticker check returned the error immediately on any failure:
```go
if deleted, err := checkDeletion(); err != nil {
    return err  // single transient error aborts the entire wait
}
```
The ticker loop already tolerates 3 consecutive errors before giving up. The initial check applied no such tolerance, making behaviour inconsistent depending on when the transient error happened.

**Fix:** Only return success on `err == nil && deleted`; any other result (error or not-yet-deleted) falls through to the ticker loop where the tolerance applies.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/provider/ -run "^Test[^Acc]"` — all pass including `TestRemainingTimeout`
- [x] `gofmt -l ./internal/provider/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
