### PR TITLE
docs: fix resource classification and stale references in registry docs

### DIFF
--- a/docs/data-sources/schedulejob.md
+++ b/docs/data-sources/schedulejob.md
@@ -1,6 +1,6 @@
 ---
 page_title: "arubacloud_schedulejob Data Source - ArubaCloud"
-subcategory: "Management"
+subcategory: "Schedule"
 description: |-
   Retrieves information about an existing ArubaCloud Scheduled Job.
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     arubacloud = {
       source  = "arubacloud/arubacloud"
-      version = ">= 0.0.1"
+      version = ">= 0.3.0"
     }
   }
 }
@@ -41,7 +41,7 @@ terraform {
   required_providers {
     arubacloud = {
       source  = "arubacloud/arubacloud"
-      version = ">= 0.0.1"
+      version = ">= 0.3.0"
     }
   }
 }
@@ -197,21 +197,22 @@ output "cloudserver_id" {
 
 | Category | Resources | Data Sources |
 |---|---|---|
-| **Compute** | [`arubacloud_cloudserver`](resources/cloudserver), [`arubacloud_keypair`](resources/keypair), [`arubacloud_elasticip`](resources/elasticip) | [`arubacloud_cloudserver`](data-sources/cloudserver), [`arubacloud_keypair`](data-sources/keypair), [`arubacloud_elasticip`](data-sources/elasticip) |
-| **Network** | [`arubacloud_vpc`](resources/vpc), [`arubacloud_subnet`](resources/subnet), [`arubacloud_securitygroup`](resources/securitygroup), [`arubacloud_securityrule`](resources/securityrule), [`arubacloud_vpcpeering`](resources/vpcpeering), [`arubacloud_vpcpeeringroute`](resources/vpcpeeringroute), [`arubacloud_vpntunnel`](resources/vpntunnel), [`arubacloud_vpnroute`](resources/vpnroute) | [`arubacloud_vpc`](data-sources/vpc), [`arubacloud_subnet`](data-sources/subnet), [`arubacloud_securitygroup`](data-sources/securitygroup), [`arubacloud_securityrule`](data-sources/securityrule), [`arubacloud_vpcpeering`](data-sources/vpcpeering), [`arubacloud_vpcpeeringroute`](data-sources/vpcpeeringroute), [`arubacloud_vpntunnel`](data-sources/vpntunnel), [`arubacloud_vpnroute`](data-sources/vpnroute) |
+| **Management** | [`arubacloud_project`](resources/project) | [`arubacloud_project`](data-sources/project) |
+| **Compute** | [`arubacloud_cloudserver`](resources/cloudserver), [`arubacloud_keypair`](resources/keypair) | [`arubacloud_cloudserver`](data-sources/cloudserver), [`arubacloud_keypair`](data-sources/keypair) |
 | **Storage** | [`arubacloud_blockstorage`](resources/blockstorage), [`arubacloud_snapshot`](resources/snapshot), [`arubacloud_backup`](resources/backup), [`arubacloud_restore`](resources/restore) | [`arubacloud_blockstorage`](data-sources/blockstorage), [`arubacloud_snapshot`](data-sources/snapshot), [`arubacloud_backup`](data-sources/backup), [`arubacloud_restore`](data-sources/restore) |
+| **Network** | [`arubacloud_vpc`](resources/vpc), [`arubacloud_subnet`](resources/subnet), [`arubacloud_securitygroup`](resources/securitygroup), [`arubacloud_securityrule`](resources/securityrule), [`arubacloud_elasticip`](resources/elasticip), [`arubacloud_vpcpeering`](resources/vpcpeering), [`arubacloud_vpcpeeringroute`](resources/vpcpeeringroute), [`arubacloud_vpntunnel`](resources/vpntunnel), [`arubacloud_vpnroute`](resources/vpnroute) | [`arubacloud_vpc`](data-sources/vpc), [`arubacloud_subnet`](data-sources/subnet), [`arubacloud_securitygroup`](data-sources/securitygroup), [`arubacloud_securityrule`](data-sources/securityrule), [`arubacloud_elasticip`](data-sources/elasticip), [`arubacloud_vpcpeering`](data-sources/vpcpeering), [`arubacloud_vpcpeeringroute`](data-sources/vpcpeeringroute), [`arubacloud_vpntunnel`](data-sources/vpntunnel), [`arubacloud_vpnroute`](data-sources/vpnroute) |
 | **Container** | [`arubacloud_kaas`](resources/kaas), [`arubacloud_containerregistry`](resources/containerregistry) | [`arubacloud_kaas`](data-sources/kaas), [`arubacloud_containerregistry`](data-sources/containerregistry) |
-| **Database** | [`arubacloud_dbaas`](resources/dbaas), [`arubacloud_database`](resources/database), [`arubacloud_databasegrant`](resources/databasegrant), [`arubacloud_databasebackup`](resources/databasebackup), [`arubacloud_dbaasuser`](resources/dbaasuser) | [`arubacloud_dbaas`](data-sources/dbaas), [`arubacloud_database`](data-sources/database), [`arubacloud_databasegrant`](data-sources/databasegrant), [`arubacloud_databasebackup`](data-sources/databasebackup), [`arubacloud_dbaasuser`](data-sources/dbaasuser) |
-| **Management** | [`arubacloud_project`](resources/project), [`arubacloud_schedulejob`](resources/schedulejob) | [`arubacloud_project`](data-sources/project), [`arubacloud_schedulejob`](data-sources/schedulejob) |
+| **Database** | [`arubacloud_dbaas`](resources/dbaas), [`arubacloud_database`](resources/database), [`arubacloud_dbaasuser`](resources/dbaasuser), [`arubacloud_databasegrant`](resources/databasegrant), [`arubacloud_databasebackup`](resources/databasebackup) | [`arubacloud_dbaas`](data-sources/dbaas), [`arubacloud_database`](data-sources/database), [`arubacloud_dbaasuser`](data-sources/dbaasuser), [`arubacloud_databasegrant`](data-sources/databasegrant), [`arubacloud_databasebackup`](data-sources/databasebackup) |
 | **Security** | [`arubacloud_kms`](resources/kms) | [`arubacloud_kms`](data-sources/kms) |
+| **Schedule** | [`arubacloud_schedulejob`](resources/schedulejob) | [`arubacloud_schedulejob`](data-sources/schedulejob) |
 
 ## Argument Reference
 
 The following arguments are supported:
 
-- `api_key` - (Required, string) ArubaCloud API key. Can also be specified with the `ARUBACLOUD_API_KEY` environment variable.
-- `api_secret` - (Required, string) ArubaCloud API secret. Can also be specified with the `ARUBACLOUD_API_SECRET` environment variable.
-- `resource_timeout` - (Optional, string) Timeout for waiting for resources to become active after creation (e.g. `"5m"`, `"10m"`). Default: `"10m"`.
+- `client_id` - (Required, string) ArubaCloud OAuth2 client ID. Can also be specified with the `ARUBACLOUD_CLIENT_ID` environment variable.
+- `client_secret` - (Required, string) ArubaCloud OAuth2 client secret. Can also be specified with the `ARUBACLOUD_CLIENT_SECRET` environment variable.
+- `resource_timeout` - (Optional, string) Timeout for waiting for resources to become active after creation (e.g. `"15m"`, `"45m"`). Default: `"30m"`.
 - `base_url` - (Optional, string) Override the ArubaCloud API base URL. Advanced use only.
 - `token_issuer_url` - (Optional, string) Override the ArubaCloud token issuer URL. Advanced use only.
 - `log_level` - (Optional, string) SDK log level for HTTP request/response tracing. Accepted values (case-insensitive): `OFF`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`. Default: `OFF`. Can also be set via the `ARUBACLOUD_LOG_LEVEL` environment variable; the HCL attribute takes precedence.
@@ -231,9 +232,9 @@ A message is visible only when **both** filters permit it. SDK messages are tagg
 
 ```hcl
 provider "arubacloud" {
-  api_key    = var.api_key
-  api_secret = var.api_secret
-  log_level  = "DEBUG"
+  client_id     = var.client_id
+  client_secret = var.client_secret
+  log_level     = "DEBUG"
 }
 ```
 

--- a/docs/resources/schedulejob.md
+++ b/docs/resources/schedulejob.md
@@ -1,6 +1,6 @@
 ---
 page_title: "arubacloud_schedulejob Resource - ArubaCloud"
-subcategory: "Management"
+subcategory: "Schedule"
 description: |-
   Manages an ArubaCloud Scheduled Job — a cron-triggered automation task.
 ---

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     arubacloud = {
       source  = "arubacloud/arubacloud"
-      version = ">= 0.0.1"
+      version = ">= 0.3.0"
     }
   }
 }

--- a/examples/provider/quick-start.tf
+++ b/examples/provider/quick-start.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     arubacloud = {
       source  = "arubacloud/arubacloud"
-      version = ">= 0.0.1"
+      version = ">= 0.3.0"
     }
   }
 }

--- a/templates/data-sources/schedulejob.md.tmpl
+++ b/templates/data-sources/schedulejob.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "arubacloud_schedulejob Data Source - ArubaCloud"
-subcategory: "Management"
+subcategory: "Schedule"
 description: |-
   Retrieves information about an existing ArubaCloud Scheduled Job.
 ---

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -24,21 +24,22 @@ The following end-to-end example provisions a CloudServer with all required depe
 
 | Category | Resources | Data Sources |
 |---|---|---|
-| **Compute** | [`arubacloud_cloudserver`](resources/cloudserver), [`arubacloud_keypair`](resources/keypair), [`arubacloud_elasticip`](resources/elasticip) | [`arubacloud_cloudserver`](data-sources/cloudserver), [`arubacloud_keypair`](data-sources/keypair), [`arubacloud_elasticip`](data-sources/elasticip) |
-| **Network** | [`arubacloud_vpc`](resources/vpc), [`arubacloud_subnet`](resources/subnet), [`arubacloud_securitygroup`](resources/securitygroup), [`arubacloud_securityrule`](resources/securityrule), [`arubacloud_vpcpeering`](resources/vpcpeering), [`arubacloud_vpcpeeringroute`](resources/vpcpeeringroute), [`arubacloud_vpntunnel`](resources/vpntunnel), [`arubacloud_vpnroute`](resources/vpnroute) | [`arubacloud_vpc`](data-sources/vpc), [`arubacloud_subnet`](data-sources/subnet), [`arubacloud_securitygroup`](data-sources/securitygroup), [`arubacloud_securityrule`](data-sources/securityrule), [`arubacloud_vpcpeering`](data-sources/vpcpeering), [`arubacloud_vpcpeeringroute`](data-sources/vpcpeeringroute), [`arubacloud_vpntunnel`](data-sources/vpntunnel), [`arubacloud_vpnroute`](data-sources/vpnroute) |
+| **Management** | [`arubacloud_project`](resources/project) | [`arubacloud_project`](data-sources/project) |
+| **Compute** | [`arubacloud_cloudserver`](resources/cloudserver), [`arubacloud_keypair`](resources/keypair) | [`arubacloud_cloudserver`](data-sources/cloudserver), [`arubacloud_keypair`](data-sources/keypair) |
 | **Storage** | [`arubacloud_blockstorage`](resources/blockstorage), [`arubacloud_snapshot`](resources/snapshot), [`arubacloud_backup`](resources/backup), [`arubacloud_restore`](resources/restore) | [`arubacloud_blockstorage`](data-sources/blockstorage), [`arubacloud_snapshot`](data-sources/snapshot), [`arubacloud_backup`](data-sources/backup), [`arubacloud_restore`](data-sources/restore) |
+| **Network** | [`arubacloud_vpc`](resources/vpc), [`arubacloud_subnet`](resources/subnet), [`arubacloud_securitygroup`](resources/securitygroup), [`arubacloud_securityrule`](resources/securityrule), [`arubacloud_elasticip`](resources/elasticip), [`arubacloud_vpcpeering`](resources/vpcpeering), [`arubacloud_vpcpeeringroute`](resources/vpcpeeringroute), [`arubacloud_vpntunnel`](resources/vpntunnel), [`arubacloud_vpnroute`](resources/vpnroute) | [`arubacloud_vpc`](data-sources/vpc), [`arubacloud_subnet`](data-sources/subnet), [`arubacloud_securitygroup`](data-sources/securitygroup), [`arubacloud_securityrule`](data-sources/securityrule), [`arubacloud_elasticip`](data-sources/elasticip), [`arubacloud_vpcpeering`](data-sources/vpcpeering), [`arubacloud_vpcpeeringroute`](data-sources/vpcpeeringroute), [`arubacloud_vpntunnel`](data-sources/vpntunnel), [`arubacloud_vpnroute`](data-sources/vpnroute) |
 | **Container** | [`arubacloud_kaas`](resources/kaas), [`arubacloud_containerregistry`](resources/containerregistry) | [`arubacloud_kaas`](data-sources/kaas), [`arubacloud_containerregistry`](data-sources/containerregistry) |
-| **Database** | [`arubacloud_dbaas`](resources/dbaas), [`arubacloud_database`](resources/database), [`arubacloud_databasegrant`](resources/databasegrant), [`arubacloud_databasebackup`](resources/databasebackup), [`arubacloud_dbaasuser`](resources/dbaasuser) | [`arubacloud_dbaas`](data-sources/dbaas), [`arubacloud_database`](data-sources/database), [`arubacloud_databasegrant`](data-sources/databasegrant), [`arubacloud_databasebackup`](data-sources/databasebackup), [`arubacloud_dbaasuser`](data-sources/dbaasuser) |
-| **Management** | [`arubacloud_project`](resources/project), [`arubacloud_schedulejob`](resources/schedulejob) | [`arubacloud_project`](data-sources/project), [`arubacloud_schedulejob`](data-sources/schedulejob) |
+| **Database** | [`arubacloud_dbaas`](resources/dbaas), [`arubacloud_database`](resources/database), [`arubacloud_dbaasuser`](resources/dbaasuser), [`arubacloud_databasegrant`](resources/databasegrant), [`arubacloud_databasebackup`](resources/databasebackup) | [`arubacloud_dbaas`](data-sources/dbaas), [`arubacloud_database`](data-sources/database), [`arubacloud_dbaasuser`](data-sources/dbaasuser), [`arubacloud_databasegrant`](data-sources/databasegrant), [`arubacloud_databasebackup`](data-sources/databasebackup) |
 | **Security** | [`arubacloud_kms`](resources/kms) | [`arubacloud_kms`](data-sources/kms) |
+| **Schedule** | [`arubacloud_schedulejob`](resources/schedulejob) | [`arubacloud_schedulejob`](data-sources/schedulejob) |
 
 ## Argument Reference
 
 The following arguments are supported:
 
-- `api_key` - (Required, string) ArubaCloud API key. Can also be specified with the `ARUBACLOUD_API_KEY` environment variable.
-- `api_secret` - (Required, string) ArubaCloud API secret. Can also be specified with the `ARUBACLOUD_API_SECRET` environment variable.
-- `resource_timeout` - (Optional, string) Timeout for waiting for resources to become active after creation (e.g. `"5m"`, `"10m"`). Default: `"10m"`.
+- `client_id` - (Required, string) ArubaCloud OAuth2 client ID. Can also be specified with the `ARUBACLOUD_CLIENT_ID` environment variable.
+- `client_secret` - (Required, string) ArubaCloud OAuth2 client secret. Can also be specified with the `ARUBACLOUD_CLIENT_SECRET` environment variable.
+- `resource_timeout` - (Optional, string) Timeout for waiting for resources to become active after creation (e.g. `"15m"`, `"45m"`). Default: `"30m"`.
 - `base_url` - (Optional, string) Override the ArubaCloud API base URL. Advanced use only.
 - `token_issuer_url` - (Optional, string) Override the ArubaCloud token issuer URL. Advanced use only.
 - `log_level` - (Optional, string) SDK log level for HTTP request/response tracing. Accepted values (case-insensitive): `OFF`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`. Default: `OFF`. Can also be set via the `ARUBACLOUD_LOG_LEVEL` environment variable; the HCL attribute takes precedence.
@@ -58,9 +59,9 @@ A message is visible only when **both** filters permit it. SDK messages are tagg
 
 ```hcl
 provider "arubacloud" {
-  api_key    = var.api_key
-  api_secret = var.api_secret
-  log_level  = "DEBUG"
+  client_id     = var.client_id
+  client_secret = var.client_secret
+  log_level     = "DEBUG"
 }
 ```
 

--- a/templates/resources/schedulejob.md.tmpl
+++ b/templates/resources/schedulejob.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "arubacloud_schedulejob Resource - ArubaCloud"
-subcategory: "Management"
+subcategory: "Schedule"
 description: |-
   Manages an ArubaCloud Scheduled Job — a cron-triggered automation task.
 ---


### PR DESCRIPTION
## Summary

- `arubacloud_schedulejob` subcategory corrected from `Management` → `Schedule` in both the resource and data-source frontmatter (this drives the Terraform Registry left-hand sidebar grouping)
- `arubacloud_elasticip` moved from the **Compute** row to **Network** in the `docs/index.md` table (its individual file already had `subcategory: \"Network\"` — the table was inconsistent)
- `arubacloud_schedulejob` extracted from the **Management** row into its own **Schedule** row in the table
- Database entries reordered to the logical hierarchy: `dbaas → database → dbaasuser → databasegrant → databasebackup`
- Argument Reference updated: `api_key`/`api_secret` → `client_id`/`client_secret` and `ARUBACLOUD_API_KEY/SECRET` → `ARUBACLOUD_CLIENT_ID/SECRET` (renamed as a breaking change in v0.2.0)
- `resource_timeout` default corrected: `\"10m\"` → `\"30m\"` (raised in v0.2.0)
- Logging example provider block updated to use `client_id`/`client_secret`
- Version pins bumped from `>= 0.0.1` to `>= 0.3.0`

## Test plan

- [ ] Verify Registry sidebar shows **Schedule** group with `arubacloud_schedulejob` after publish
- [ ] Confirm `arubacloud_elasticip` appears under **Network** in the Registry
- [ ] Review `docs/index.md` Argument Reference matches current provider schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)