### PR TITLE
feat: add uri to 18 data sources; add billing_period and backup type validators

### DIFF
--- a/docs/data-sources/backup.md
+++ b/docs/data-sources/backup.md
@@ -42,6 +42,7 @@ In addition to all arguments above, the following attributes are exported:
 - `retention_days` (Number) Number of days to retain the backup before automatic deletion. Optional — if omitted, the backup is retained indefinitely.
 - `tags` (List of String) List of string tags attached to the resource for filtering and organisation.
 - `type` (String) Backup type. Accepted values: `Full`, `Incremental`.
+- `uri` (String) Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.
 - `volume_id` (String) ID of the block storage volume this backup was taken from.
 
 

--- a/docs/data-sources/blockstorage.md
+++ b/docs/data-sources/blockstorage.md
@@ -79,6 +79,7 @@ In addition to all arguments above, the following attributes are exported:
 - `snapshot_id` (String) ID of the snapshot this volume was created from, if any.
 - `tags` (List of String) List of string tags attached to the resource for filtering and organisation.
 - `type` (String) Storage type. Accepted values: `Standard`, `Performance`.
+- `uri` (String) Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.
 - `zone` (String) Availability zone within the region. If omitted the volume is regional (accessible across all zones).
 
 

--- a/docs/data-sources/database.md
+++ b/docs/data-sources/database.md
@@ -49,5 +49,6 @@ In addition to all arguments above, the following attributes are exported:
 #### Read-Only
 
 - `name` (String) Display name for the database.
+- `uri` (String) Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.
 
 

--- a/docs/data-sources/databasebackup.md
+++ b/docs/data-sources/databasebackup.md
@@ -55,6 +55,7 @@ In addition to all arguments above, the following attributes are exported:
 - `location` (String) Region identifier where the backup is stored.
 - `name` (String) Display name for the database backup.
 - `tags` (List of String) List of string tags attached to the resource for filtering and organisation.
+- `uri` (String) Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.
 - `zone` (String) Availability zone within the region where the backup is stored.
 
 

--- a/docs/data-sources/databasegrant.md
+++ b/docs/data-sources/databasegrant.md
@@ -42,5 +42,6 @@ In addition to all arguments above, the following attributes are exported:
 
 - `id` (String) Computed by the API. Unique identifier for the grant (composite key: `project_id/dbaas_id/database/user_id`).
 - `role` (String) Privilege level granted to the user on the database.
+- `uri` (String) Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.
 
 

--- a/docs/data-sources/dbaasuser.md
+++ b/docs/data-sources/dbaasuser.md
@@ -44,5 +44,6 @@ In addition to all arguments above, the following attributes are exported:
 
 - `id` (String) Computed by the API. Unique identifier for the resource (same as the username).
 - `password` (String, Sensitive) Password for the DBaaS user. Write-only — this value is sent to the API but is not returned in subsequent read responses.
+- `uri` (String) Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.
 
 

--- a/docs/data-sources/elasticip.md
+++ b/docs/data-sources/elasticip.md
@@ -57,5 +57,6 @@ In addition to all arguments above, the following attributes are exported:
 - `location` (String) Region identifier for the resource (e.g., `ITBG-Bergamo`). See the [available locations and zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center).
 - `name` (String) Display name for the Elastic IP.
 - `tags` (List of String) List of string tags attached to the resource for filtering and organisation.
+- `uri` (String) Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.
 
 

--- a/docs/data-sources/keypair.md
+++ b/docs/data-sources/keypair.md
@@ -55,6 +55,7 @@ In addition to all arguments above, the following attributes are exported:
 - `location` (String) Region identifier for the resource (e.g., `ITBG-Bergamo`). See the [available locations and zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center).
 - `name` (String) Display name for the KeyPair.
 - `tags` (List of String) List of string tags attached to the resource for filtering and organisation.
+- `uri` (String) Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.
 - `value` (String) OpenSSH-format public key string (e.g., `ssh-rsa AAAA...`). The provider uploads this to ArubaCloud; the corresponding private key is never stored.
 
 

--- a/docs/data-sources/kms.md
+++ b/docs/data-sources/kms.md
@@ -49,5 +49,6 @@ In addition to all arguments above, the following attributes are exported:
 - `description` (String) Optional human-readable description of the KMS instance.
 - `endpoint` (String) Computed by the API. Endpoint URL used to interact with the KMS service.
 - `name` (String) Display name for the KMS instance.
+- `uri` (String) Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.
 
 

--- a/docs/data-sources/restore.md
+++ b/docs/data-sources/restore.md
@@ -54,6 +54,7 @@ In addition to all arguments above, the following attributes are exported:
 - `location` (String) Region identifier (e.g., `ITBG-Bergamo`). See the [available locations and zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center).
 - `name` (String) Display name for the restore operation.
 - `tags` (List of String) List of string tags attached to the resource for filtering and organisation.
+- `uri` (String) Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.
 - `volume_id` (String) ID of the target block storage volume that was restored.
 
 

--- a/docs/data-sources/schedulejob.md
+++ b/docs/data-sources/schedulejob.md
@@ -49,5 +49,6 @@ In addition to all arguments above, the following attributes are exported:
 - `cron` (String) Cron expression defining the job schedule (e.g., `0 * * * *` for hourly). Standard 5-field cron format.
 - `description` (String) Optional human-readable description of the scheduled job.
 - `name` (String) Display name for the scheduled job.
+- `uri` (String) Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.
 
 

--- a/docs/data-sources/securitygroup.md
+++ b/docs/data-sources/securitygroup.md
@@ -51,5 +51,6 @@ In addition to all arguments above, the following attributes are exported:
 - `location` (String) Region identifier for the resource (e.g., `ITBG-Bergamo`). See the [available locations and zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center).
 - `name` (String) Display name for the security group.
 - `tags` (List of String) List of string tags attached to the resource for filtering and organisation.
+- `uri` (String) Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.
 
 

--- a/docs/data-sources/snapshot.md
+++ b/docs/data-sources/snapshot.md
@@ -49,6 +49,7 @@ In addition to all arguments above, the following attributes are exported:
 - `billing_period` (String) Billing cycle. Accepted values: `Hour`, `Month`, `Year`.
 - `location` (String) Region identifier (e.g., `ITBG-Bergamo`). See the [available locations and zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center).
 - `name` (String) Display name for the snapshot.
+- `uri` (String) Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.
 - `volume_id` (String) ID of the block storage volume this snapshot was taken from.
 
 

--- a/docs/data-sources/vpc.md
+++ b/docs/data-sources/vpc.md
@@ -52,5 +52,6 @@ In addition to all arguments above, the following attributes are exported:
 - `location` (String) Region identifier for the resource (e.g., `ITBG-Bergamo`).
 - `name` (String) Display name for the VPC.
 - `tags` (List of String) List of string tags attached to the resource.
+- `uri` (String) Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.
 
 

--- a/docs/data-sources/vpcpeering.md
+++ b/docs/data-sources/vpcpeering.md
@@ -43,5 +43,6 @@ In addition to all arguments above, the following attributes are exported:
 #### Read-Only
 
 - `name` (String) Display name for the VPC peering.
+- `uri` (String) Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.
 
 

--- a/docs/data-sources/vpcpeeringroute.md
+++ b/docs/data-sources/vpcpeeringroute.md
@@ -45,5 +45,6 @@ In addition to all arguments above, the following attributes are exported:
 #### Read-Only
 
 - `name` (String) Display name for the VPC peering route.
+- `uri` (String) Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.
 
 

--- a/docs/data-sources/vpnroute.md
+++ b/docs/data-sources/vpnroute.md
@@ -51,5 +51,6 @@ In addition to all arguments above, the following attributes are exported:
 - `destination` (String) CIDR of the ArubaCloud-side subnet routed over this tunnel (maps to `cloud_subnet`).
 - `gateway` (String) CIDR of the on-premises subnet reachable through this tunnel (maps to `on_prem_subnet`).
 - `name` (String) Display name for the VPN route.
+- `uri` (String) Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.
 
 

--- a/docs/data-sources/vpntunnel.md
+++ b/docs/data-sources/vpntunnel.md
@@ -43,5 +43,6 @@ In addition to all arguments above, the following attributes are exported:
 - `name` (String) Display name for the VPN tunnel.
 - `remote_peer` (String) Public IP address of the remote peer (on-premises gateway).
 - `status` (String) Current operational status of the VPN tunnel.
+- `uri` (String) Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.
 
 

--- a/internal/provider/backup_data_source.go
+++ b/internal/provider/backup_data_source.go
@@ -24,6 +24,7 @@ type BackupDataSource struct {
 
 type BackupDataSourceModel struct {
 	Id            types.String `tfsdk:"id"`
+	Uri           types.String `tfsdk:"uri"`
 	Name          types.String `tfsdk:"name"`
 	Location      types.String `tfsdk:"location"`
 	Tags          types.List   `tfsdk:"tags"`
@@ -45,6 +46,10 @@ func (d *BackupDataSource) Schema(ctx context.Context, req datasource.SchemaRequ
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Unique identifier of the backup to look up.",
 				Required:            true,
+			},
+			"uri": schema.StringAttribute{
+				MarkdownDescription: "Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.",
+				Computed:            true,
 			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: "Display name for the backup.",
@@ -120,6 +125,7 @@ func (d *BackupDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	}
 
 	data.Id = types.StringValue(backup.ID())
+	data.Uri = strVal(backup.URI())
 	data.Name = types.StringValue(backup.Name())
 	data.ProjectID = types.StringValue(projectID)
 	if backup.Region() != "" {

--- a/internal/provider/backup_resource.go
+++ b/internal/provider/backup_resource.go
@@ -7,11 +7,13 @@ import (
 	"time"
 
 	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -88,6 +90,9 @@ func (r *BackupResource) Schema(ctx context.Context, req resource.SchemaRequest,
 			"type": schema.StringAttribute{
 				MarkdownDescription: "Backup type. Accepted values: `Full`, `Incremental`. (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 				Required:            true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("Full", "Incremental"),
+				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -106,6 +111,7 @@ func (r *BackupResource) Schema(ctx context.Context, req resource.SchemaRequest,
 			"billing_period": schema.StringAttribute{
 				MarkdownDescription: "Billing cycle. Accepted values: `Hour`, `Month`, `Year`.",
 				Optional:            true,
+				Validators:          []validator.String{stringvalidator.OneOf("Hour", "Month", "Year")},
 			},
 		},
 	}

--- a/internal/provider/blockstorage_data_source.go
+++ b/internal/provider/blockstorage_data_source.go
@@ -23,6 +23,7 @@ type BlockStorageDataSource struct {
 
 type BlockStorageDataSourceModel struct {
 	Id            types.String `tfsdk:"id"`
+	Uri           types.String `tfsdk:"uri"`
 	Name          types.String `tfsdk:"name"`
 	ProjectId     types.String `tfsdk:"project_id"`
 	Location      types.String `tfsdk:"location"`
@@ -57,6 +58,10 @@ func (d *BlockStorageDataSource) Schema(ctx context.Context, req datasource.Sche
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Unique identifier of the block storage volume to look up.",
 				Required:            true,
+			},
+			"uri": schema.StringAttribute{
+				MarkdownDescription: "Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.",
+				Computed:            true,
 			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: "Display name for the block storage volume.",
@@ -144,6 +149,7 @@ func (d *BlockStorageDataSource) Read(ctx context.Context, req datasource.ReadRe
 	}
 
 	data.Id = types.StringValue(vol.ID())
+	data.Uri = strVal(vol.URI())
 	data.Name = types.StringValue(vol.Name())
 	data.ProjectId = types.StringValue(projectID)
 	if vol.Region() != "" {

--- a/internal/provider/blockstorage_resource.go
+++ b/internal/provider/blockstorage_resource.go
@@ -6,11 +6,13 @@ import (
 	"time"
 
 	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -85,6 +87,7 @@ func (r *BlockStorageResource) Schema(ctx context.Context, req resource.SchemaRe
 			"billing_period": schema.StringAttribute{
 				MarkdownDescription: "Billing cycle. Accepted values: `Hour`, `Month`, `Year`.",
 				Required:            true,
+				Validators:          []validator.String{stringvalidator.OneOf("Hour", "Month", "Year")},
 			},
 			"zone": schema.StringAttribute{
 				MarkdownDescription: "Availability zone within the region. If omitted the volume is regional (accessible across all zones).",

--- a/internal/provider/containerregistry_resource.go
+++ b/internal/provider/containerregistry_resource.go
@@ -6,12 +6,14 @@ import (
 	"time"
 
 	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -96,6 +98,7 @@ func (r *ContainerRegistryResource) Schema(ctx context.Context, req resource.Sch
 			"billing_period": schema.StringAttribute{
 				MarkdownDescription: "Billing cycle. Accepted values: `Hour`, `Month`, `Year`.",
 				Optional:            true,
+				Validators:          []validator.String{stringvalidator.OneOf("Hour", "Month", "Year")},
 			},
 			"network": schema.SingleNestedAttribute{
 				MarkdownDescription: "Network resources attached to the registry.",

--- a/internal/provider/database_data_source.go
+++ b/internal/provider/database_data_source.go
@@ -23,6 +23,7 @@ type DatabaseDataSource struct {
 
 type DatabaseDataSourceModel struct {
 	Id        types.String `tfsdk:"id"`
+	Uri       types.String `tfsdk:"uri"`
 	ProjectID types.String `tfsdk:"project_id"`
 	DBaaSID   types.String `tfsdk:"dbaas_id"`
 	Name      types.String `tfsdk:"name"`
@@ -39,6 +40,10 @@ func (d *DatabaseDataSource) Schema(ctx context.Context, req datasource.SchemaRe
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Unique identifier of the database to look up (same as the database name).",
 				Required:            true,
+			},
+			"uri": schema.StringAttribute{
+				MarkdownDescription: "Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.",
+				Computed:            true,
 			},
 			"project_id": schema.StringAttribute{
 				MarkdownDescription: "ID of the project that owns this resource.",
@@ -94,6 +99,7 @@ func (d *DatabaseDataSource) Read(ctx context.Context, req datasource.ReadReques
 	}
 
 	data.Id = types.StringValue(db.Name())
+	data.Uri = strVal(db.URI())
 	data.Name = types.StringValue(db.Name())
 	data.ProjectID = types.StringValue(projectID)
 	data.DBaaSID = types.StringValue(dbaasID)

--- a/internal/provider/databasebackup_data_source.go
+++ b/internal/provider/databasebackup_data_source.go
@@ -23,6 +23,7 @@ type DatabaseBackupDataSource struct {
 
 type DatabaseBackupDataSourceModel struct {
 	Id            types.String `tfsdk:"id"`
+	Uri           types.String `tfsdk:"uri"`
 	Name          types.String `tfsdk:"name"`
 	Location      types.String `tfsdk:"location"`
 	Tags          types.List   `tfsdk:"tags"`
@@ -44,6 +45,10 @@ func (d *DatabaseBackupDataSource) Schema(ctx context.Context, req datasource.Sc
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Unique identifier of the database backup to look up.",
 				Required:            true,
+			},
+			"uri": schema.StringAttribute{
+				MarkdownDescription: "Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.",
+				Computed:            true,
 			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: "Display name for the database backup.",
@@ -119,6 +124,7 @@ func (d *DatabaseBackupDataSource) Read(ctx context.Context, req datasource.Read
 	}
 
 	data.Id = types.StringValue(backup.ID())
+	data.Uri = strVal(backup.URI())
 	data.Name = types.StringValue(backup.Name())
 	data.ProjectID = types.StringValue(projectID)
 	data.Tags = TagsToListPreserveNull(backup.Tags(), data.Tags)

--- a/internal/provider/databasebackup_resource.go
+++ b/internal/provider/databasebackup_resource.go
@@ -6,11 +6,13 @@ import (
 	"time"
 
 	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -93,6 +95,7 @@ func (r *DatabaseBackupResource) Schema(ctx context.Context, req resource.Schema
 			"billing_period": schema.StringAttribute{
 				MarkdownDescription: "Billing cycle. Accepted values: `Hour`, `Month`, `Year`.",
 				Required:            true,
+				Validators:          []validator.String{stringvalidator.OneOf("Hour", "Month", "Year")},
 			},
 		},
 	}

--- a/internal/provider/databasegrant_data_source.go
+++ b/internal/provider/databasegrant_data_source.go
@@ -23,6 +23,7 @@ type DatabaseGrantDataSource struct {
 
 type DatabaseGrantDataSourceModel struct {
 	Id        types.String `tfsdk:"id"`
+	Uri       types.String `tfsdk:"uri"`
 	ProjectID types.String `tfsdk:"project_id"`
 	DBaaSID   types.String `tfsdk:"dbaas_id"`
 	Database  types.String `tfsdk:"database"`
@@ -40,6 +41,10 @@ func (d *DatabaseGrantDataSource) Schema(ctx context.Context, req datasource.Sch
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Computed by the API. Unique identifier for the grant (composite key: `project_id/dbaas_id/database/user_id`).",
+				Computed:            true,
+			},
+			"uri": schema.StringAttribute{
+				MarkdownDescription: "Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.",
 				Computed:            true,
 			},
 			"project_id": schema.StringAttribute{
@@ -106,6 +111,7 @@ func (d *DatabaseGrantDataSource) Read(ctx context.Context, req datasource.ReadR
 	}
 
 	data.Id = types.StringValue(fmt.Sprintf("%s/%s/%s/%s", projectID, dbaasID, database, userID))
+	data.Uri = strVal(grant.URI())
 	data.ProjectID = types.StringValue(projectID)
 	data.DBaaSID = types.StringValue(dbaasID)
 	data.Database = types.StringValue(database)

--- a/internal/provider/dbaas_resource.go
+++ b/internal/provider/dbaas_resource.go
@@ -6,12 +6,14 @@ import (
 	"time"
 
 	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -162,6 +164,7 @@ func (r *DBaaSResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 			"billing_period": schema.StringAttribute{
 				MarkdownDescription: "Billing cycle. Accepted values: `Hour`, `Month`, `Year`.",
 				Optional:            true,
+				Validators:          []validator.String{stringvalidator.OneOf("Hour", "Month", "Year")},
 			},
 		},
 	}

--- a/internal/provider/dbaasuser_data_source.go
+++ b/internal/provider/dbaasuser_data_source.go
@@ -13,6 +13,7 @@ import (
 
 type DBaaSUserDataSourceModel struct {
 	Id        types.String `tfsdk:"id"`
+	Uri       types.String `tfsdk:"uri"`
 	ProjectID types.String `tfsdk:"project_id"`
 	DBaaSID   types.String `tfsdk:"dbaas_id"`
 	Username  types.String `tfsdk:"username"`
@@ -43,6 +44,10 @@ func (d *DBaaSUserDataSource) Schema(ctx context.Context, req datasource.SchemaR
 			},
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Computed by the API. Unique identifier for the resource (same as the username).",
+				Computed:            true,
+			},
+			"uri": schema.StringAttribute{
+				MarkdownDescription: "Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.",
 				Computed:            true,
 			},
 			"project_id": schema.StringAttribute{
@@ -100,6 +105,7 @@ func (d *DBaaSUserDataSource) Read(ctx context.Context, req datasource.ReadReque
 	}
 
 	data.Id = types.StringValue(user.Username())
+	data.Uri = strVal(user.URI())
 	data.Username = types.StringValue(user.Username())
 	data.ProjectID = types.StringValue(projectID)
 	data.DBaaSID = types.StringValue(dbaasID)

--- a/internal/provider/elasticip_data_source.go
+++ b/internal/provider/elasticip_data_source.go
@@ -23,6 +23,7 @@ type ElasticIPDataSource struct {
 
 type ElasticIPDataSourceModel struct {
 	Id            types.String `tfsdk:"id"`
+	Uri           types.String `tfsdk:"uri"`
 	Name          types.String `tfsdk:"name"`
 	Location      types.String `tfsdk:"location"`
 	ProjectId     types.String `tfsdk:"project_id"`
@@ -42,6 +43,10 @@ func (d *ElasticIPDataSource) Schema(ctx context.Context, req datasource.SchemaR
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Computed by the API. Unique identifier for the resource.",
 				Required:            true,
+			},
+			"uri": schema.StringAttribute{
+				MarkdownDescription: "Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.",
+				Computed:            true,
 			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: "Display name for the Elastic IP.",
@@ -109,6 +114,7 @@ func (d *ElasticIPDataSource) Read(ctx context.Context, req datasource.ReadReque
 	}
 
 	data.Id = types.StringValue(eip.ID())
+	data.Uri = strVal(eip.URI())
 	data.Name = types.StringValue(eip.Name())
 	data.ProjectId = types.StringValue(projectID)
 	data.Tags = TagsToListPreserveNull(eip.Tags(), data.Tags)

--- a/internal/provider/kaas_resource.go
+++ b/internal/provider/kaas_resource.go
@@ -7,12 +7,14 @@ import (
 	"time"
 
 	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -112,6 +114,7 @@ func (r *KaaSResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 			"billing_period": schema.StringAttribute{
 				MarkdownDescription: "Billing cycle. Accepted values: `Hour`, `Month`, `Year`.",
 				Optional:            true,
+				Validators:          []validator.String{stringvalidator.OneOf("Hour", "Month", "Year")},
 			},
 			"management_ip": schema.StringAttribute{
 				MarkdownDescription: "Computed by the API. Management IP address of the cluster control plane, available once the cluster is active.",

--- a/internal/provider/keypair_data_source.go
+++ b/internal/provider/keypair_data_source.go
@@ -13,6 +13,7 @@ import (
 
 type KeypairDataSourceModel struct {
 	Id        types.String `tfsdk:"id"`
+	Uri       types.String `tfsdk:"uri"`
 	Name      types.String `tfsdk:"name"`
 	Location  types.String `tfsdk:"location"`
 	ProjectID types.String `tfsdk:"project_id"`
@@ -41,6 +42,10 @@ func (d *KeypairDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Computed by the API. Unique identifier for the resource.",
 				Required:            true,
+			},
+			"uri": schema.StringAttribute{
+				MarkdownDescription: "Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.",
+				Computed:            true,
 			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: "Display name for the KeyPair.",
@@ -104,6 +109,7 @@ func (d *KeypairDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	}
 
 	data.Id = types.StringValue(kp.ID())
+	data.Uri = strVal(kp.URI())
 	data.Name = types.StringValue(kp.Name())
 	data.ProjectID = types.StringValue(projectID)
 

--- a/internal/provider/kms_data_source.go
+++ b/internal/provider/kms_data_source.go
@@ -13,6 +13,7 @@ import (
 
 type KMSDataSourceModel struct {
 	Id          types.String `tfsdk:"id"`
+	Uri         types.String `tfsdk:"uri"`
 	ProjectID   types.String `tfsdk:"project_id"`
 	Name        types.String `tfsdk:"name"`
 	Description types.String `tfsdk:"description"`
@@ -40,6 +41,10 @@ func (d *KMSDataSource) Schema(ctx context.Context, req datasource.SchemaRequest
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Unique identifier of the KMS instance to look up.",
 				Required:            true,
+			},
+			"uri": schema.StringAttribute{
+				MarkdownDescription: "Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.",
+				Computed:            true,
 			},
 			"project_id": schema.StringAttribute{
 				MarkdownDescription: "ID of the project that owns this resource.",
@@ -98,6 +103,7 @@ func (d *KMSDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 	}
 
 	data.Id = types.StringValue(kms.ID())
+	data.Uri = strVal(kms.URI())
 	data.Name = types.StringValue(kms.Name())
 	data.ProjectID = types.StringValue(projectID)
 	// description and endpoint are not returned by the API

--- a/internal/provider/kms_resource.go
+++ b/internal/provider/kms_resource.go
@@ -6,11 +6,13 @@ import (
 	"time"
 
 	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -76,6 +78,7 @@ func (r *KMSResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 			"billing_period": schema.StringAttribute{
 				MarkdownDescription: "Billing cycle. Accepted values: `Hour`, `Month`, `Year`.",
 				Optional:            true,
+				Validators:          []validator.String{stringvalidator.OneOf("Hour", "Month", "Year")},
 				Computed:            true,
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},

--- a/internal/provider/restore_data_source.go
+++ b/internal/provider/restore_data_source.go
@@ -23,6 +23,7 @@ type RestoreDataSource struct {
 
 type RestoreDataSourceModel struct {
 	Id        types.String   `tfsdk:"id"`
+	Uri       types.String   `tfsdk:"uri"`
 	Name      types.String   `tfsdk:"name"`
 	Location  types.String   `tfsdk:"location"`
 	Tags      []types.String `tfsdk:"tags"`
@@ -42,6 +43,10 @@ func (d *RestoreDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Unique identifier of the restore operation to look up.",
 				Required:            true,
+			},
+			"uri": schema.StringAttribute{
+				MarkdownDescription: "Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.",
+				Computed:            true,
 			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: "Display name for the restore operation.",
@@ -110,6 +115,7 @@ func (d *RestoreDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	}
 
 	data.Id = types.StringValue(restore.ID())
+	data.Uri = strVal(restore.URI())
 	data.Name = types.StringValue(restore.Name())
 	data.ProjectId = types.StringValue(projectID)
 	data.BackupId = types.StringValue(backupID)

--- a/internal/provider/schedulejob_data_source.go
+++ b/internal/provider/schedulejob_data_source.go
@@ -23,6 +23,7 @@ type ScheduleJobDataSource struct {
 
 type ScheduleJobDataSourceModel struct {
 	Id          types.String `tfsdk:"id"`
+	Uri         types.String `tfsdk:"uri"`
 	Name        types.String `tfsdk:"name"`
 	ProjectID   types.String `tfsdk:"project_id"`
 	Description types.String `tfsdk:"description"`
@@ -40,6 +41,10 @@ func (d *ScheduleJobDataSource) Schema(ctx context.Context, req datasource.Schem
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Unique identifier of the scheduled job to look up.",
 				Required:            true,
+			},
+			"uri": schema.StringAttribute{
+				MarkdownDescription: "Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.",
+				Computed:            true,
 			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: "Display name for the scheduled job.",
@@ -98,6 +103,7 @@ func (d *ScheduleJobDataSource) Read(ctx context.Context, req datasource.ReadReq
 	}
 
 	data.Id = types.StringValue(job.ID())
+	data.Uri = strVal(job.URI())
 	data.Name = types.StringValue(job.Name())
 	data.ProjectID = types.StringValue(projectID)
 	if cron := job.Cron(); cron != "" {

--- a/internal/provider/securitygroup_data_source.go
+++ b/internal/provider/securitygroup_data_source.go
@@ -23,6 +23,7 @@ type SecurityGroupDataSource struct {
 
 type SecurityGroupDataSourceModel struct {
 	Id        types.String `tfsdk:"id"`
+	Uri       types.String `tfsdk:"uri"`
 	Name      types.String `tfsdk:"name"`
 	Location  types.String `tfsdk:"location"`
 	Tags      types.List   `tfsdk:"tags"`
@@ -41,6 +42,10 @@ func (d *SecurityGroupDataSource) Schema(ctx context.Context, req datasource.Sch
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Unique identifier of the security group to look up.",
 				Required:            true,
+			},
+			"uri": schema.StringAttribute{
+				MarkdownDescription: "Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.",
+				Computed:            true,
 			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: "Display name for the security group.",
@@ -105,6 +110,7 @@ func (d *SecurityGroupDataSource) Read(ctx context.Context, req datasource.ReadR
 	}
 
 	data.Id = types.StringValue(sg.ID())
+	data.Uri = strVal(sg.URI())
 	data.Name = types.StringValue(sg.Name())
 	data.ProjectId = types.StringValue(projectID)
 	data.VpcId = types.StringValue(vpcID)

--- a/internal/provider/snapshot_data_source.go
+++ b/internal/provider/snapshot_data_source.go
@@ -24,6 +24,7 @@ type SnapshotDataSource struct {
 
 type SnapshotDataSourceModel struct {
 	Id            types.String `tfsdk:"id"`
+	Uri           types.String `tfsdk:"uri"`
 	Name          types.String `tfsdk:"name"`
 	ProjectId     types.String `tfsdk:"project_id"`
 	Location      types.String `tfsdk:"location"`
@@ -42,6 +43,10 @@ func (d *SnapshotDataSource) Schema(ctx context.Context, req datasource.SchemaRe
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Unique identifier of the snapshot to look up.",
 				Required:            true,
+			},
+			"uri": schema.StringAttribute{
+				MarkdownDescription: "Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.",
+				Computed:            true,
 			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: "Display name for the snapshot.",
@@ -104,6 +109,7 @@ func (d *SnapshotDataSource) Read(ctx context.Context, req datasource.ReadReques
 	}
 
 	data.Id = types.StringValue(snap.ID())
+	data.Uri = strVal(snap.URI())
 	data.Name = types.StringValue(snap.Name())
 	data.ProjectId = types.StringValue(projectID)
 	if snap.Region() != "" {

--- a/internal/provider/vpc_data_source.go
+++ b/internal/provider/vpc_data_source.go
@@ -23,6 +23,7 @@ type VPCDataSource struct {
 
 type VPCDataSourceModel struct {
 	Id        types.String `tfsdk:"id"`
+	Uri       types.String `tfsdk:"uri"`
 	Name      types.String `tfsdk:"name"`
 	Location  types.String `tfsdk:"location"`
 	ProjectId types.String `tfsdk:"project_id"`
@@ -40,6 +41,10 @@ func (d *VPCDataSource) Schema(ctx context.Context, req datasource.SchemaRequest
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Unique identifier of the VPC to look up.",
 				Required:            true,
+			},
+			"uri": schema.StringAttribute{
+				MarkdownDescription: "Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.",
+				Computed:            true,
 			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: "Display name for the VPC.",
@@ -97,6 +102,7 @@ func (d *VPCDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 	}
 
 	data.Id = types.StringValue(vpc.ID())
+	data.Uri = strVal(vpc.URI())
 	data.Name = types.StringValue(vpc.Name())
 	data.ProjectId = types.StringValue(projectID)
 	data.Tags = TagsToListPreserveNull(vpc.Tags(), data.Tags)

--- a/internal/provider/vpcpeering_data_source.go
+++ b/internal/provider/vpcpeering_data_source.go
@@ -23,6 +23,7 @@ type VPCPeeringDataSource struct {
 
 type VPCPeeringDataSourceModel struct {
 	Id        types.String `tfsdk:"id"`
+	Uri       types.String `tfsdk:"uri"`
 	Name      types.String `tfsdk:"name"`
 	ProjectId types.String `tfsdk:"project_id"`
 	VpcId     types.String `tfsdk:"vpc_id"`
@@ -39,6 +40,10 @@ func (d *VPCPeeringDataSource) Schema(ctx context.Context, req datasource.Schema
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Unique identifier of the VPC peering to look up.",
 				Required:            true,
+			},
+			"uri": schema.StringAttribute{
+				MarkdownDescription: "Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.",
+				Computed:            true,
 			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: "Display name for the VPC peering.",
@@ -94,6 +99,7 @@ func (d *VPCPeeringDataSource) Read(ctx context.Context, req datasource.ReadRequ
 	}
 
 	data.Id = types.StringValue(peering.ID())
+	data.Uri = strVal(peering.URI())
 	data.Name = types.StringValue(peering.Name())
 	data.ProjectId = types.StringValue(projectID)
 	data.VpcId = types.StringValue(vpcID)

--- a/internal/provider/vpcpeeringroute_data_source.go
+++ b/internal/provider/vpcpeeringroute_data_source.go
@@ -23,6 +23,7 @@ type VPCPeeringRouteDataSource struct {
 
 type VPCPeeringRouteDataSourceModel struct {
 	Id           types.String `tfsdk:"id"`
+	Uri          types.String `tfsdk:"uri"`
 	Name         types.String `tfsdk:"name"`
 	ProjectId    types.String `tfsdk:"project_id"`
 	VpcId        types.String `tfsdk:"vpc_id"`
@@ -40,6 +41,10 @@ func (d *VPCPeeringRouteDataSource) Schema(ctx context.Context, req datasource.S
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Unique identifier of the VPC peering route to look up (same as the route name).",
 				Required:            true,
+			},
+			"uri": schema.StringAttribute{
+				MarkdownDescription: "Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.",
+				Computed:            true,
 			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: "Display name for the VPC peering route.",
@@ -101,6 +106,7 @@ func (d *VPCPeeringRouteDataSource) Read(ctx context.Context, req datasource.Rea
 
 	// VPCPeeringRoute uses name as ID.
 	data.Id = types.StringValue(route.Name())
+	data.Uri = strVal(route.URI())
 	data.Name = types.StringValue(route.Name())
 	data.ProjectId = types.StringValue(projectID)
 	data.VpcId = types.StringValue(vpcID)

--- a/internal/provider/vpcpeeringroute_resource.go
+++ b/internal/provider/vpcpeeringroute_resource.go
@@ -6,11 +6,13 @@ import (
 	"time"
 
 	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -93,6 +95,7 @@ func (r *VpcPeeringRouteResource) Schema(ctx context.Context, req resource.Schem
 			"billing_period": schema.StringAttribute{
 				MarkdownDescription: "Billing cycle for the resource. Accepted values: `Hour`, `Month`, `Year`.",
 				Required:            true,
+				Validators:          []validator.String{stringvalidator.OneOf("Hour", "Month", "Year")},
 			},
 		},
 	}

--- a/internal/provider/vpnroute_data_source.go
+++ b/internal/provider/vpnroute_data_source.go
@@ -23,6 +23,7 @@ type VPNRouteDataSource struct {
 
 type VPNRouteDataSourceModel struct {
 	Id          types.String `tfsdk:"id"`
+	Uri         types.String `tfsdk:"uri"`
 	Name        types.String `tfsdk:"name"`
 	ProjectId   types.String `tfsdk:"project_id"`
 	VpnTunnelId types.String `tfsdk:"vpn_tunnel_id"`
@@ -41,6 +42,10 @@ func (d *VPNRouteDataSource) Schema(ctx context.Context, req datasource.SchemaRe
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Unique identifier of the VPN route to look up.",
 				Required:            true,
+			},
+			"uri": schema.StringAttribute{
+				MarkdownDescription: "Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.",
+				Computed:            true,
 			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: "Display name for the VPN route.",
@@ -104,6 +109,7 @@ func (d *VPNRouteDataSource) Read(ctx context.Context, req datasource.ReadReques
 	}
 
 	data.Id = types.StringValue(route.ID())
+	data.Uri = strVal(route.URI())
 	data.Name = types.StringValue(route.Name())
 	data.ProjectId = types.StringValue(projectID)
 	data.VpnTunnelId = types.StringValue(vpnTunnelID)

--- a/internal/provider/vpntunnel_data_source.go
+++ b/internal/provider/vpntunnel_data_source.go
@@ -23,6 +23,7 @@ type VPNTunnelDataSource struct {
 
 type VPNTunnelDataSourceModel struct {
 	Id         types.String `tfsdk:"id"`
+	Uri        types.String `tfsdk:"uri"`
 	Name       types.String `tfsdk:"name"`
 	ProjectId  types.String `tfsdk:"project_id"`
 	RemotePeer types.String `tfsdk:"remote_peer"`
@@ -40,6 +41,10 @@ func (d *VPNTunnelDataSource) Schema(ctx context.Context, req datasource.SchemaR
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Unique identifier of the VPN tunnel to look up.",
 				Required:            true,
+			},
+			"uri": schema.StringAttribute{
+				MarkdownDescription: "Computed by the API. Full resource URI. Use this value in `*_uri_ref` attributes of other resources.",
+				Computed:            true,
 			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: "Display name for the VPN tunnel.",
@@ -98,6 +103,7 @@ func (d *VPNTunnelDataSource) Read(ctx context.Context, req datasource.ReadReque
 	}
 
 	data.Id = types.StringValue(tunnel.ID())
+	data.Uri = strVal(tunnel.URI())
 	data.Name = types.StringValue(tunnel.Name())
 	data.ProjectId = types.StringValue(projectID)
 	// PeerClientPublicIP is the remote peer — exposed via wrapper accessor.

--- a/internal/provider/vpntunnel_resource.go
+++ b/internal/provider/vpntunnel_resource.go
@@ -7,11 +7,13 @@ import (
 	"time"
 
 	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -91,6 +93,7 @@ func (r *VPNTunnelResource) Schema(ctx context.Context, req resource.SchemaReque
 					"billing_period": schema.StringAttribute{
 						MarkdownDescription: "Billing cycle for the resource. Accepted values: `Hour`, `Month`, `Year`.",
 						Optional:            true,
+						Validators:          []validator.String{stringvalidator.OneOf("Hour", "Month", "Year")},
 					},
 					"ip_configurations": schema.SingleNestedAttribute{
 						MarkdownDescription: "Network references for the VPN tunnel — VPC, subnet, and public IP.",


### PR DESCRIPTION
## Summary

### Closes #171 — `uri` attribute added to 18 data sources

The `uri` attribute is the primary reference key used throughout this provider (all `*_uri_ref` attributes accept a URI). Users could not look up existing resources via data sources and pass their URIs to other resources — the data sources simply didn't expose `uri`.

**18 data sources updated:** `backup`, `restore`, `blockstorage`, `snapshot`, `vpc`, `securitygroup`, `elasticip`, `vpcpeering`, `vpcpeeringroute`, `vpntunnel`, `vpnroute`, `kms`, `keypair`, `databasebackup`, `database`, `dbaasuser`, `databasegrant`, `schedulejob`

Each data source gets:
1. `Uri types.String` added to the model struct
2. `"uri": schema.StringAttribute{Computed: true}` added to the schema
3. `data.Uri = strVal(sdkVar.URI())` added to the `Read()` method

**Not updated:** `project` data source (the project resource has no `uri` field).
**Already had `uri`:** `cloudserver`, `kaas`, `dbaas`, `containerregistry`, `subnet`, `securityrule`.

### Closes #170 — `billing_period` and backup `type` validators

Added `stringvalidator.OneOf(...)` to:
- `billing_period` (`Hour`, `Month`, `Year`) on: `backup`, `blockstorage`, `containerregistry`, `databasebackup`, `dbaas`, `kaas`, `kms`, `vpcpeeringroute`, `vpntunnel`
- `type` (`Full`, `Incremental`) on: `backup`

`engine_id` in `dbaas` is intentionally left without a finite-set validator — valid values are API-version-dependent and would require provider updates when new engines are added.

`elasticip` and `snapshot` already had `billing_period` validators.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/provider/ -run "^Test[^Acc]"` — all pass
- [x] `gofmt -l ./internal/provider/` — clean
- [x] `make generate` — docs regenerated
- [ ] Acceptance: `data "arubacloud_backup" "x" { ... }` → verify `uri` attribute is non-null

🤖 Generated with [Claude Code](https://claude.com/claude-code)
