### PR TITLE
fix: post-wait re-read for backup and restore Create; add initial-check-tolerance test

### DIFF
--- a/internal/provider/backup_resource.go
+++ b/internal/provider/backup_resource.go
@@ -194,6 +194,15 @@ func (r *BackupResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
+	// Re-read to capture server-assigned fields (normalised URI, billing period, etc.)
+	// that may differ between the Create response and the fully-provisioned state.
+	fresh, freshErr := r.client.Client.FromStorage().Backups().Get(ctx, backupRef(&data))
+	if freshErr == nil {
+		applyBackupToState(fresh, &data)
+	} else {
+		tflog.Warn(ctx, fmt.Sprintf("Failed to refresh Backup after creation: %v", freshErr))
+	}
+
 	tflog.Trace(ctx, "created a Backup resource", map[string]interface{}{
 		"backup_id":   data.Id.ValueString(),
 		"backup_name": data.Name.ValueString(),
@@ -240,6 +249,13 @@ func (r *BackupResource) Read(ctx context.Context, req resource.ReadRequest, res
 		}
 	}
 
+	applyBackupToState(backup, &data)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// applyBackupToState maps fields from the SDK StorageBackup wrapper into data.
+// Called from both Create (post-wait re-read) and Read.
+func applyBackupToState(backup *aruba.StorageBackup, data *BackupResourceModel) {
 	data.Id = types.StringValue(backup.ID())
 	data.Uri = strVal(backup.URI())
 	data.Name = types.StringValue(backup.Name())
@@ -263,8 +279,6 @@ func (r *BackupResource) Read(ctx context.Context, req resource.ReadRequest, res
 	if bp := billingPeriodFromAPI(string(backup.BillingPeriod())); bp != "" {
 		data.BillingPeriod = types.StringValue(bp)
 	}
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
 func (r *BackupResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/internal/provider/resource_wait_test.go
+++ b/internal/provider/resource_wait_test.go
@@ -159,6 +159,30 @@ func TestWaitForResourceDeleted_ContextCancelledReturnsError(t *testing.T) {
 	}
 }
 
+func TestWaitForResourceDeleted_InitialCheckTransientErrorFallsThrough(t *testing.T) {
+	withFastPoll(t)
+
+	// First call (initial check) returns a transient error.
+	// Second call (first ticker tick) confirms deletion.
+	// Without the fix the first error would abort the wait immediately.
+	callCount := 0
+	checker := func(_ context.Context) (bool, error) {
+		callCount++
+		if callCount == 1 {
+			return false, fmt.Errorf("transient network error")
+		}
+		return true, nil // deleted on second call
+	}
+
+	err := WaitForResourceDeleted(context.Background(), checker, "backup", "bkp-1", 5*time.Second)
+	if err != nil {
+		t.Fatalf("expected nil, got: %v", err)
+	}
+	if callCount < 2 {
+		t.Fatalf("expected at least 2 checker calls, got %d", callCount)
+	}
+}
+
 // ── WaitForResourceActive ────────────────────────────────────────────────────
 
 // withFastActivePoll sets the active-poll interval to a very short duration for

--- a/internal/provider/restore_resource.go
+++ b/internal/provider/restore_resource.go
@@ -179,6 +179,14 @@ func (r *RestoreResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
+	// Re-read to capture server-assigned fields after provisioning.
+	fresh, freshErr := r.client.Client.FromStorage().Restores().Get(ctx, restoreRef(&data))
+	if freshErr == nil {
+		applyRestoreToState(fresh, &data)
+	} else {
+		tflog.Warn(ctx, fmt.Sprintf("Failed to refresh Restore after creation: %v", freshErr))
+	}
+
 	tflog.Trace(ctx, "created a Restore resource", map[string]interface{}{
 		"restore_id":   data.Id.ValueString(),
 		"restore_name": data.Name.ValueString(),
@@ -225,6 +233,14 @@ func (r *RestoreResource) Read(ctx context.Context, req resource.ReadRequest, re
 		}
 	}
 
+	applyRestoreToState(restore, &data)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// applyRestoreToState maps fields from the SDK StorageRestore wrapper into data.
+// Called from both Create (post-wait re-read) and Read.
+// VolumeID, BackupID, and ProjectID are not returned by the API and are preserved from state.
+func applyRestoreToState(restore *aruba.StorageRestore, data *RestoreResourceModel) {
 	data.Id = types.StringValue(restore.ID())
 	data.Uri = strVal(restore.URI())
 	data.Name = types.StringValue(restore.Name())
@@ -232,9 +248,6 @@ func (r *RestoreResource) Read(ctx context.Context, req resource.ReadRequest, re
 	if restore.Region() != "" {
 		data.Location = types.StringValue(string(restore.Region()))
 	}
-	// VolumeID is preserved from state (not returned by API).
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
 func (r *RestoreResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {


### PR DESCRIPTION
## Summary

### Closes #166 — Post-wait re-read for backup and restore Create

`backup_resource.go` and `restore_resource.go` `Create()` methods wrote state immediately after `WaitUntilReady()` using only the values from the `Create` API response. Fields the API assigns or normalises asynchronously (canonical URI, billing period canonical form, location normalisation) were not captured. A `terraform plan` immediately after `terraform apply` could show spurious diffs for these fields.

**Fix:** After `WaitUntilReady` returns, call `Get()` and apply the fresh response to state. State-mapping logic extracted into shared helpers `applyBackupToState()` and `applyRestoreToState()`, called from both `Create` (post-wait) and `Read`.

### Closes #167 — Unit test for initial-check tolerance

`resource_wait_test.go` already had comprehensive coverage for `WaitForResourceActive`, `WaitForResourceDeleted`, `CreateWithTransientRetry`, and `DeleteResourceWithRetry`. The one gap was a test for the initial-check transient-error behaviour fixed in the prior PR (#168).

**Added:** `TestWaitForResourceDeleted_InitialCheckTransientErrorFallsThrough` — verifies that a transient error on the first deletion check falls through to the ticker loop (3-error tolerance) rather than aborting the entire wait immediately.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/provider/ -run "^Test[^Acc]"` — all pass including the new test
- [x] `gofmt -l ./internal/provider/` — clean
- [ ] Acceptance: create a backup and immediately run `terraform plan` — verify no diff on any field

🤖 Generated with [Claude Code](https://claude.com/claude-code)
