### PR TITLE
feat: v0.4.0 — VPN tunnel fix, KaaS kubeconfig description, CloudServer update wait

### DIFF
--- a/docs/resources/backup.md
+++ b/docs/resources/backup.md
@@ -48,6 +48,7 @@ The following arguments are supported:
 - `billing_period` (String) Billing cycle. Accepted values: `Hour`, `Month`, `Year`.
 - `retention_days` (Number) Number of days to retain the backup before automatic deletion. Optional — if omitted, the backup is retained indefinitely.
 - `tags` (List of String) List of string tags attached to the resource for filtering and organisation.
+- `timeout` (String) Per-resource timeout override (e.g. `"15m"`, `"1h"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.
 
 ### Attributes Reference
 

--- a/docs/resources/blockstorage.md
+++ b/docs/resources/blockstorage.md
@@ -62,6 +62,7 @@ The following arguments are supported:
 - `bootable` (Boolean) Whether this volume can be used as a boot volume for an `arubacloud_cloudserver`. Must be `true` when `image` is set.
 - `image` (String) Image ID to use when creating a bootable volume. Required when `bootable` is `true`. See the [available images](https://api.arubacloud.com/docs/metadata/#cloud-server-bootvolume).
 - `tags` (List of String) List of string tags attached to the resource for filtering and organisation.
+- `timeout` (String) Per-resource timeout override (e.g. `"15m"`, `"1h"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.
 - `zone` (String) Availability zone within the region. If omitted the volume is regional (accessible across all zones).
 
 ### Attributes Reference

--- a/docs/resources/cloudserver.md
+++ b/docs/resources/cloudserver.md
@@ -61,6 +61,7 @@ The following arguments are supported:
 #### Optional
 
 - `tags` (List of String) List of string tags attached to the resource for filtering and organisation.
+- `timeout` (String) Per-resource timeout override (e.g. `"15m"`, `"1h"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.
 
 ### Attributes Reference
 

--- a/docs/resources/containerregistry.md
+++ b/docs/resources/containerregistry.md
@@ -66,6 +66,7 @@ The following arguments are supported:
 - `billing_period` (String) Billing cycle. Accepted values: `Hour`, `Month`, `Year`.
 - `settings` (Attributes) Optional registry configuration settings. (see [below for nested schema](#nestedatt--settings))
 - `tags` (List of String) List of string tags attached to the resource for filtering and organisation.
+- `timeout` (String) Per-resource timeout override (e.g. `"15m"`, `"1h"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.
 
 ### Attributes Reference
 

--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -32,6 +32,10 @@ The following arguments are supported:
 - `name` (String) Display name for the database.
 - `project_id` (String) ID of the project that owns this resource.
 
+#### Optional
+
+- `timeout` (String) Per-resource timeout override (e.g. `"15m"`, `"1h"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.
+
 ### Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/docs/resources/databasebackup.md
+++ b/docs/resources/databasebackup.md
@@ -42,6 +42,7 @@ The following arguments are supported:
 #### Optional
 
 - `tags` (List of String) List of string tags attached to the resource for filtering and organisation.
+- `timeout` (String) Per-resource timeout override (e.g. `"15m"`, `"1h"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.
 
 ### Attributes Reference
 

--- a/docs/resources/databasegrant.md
+++ b/docs/resources/databasegrant.md
@@ -38,6 +38,10 @@ The following arguments are supported:
 - `role` (String) Privilege level granted. Accepted values depend on the database engine (e.g., `ALL`, `READ`, `WRITE`).
 - `user_id` (String) Name or ID of the DBaaS user receiving the grant.
 
+#### Optional
+
+- `timeout` (String) Per-resource timeout override (e.g. `"15m"`, `"1h"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.
+
 ### Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/docs/resources/dbaas.md
+++ b/docs/resources/dbaas.md
@@ -69,6 +69,7 @@ The following arguments are supported:
 
 - `billing_period` (String) Billing cycle. Accepted values: `Hour`, `Month`, `Year`.
 - `tags` (List of String) List of string tags attached to the resource for filtering and organisation.
+- `timeout` (String) Per-resource timeout override (e.g. `"15m"`, `"1h"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.
 
 ### Attributes Reference
 

--- a/docs/resources/dbaasuser.md
+++ b/docs/resources/dbaasuser.md
@@ -35,6 +35,10 @@ The following arguments are supported:
 - `project_id` (String) ID of the project that owns this resource.
 - `username` (String) Display name for the DBaaS user.
 
+#### Optional
+
+- `timeout` (String) Per-resource timeout override (e.g. `"15m"`, `"1h"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.
+
 ### Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/docs/resources/elasticip.md
+++ b/docs/resources/elasticip.md
@@ -46,6 +46,7 @@ The following arguments are supported:
 
 - `billing_period` (String) Billing cycle. Accepted values: `Hour`, `Month`, `Year`.
 - `tags` (List of String) List of string tags.
+- `timeout` (String) Per-resource timeout override (e.g. `"15m"`, `"1h"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.
 
 ### Attributes Reference
 

--- a/docs/resources/kaas.md
+++ b/docs/resources/kaas.md
@@ -91,6 +91,7 @@ The following arguments are supported:
 
 - `billing_period` (String) Billing cycle. Accepted values: `Hour`, `Month`, `Year`.
 - `tags` (List of String) List of string tags attached to the resource for filtering and organisation.
+- `timeout` (String) Per-resource timeout override (e.g. `"15m"`, `"1h"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.
 
 ### Attributes Reference
 
@@ -99,7 +100,7 @@ In addition to all arguments above, the following attributes are exported:
 #### Read-Only
 
 - `id` (String) Computed by the API. Unique identifier for the resource.
-- `kubeconfig` (String, Sensitive) Computed by the API. Kubeconfig YAML for kubectl access, downloaded when the cluster is active. Write-only — this value is sent to the API but is not returned in subsequent read responses.
+- `kubeconfig` (String, Sensitive) Kubeconfig YAML for `kubectl` access. Populated automatically when the cluster becomes active. Sensitive — stored in Terraform state but redacted from plan output.
 - `management_ip` (String) Computed by the API. Management IP address of the cluster control plane, available once the cluster is active.
 - `uri` (String) Computed by the API. Full resource URI used as a reference value in other resources.
 

--- a/docs/resources/keypair.md
+++ b/docs/resources/keypair.md
@@ -42,6 +42,7 @@ The following arguments are supported:
 #### Optional
 
 - `tags` (List of String) List of string tags attached to the resource for filtering and organisation.
+- `timeout` (String) Per-resource timeout override (e.g. `"15m"`, `"1h"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.
 
 ### Attributes Reference
 

--- a/docs/resources/kms.md
+++ b/docs/resources/kms.md
@@ -40,6 +40,7 @@ The following arguments are supported:
 - `billing_period` (String) Billing cycle. Accepted values: `Hour`, `Month`, `Year`.
 - `location` (String) Region identifier (e.g., `ITBG-Bergamo`). See the [available locations and zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center).
 - `tags` (List of String) List of string tags attached to the resource for filtering and organisation.
+- `timeout` (String) Per-resource timeout override (e.g. `"15m"`, `"1h"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.
 
 ### Attributes Reference
 

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -36,6 +36,7 @@ The following arguments are supported:
 
 - `description` (String) Optional human-readable description of the project.
 - `tags` (List of String) List of string tags attached to the resource for filtering and organisation.
+- `timeout` (String) Per-resource timeout override (e.g. `"15m"`, `"1h"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.
 
 ### Attributes Reference
 

--- a/docs/resources/restore.md
+++ b/docs/resources/restore.md
@@ -37,6 +37,7 @@ The following arguments are supported:
 #### Optional
 
 - `tags` (List of String) List of string tags attached to the resource for filtering and organisation.
+- `timeout` (String) Per-resource timeout override (e.g. `"15m"`, `"1h"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.
 
 ### Attributes Reference
 

--- a/docs/resources/schedulejob.md
+++ b/docs/resources/schedulejob.md
@@ -45,6 +45,7 @@ The following arguments are supported:
 #### Optional
 
 - `tags` (List of String) List of string tags attached to the resource for filtering and organisation.
+- `timeout` (String) Per-resource timeout override (e.g. `"15m"`, `"1h"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.
 
 ### Attributes Reference
 

--- a/docs/resources/securitygroup.md
+++ b/docs/resources/securitygroup.md
@@ -40,6 +40,7 @@ The following arguments are supported:
 #### Optional
 
 - `tags` (List of String) List of string tags attached to the resource for filtering and organisation.
+- `timeout` (String) Per-resource timeout override (e.g. `"15m"`, `"1h"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.
 
 ### Attributes Reference
 

--- a/docs/resources/securityrule.md
+++ b/docs/resources/securityrule.md
@@ -72,6 +72,7 @@ The following arguments are supported:
 #### Optional
 
 - `tags` (List of String) List of string tags attached to the resource for filtering and organisation.
+- `timeout` (String) Per-resource timeout override (e.g. `"15m"`, `"1h"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.
 
 ### Attributes Reference
 

--- a/docs/resources/snapshot.md
+++ b/docs/resources/snapshot.md
@@ -39,6 +39,7 @@ The following arguments are supported:
 #### Optional
 
 - `tags` (List of String) List of string tags attached to the resource for filtering and organisation.
+- `timeout` (String) Per-resource timeout override (e.g. `"15m"`, `"1h"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.
 
 ### Attributes Reference
 

--- a/docs/resources/subnet.md
+++ b/docs/resources/subnet.md
@@ -73,6 +73,7 @@ The following arguments are supported:
 
 - `network` (Attributes) Network configuration block. Required when `type` is `Advanced`. (see [below for nested schema](#nestedatt--network))
 - `tags` (List of String) List of string tags attached to the resource for filtering and organisation.
+- `timeout` (String) Per-resource timeout override (e.g. `"15m"`, `"1h"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.
 
 ### Attributes Reference
 

--- a/docs/resources/vpc.md
+++ b/docs/resources/vpc.md
@@ -38,6 +38,7 @@ The following arguments are supported:
 #### Optional
 
 - `tags` (List of String) List of string tags attached to the resource for filtering and organisation.
+- `timeout` (String) Per-resource timeout override (e.g. `"15m"`, `"1h"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.
 
 ### Attributes Reference
 

--- a/docs/resources/vpcpeering.md
+++ b/docs/resources/vpcpeering.md
@@ -40,6 +40,7 @@ The following arguments are supported:
 #### Optional
 
 - `tags` (List of String) List of string tags attached to the resource for filtering and organisation.
+- `timeout` (String) Per-resource timeout override (e.g. `"15m"`, `"1h"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.
 
 ### Attributes Reference
 

--- a/docs/resources/vpcpeeringroute.md
+++ b/docs/resources/vpcpeeringroute.md
@@ -40,6 +40,7 @@ The following arguments are supported:
 #### Optional
 
 - `tags` (List of String) List of string tags attached to the resource for filtering and organisation.
+- `timeout` (String) Per-resource timeout override (e.g. `"15m"`, `"1h"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.
 
 ### Attributes Reference
 

--- a/docs/resources/vpnroute.md
+++ b/docs/resources/vpnroute.md
@@ -45,6 +45,7 @@ The following arguments are supported:
 #### Optional
 
 - `tags` (List of String) List of string tags attached to the resource for filtering and organisation.
+- `timeout` (String) Per-resource timeout override (e.g. `"15m"`, `"1h"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.
 
 ### Attributes Reference
 

--- a/docs/resources/vpntunnel.md
+++ b/docs/resources/vpntunnel.md
@@ -43,6 +43,7 @@ The following arguments are supported:
 #### Optional
 
 - `tags` (List of String) List of string tags attached to the resource for filtering and organisation.
+- `timeout` (String) Per-resource timeout override (e.g. `"15m"`, `"1h"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.
 
 ### Attributes Reference
 
@@ -86,6 +87,7 @@ Optional:
 
 Optional:
 
+- `cidr` (String) CIDR block of the subnet (e.g. `192.168.10.0/24`). Required by the API.
 - `id` (String) ID of the subnet.
 
 
@@ -116,7 +118,7 @@ Optional:
 - `encryption` (String) ESP encryption algorithm (e.g., `aes256`).
 - `hash` (String) ESP integrity/hash algorithm (e.g., `sha256`).
 - `lifetime` (Number) ESP phase-2 lifetime in seconds.
-- `pfs` (String) ESP Perfect Forward Secrecy group (e.g., `modp2048`).
+- `pfs` (String) ESP Perfect Forward Secrecy group. Use `"enable"`, `"disable"`, or `"dh-group<N>"` (e.g. `"dh-group14"` for MODP-2048).
 
 
 <a id="nestedatt--properties--vpn_client_settings--ike"></a>
@@ -124,7 +126,7 @@ Optional:
 
 Optional:
 
-- `dh_group` (String) IKE Diffie-Hellman group (e.g., `modp2048`).
+- `dh_group` (String) IKE Diffie-Hellman group. Use the numeric group identifier: `"1"`, `"2"`, `"5"`, `"14"` … `"32"`. The common choice for IKEv2 is `"14"` (MODP-2048).
 - `dpd_action` (String) Dead Peer Detection action on failure (e.g., `restart`).
 - `dpd_interval` (Number) DPD keep-alive interval in seconds.
 - `dpd_timeout` (Number) DPD timeout before the peer is considered dead, in seconds.

--- a/internal/provider/backup_resource.go
+++ b/internal/provider/backup_resource.go
@@ -29,6 +29,7 @@ type BackupResourceModel struct {
 	VolumeID      types.String `tfsdk:"volume_id"`
 	RetentionDays types.Int64  `tfsdk:"retention_days"`
 	BillingPeriod types.String `tfsdk:"billing_period"`
+	Timeout       types.String `tfsdk:"timeout"`
 }
 
 type BackupResource struct {
@@ -113,6 +114,10 @@ func (r *BackupResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				Optional:            true,
 				Validators:          []validator.String{stringvalidator.OneOf("Hour", "Month", "Year")},
 			},
+			"timeout": schema.StringAttribute{
+				MarkdownDescription: "Per-resource timeout override (e.g. `\"15m\"`, `\"1h\"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.",
+				Optional:            true,
+			},
 		},
 	}
 }
@@ -195,7 +200,7 @@ func (r *BackupResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	if waitErr := backup.WaitUntilReady(ctx, sdkWaitOptions(r.client.ResourceTimeout)...); waitErr != nil {
+	if waitErr := backup.WaitUntilReady(ctx, sdkWaitOptions(effectiveTimeout(data.Timeout, r.client.ResourceTimeout))...); waitErr != nil {
 		ReportWaitResult(&resp.Diagnostics, waitErr, "Backup", data.Id.ValueString())
 		return
 	}
@@ -360,12 +365,12 @@ func (r *BackupResource) Delete(ctx context.Context, req resource.DeleteRequest,
 	err := DeleteResourceWithRetry(ctx, func() error {
 		return CheckResponseErrAsError("delete", "Backup",
 			r.client.Client.FromStorage().Backups().Delete(ctx, ref))
-	}, "Backup", backupID, r.client.ResourceTimeout, deletionChecker)
+	}, "Backup", backupID, effectiveTimeout(data.Timeout, r.client.ResourceTimeout), deletionChecker)
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting Backup", err.Error())
 		return
 	}
-	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "Backup", backupID, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
+	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "Backup", backupID, remainingTimeout(deleteStart, effectiveTimeout(data.Timeout, r.client.ResourceTimeout))); waitErr != nil {
 		resp.Diagnostics.AddError("Error waiting for Backup deletion", waitErr.Error())
 		return
 	}

--- a/internal/provider/blockstorage_resource.go
+++ b/internal/provider/blockstorage_resource.go
@@ -37,6 +37,7 @@ type BlockStorageResourceModel struct {
 	Bootable      types.Bool   `tfsdk:"bootable"`
 	Image         types.String `tfsdk:"image"`
 	Tags          types.List   `tfsdk:"tags"`
+	Timeout       types.String `tfsdk:"timeout"`
 }
 
 type BlockStorageResource struct {
@@ -108,6 +109,10 @@ func (r *BlockStorageResource) Schema(ctx context.Context, req resource.SchemaRe
 			"tags": schema.ListAttribute{
 				ElementType:         types.StringType,
 				MarkdownDescription: "List of string tags attached to the resource for filtering and organisation.",
+				Optional:            true,
+			},
+			"timeout": schema.StringAttribute{
+				MarkdownDescription: "Per-resource timeout override (e.g. `\"15m\"`, `\"1h\"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.",
 				Optional:            true,
 			},
 		},
@@ -219,7 +224,7 @@ func (r *BlockStorageResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
-	if waitErr := vol.WaitUntilReady(ctx, sdkWaitOptions(r.client.ResourceTimeout)...); waitErr != nil {
+	if waitErr := vol.WaitUntilReady(ctx, sdkWaitOptions(effectiveTimeout(data.Timeout, r.client.ResourceTimeout))...); waitErr != nil {
 		ReportWaitResult(&resp.Diagnostics, waitErr, "BlockStorage", data.Id.ValueString())
 		return
 	}
@@ -380,12 +385,12 @@ func (r *BlockStorageResource) Delete(ctx context.Context, req resource.DeleteRe
 	err := DeleteResourceWithRetry(ctx, func() error {
 		return CheckResponseErrAsError("delete", "BlockStorage",
 			r.client.Client.FromStorage().Volumes().Delete(ctx, ref))
-	}, "BlockStorage", volumeID, r.client.ResourceTimeout, deletionChecker)
+	}, "BlockStorage", volumeID, effectiveTimeout(data.Timeout, r.client.ResourceTimeout), deletionChecker)
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting BlockStorage", err.Error())
 		return
 	}
-	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "BlockStorage", volumeID, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
+	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "BlockStorage", volumeID, remainingTimeout(deleteStart, effectiveTimeout(data.Timeout, r.client.ResourceTimeout))); waitErr != nil {
 		resp.Diagnostics.AddError("Error waiting for BlockStorage deletion", waitErr.Error())
 		return
 	}

--- a/internal/provider/cloudserver_resource.go
+++ b/internal/provider/cloudserver_resource.go
@@ -567,6 +567,11 @@ func (r *CloudServerResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
+	if waitErr := updated.WaitUntilReady(ctx, sdkWaitOptions(r.client.ResourceTimeout)...); waitErr != nil {
+		ReportWaitResult(&resp.Diagnostics, waitErr, "CloudServer", state.Id.ValueString())
+		return
+	}
+
 	if n := updated.Name(); n != "" {
 		data.Name = types.StringValue(n)
 	}

--- a/internal/provider/cloudserver_resource.go
+++ b/internal/provider/cloudserver_resource.go
@@ -459,11 +459,13 @@ func (r *CloudServerResource) applyServerToState(
 		}
 	}
 
+	// elastic_ip_uri_ref and securitygroup_uri_refs are not returned by the API;
+	// preserve them from the prior state to avoid spurious diffs.
 	networkAttrs := map[string]attr.Value{
 		"vpc_uri_ref":            resolveAPIStringRef(server.VPC(), origNetwork.VpcUriRef),
-		"elastic_ip_uri_ref":     origNetwork.ElasticIpUriRef,     // not returned by API; preserve state
+		"elastic_ip_uri_ref":     origNetwork.ElasticIpUriRef,
 		"subnet_uri_refs":        subnetUriRefs,
-		"securitygroup_uri_refs": origNetwork.SecurityGroupUriRefs, // not returned by API; preserve state
+		"securitygroup_uri_refs": origNetwork.SecurityGroupUriRefs,
 	}
 	networkObj, d := types.ObjectValue(csNetworkAttrTypes(), networkAttrs)
 	diags.Append(d...)

--- a/internal/provider/cloudserver_resource.go
+++ b/internal/provider/cloudserver_resource.go
@@ -30,6 +30,7 @@ type CloudServerResourceModel struct {
 	Network   types.Object `tfsdk:"network"`
 	Settings  types.Object `tfsdk:"settings"`
 	Storage   types.Object `tfsdk:"storage"`
+	Timeout   types.String `tfsdk:"timeout"`
 }
 
 type CloudServerNetworkModel struct {
@@ -189,6 +190,10 @@ func (r *CloudServerResource) Schema(ctx context.Context, req resource.SchemaReq
 					},
 				},
 			},
+			"timeout": schema.StringAttribute{
+				MarkdownDescription: "Per-resource timeout override (e.g. `\"15m\"`, `\"1h\"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.",
+				Optional:            true,
+			},
 		},
 	}
 }
@@ -308,7 +313,7 @@ func (r *CloudServerResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	if err := server.WaitUntilReady(ctx, sdkWaitOptions(r.client.ResourceTimeout)...); err != nil {
+	if err := server.WaitUntilReady(ctx, sdkWaitOptions(effectiveTimeout(data.Timeout, r.client.ResourceTimeout))...); err != nil {
 		ReportWaitResult(&resp.Diagnostics, err, "CloudServer", serverID)
 		return
 	}
@@ -440,11 +445,25 @@ func (r *CloudServerResource) applyServerToState(
 			return
 		}
 	}
+	// Subnets are returned by the API via NetworkInterfaces[].Subnet — use the
+	// live value so drift is detected. Fall back to state only when the API
+	// returns nothing (e.g. immediately after create before the response hydrates).
+	subnetUriRefs := origNetwork.SubnetUriRefs
+	if apiSubnets := server.Subnets(); len(apiSubnets) > 0 {
+		vals := make([]attr.Value, len(apiSubnets))
+		for i, s := range apiSubnets {
+			vals[i] = types.StringValue(s)
+		}
+		if lv, d := types.ListValue(types.StringType, vals); !d.HasError() {
+			subnetUriRefs = lv
+		}
+	}
+
 	networkAttrs := map[string]attr.Value{
 		"vpc_uri_ref":            resolveAPIStringRef(server.VPC(), origNetwork.VpcUriRef),
-		"elastic_ip_uri_ref":     origNetwork.ElasticIpUriRef, // not in API response; preserve state
-		"subnet_uri_refs":        origNetwork.SubnetUriRefs,   // preserve state (API returns different format)
-		"securitygroup_uri_refs": origNetwork.SecurityGroupUriRefs,
+		"elastic_ip_uri_ref":     origNetwork.ElasticIpUriRef,     // not returned by API; preserve state
+		"subnet_uri_refs":        subnetUriRefs,
+		"securitygroup_uri_refs": origNetwork.SecurityGroupUriRefs, // not returned by API; preserve state
 	}
 	networkObj, d := types.ObjectValue(csNetworkAttrTypes(), networkAttrs)
 	diags.Append(d...)
@@ -646,7 +665,7 @@ func (r *CloudServerResource) Delete(ctx context.Context, req resource.DeleteReq
 		},
 		"CloudServer",
 		serverID,
-		r.client.ResourceTimeout,
+		effectiveTimeout(data.Timeout, r.client.ResourceTimeout),
 		deletionChecker,
 	)
 	if err != nil {
@@ -654,7 +673,7 @@ func (r *CloudServerResource) Delete(ctx context.Context, req resource.DeleteReq
 		return
 	}
 
-	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "CloudServer", serverID, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
+	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "CloudServer", serverID, remainingTimeout(deleteStart, effectiveTimeout(data.Timeout, r.client.ResourceTimeout))); waitErr != nil {
 		resp.Diagnostics.AddError("Error waiting for CloudServer deletion", waitErr.Error())
 		return
 	}

--- a/internal/provider/containerregistry_resource.go
+++ b/internal/provider/containerregistry_resource.go
@@ -30,6 +30,7 @@ type ContainerRegistryResourceModel struct {
 	Network       types.Object `tfsdk:"network"`
 	Storage       types.Object `tfsdk:"storage"`
 	Settings      types.Object `tfsdk:"settings"`
+	Timeout       types.String `tfsdk:"timeout"`
 }
 
 type ContainerRegistryNetworkModel struct {
@@ -150,6 +151,10 @@ func (r *ContainerRegistryResource) Schema(ctx context.Context, req resource.Sch
 						Optional:            true,
 					},
 				},
+			},
+			"timeout": schema.StringAttribute{
+				MarkdownDescription: "Per-resource timeout override (e.g. `\"15m\"`, `\"1h\"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.",
+				Optional:            true,
 			},
 		},
 	}
@@ -291,7 +296,7 @@ func (r *ContainerRegistryResource) Create(ctx context.Context, req resource.Cre
 		return
 	}
 
-	if waitErr := registry.WaitUntilReady(ctx, sdkWaitOptions(r.client.ResourceTimeout)...); waitErr != nil {
+	if waitErr := registry.WaitUntilReady(ctx, sdkWaitOptions(effectiveTimeout(data.Timeout, r.client.ResourceTimeout))...); waitErr != nil {
 		ReportWaitResult(&resp.Diagnostics, waitErr, "ContainerRegistry", data.Id.ValueString())
 		return
 	}
@@ -465,12 +470,12 @@ func (r *ContainerRegistryResource) Delete(ctx context.Context, req resource.Del
 	err := DeleteResourceWithRetry(ctx, func() error {
 		return CheckResponseErrAsError("delete", "ContainerRegistry",
 			r.client.Client.FromContainer().ContainerRegistry().Delete(ctx, ref))
-	}, "ContainerRegistry", registryID, r.client.ResourceTimeout, deletionChecker)
+	}, "ContainerRegistry", registryID, effectiveTimeout(data.Timeout, r.client.ResourceTimeout), deletionChecker)
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting ContainerRegistry", err.Error())
 		return
 	}
-	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "ContainerRegistry", registryID, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
+	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "ContainerRegistry", registryID, remainingTimeout(deleteStart, effectiveTimeout(data.Timeout, r.client.ResourceTimeout))); waitErr != nil {
 		resp.Diagnostics.AddError("Error waiting for ContainerRegistry deletion", waitErr.Error())
 		return
 	}

--- a/internal/provider/database_resource.go
+++ b/internal/provider/database_resource.go
@@ -21,6 +21,7 @@ type DatabaseResourceModel struct {
 	ProjectID types.String `tfsdk:"project_id"`
 	DBaaSID   types.String `tfsdk:"dbaas_id"`
 	Name      types.String `tfsdk:"name"`
+	Timeout   types.String `tfsdk:"timeout"`
 }
 
 type DatabaseResource struct {
@@ -68,6 +69,10 @@ func (r *DatabaseResource) Schema(ctx context.Context, req resource.SchemaReques
 				MarkdownDescription: "Display name for the database.",
 				Required:            true,
 			},
+			"timeout": schema.StringAttribute{
+				MarkdownDescription: "Per-resource timeout override (e.g. `\"15m\"`, `\"1h\"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.",
+				Optional:            true,
+			},
 		},
 	}
 }
@@ -113,7 +118,7 @@ func (r *DatabaseResource) Create(ctx context.Context, req resource.CreateReques
 				InDBaaS(aruba.URI(dbaasURI)),
 		)
 		return CheckResponseErrAsError("create", "Database", err)
-	}, "Database", data.Name.ValueString(), r.client.ResourceTimeout); createErr != nil {
+	}, "Database", data.Name.ValueString(), effectiveTimeout(data.Timeout, r.client.ResourceTimeout)); createErr != nil {
 		resp.Diagnostics.AddError("Error creating database", createErr.Error())
 		return
 	}
@@ -135,7 +140,7 @@ func (r *DatabaseResource) Create(ctx context.Context, req resource.CreateReques
 		}
 		return "Active", nil
 	}
-	if err := WaitForResourceActive(ctx, checker, "Database", data.Id.ValueString(), r.client.ResourceTimeout); err != nil {
+	if err := WaitForResourceActive(ctx, checker, "Database", data.Id.ValueString(), effectiveTimeout(data.Timeout, r.client.ResourceTimeout)); err != nil {
 		ReportWaitResult(&resp.Diagnostics, err, "Database", data.Id.ValueString())
 		return
 	}
@@ -233,12 +238,12 @@ func (r *DatabaseResource) Delete(ctx context.Context, req resource.DeleteReques
 	err := DeleteResourceWithRetry(ctx, func() error {
 		return CheckResponseErrAsError("delete", "Database",
 			r.client.Client.FromDatabase().Databases().Delete(ctx, ref))
-	}, "Database", databaseName, r.client.ResourceTimeout, deletionChecker)
+	}, "Database", databaseName, effectiveTimeout(data.Timeout, r.client.ResourceTimeout), deletionChecker)
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting database", err.Error())
 		return
 	}
-	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "Database", databaseName, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
+	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "Database", databaseName, remainingTimeout(deleteStart, effectiveTimeout(data.Timeout, r.client.ResourceTimeout))); waitErr != nil {
 		resp.Diagnostics.AddError("Error waiting for Database deletion", waitErr.Error())
 		return
 	}

--- a/internal/provider/databasebackup_resource.go
+++ b/internal/provider/databasebackup_resource.go
@@ -28,6 +28,7 @@ type DatabaseBackupResourceModel struct {
 	DBaaSID       types.String `tfsdk:"dbaas_id"`
 	Database      types.String `tfsdk:"database"`
 	BillingPeriod types.String `tfsdk:"billing_period"`
+	Timeout       types.String `tfsdk:"timeout"`
 }
 
 type DatabaseBackupResource struct {
@@ -96,6 +97,10 @@ func (r *DatabaseBackupResource) Schema(ctx context.Context, req resource.Schema
 				MarkdownDescription: "Billing cycle. Accepted values: `Hour`, `Month`, `Year`.",
 				Required:            true,
 				Validators:          []validator.String{stringvalidator.OneOf("Hour", "Month", "Year")},
+			},
+			"timeout": schema.StringAttribute{
+				MarkdownDescription: "Per-resource timeout override (e.g. `\"15m\"`, `\"1h\"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.",
+				Optional:            true,
 			},
 		},
 	}
@@ -167,7 +172,7 @@ func (r *DatabaseBackupResource) Create(ctx context.Context, req resource.Create
 		return
 	}
 
-	if waitErr := backup.WaitUntilReady(ctx, sdkWaitOptions(r.client.ResourceTimeout)...); waitErr != nil {
+	if waitErr := backup.WaitUntilReady(ctx, sdkWaitOptions(effectiveTimeout(data.Timeout, r.client.ResourceTimeout))...); waitErr != nil {
 		ReportWaitResult(&resp.Diagnostics, waitErr, "DatabaseBackup", data.Id.ValueString())
 		return
 	}
@@ -272,12 +277,12 @@ func (r *DatabaseBackupResource) Delete(ctx context.Context, req resource.Delete
 	err := DeleteResourceWithRetry(ctx, func() error {
 		return CheckResponseErrAsError("delete", "DatabaseBackup",
 			r.client.Client.FromDatabase().Backups().Delete(ctx, ref))
-	}, "DatabaseBackup", backupID, r.client.ResourceTimeout, deletionChecker)
+	}, "DatabaseBackup", backupID, effectiveTimeout(data.Timeout, r.client.ResourceTimeout), deletionChecker)
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting DatabaseBackup", err.Error())
 		return
 	}
-	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "DatabaseBackup", backupID, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
+	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "DatabaseBackup", backupID, remainingTimeout(deleteStart, effectiveTimeout(data.Timeout, r.client.ResourceTimeout))); waitErr != nil {
 		resp.Diagnostics.AddError("Error waiting for DatabaseBackup deletion", waitErr.Error())
 		return
 	}

--- a/internal/provider/databasegrant_resource.go
+++ b/internal/provider/databasegrant_resource.go
@@ -23,6 +23,7 @@ type DatabaseGrantResourceModel struct {
 	Database  types.String `tfsdk:"database"`
 	UserID    types.String `tfsdk:"user_id"`
 	Role      types.String `tfsdk:"role"`
+	Timeout   types.String `tfsdk:"timeout"`
 }
 
 type DatabaseGrantResource struct {
@@ -77,6 +78,10 @@ func (r *DatabaseGrantResource) Schema(ctx context.Context, req resource.SchemaR
 			"role": schema.StringAttribute{
 				MarkdownDescription: "Privilege level granted. Accepted values depend on the database engine (e.g., `ALL`, `READ`, `WRITE`).",
 				Required:            true,
+			},
+			"timeout": schema.StringAttribute{
+				MarkdownDescription: "Per-resource timeout override (e.g. `\"15m\"`, `\"1h\"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.",
+				Optional:            true,
 			},
 		},
 	}
@@ -239,12 +244,12 @@ func (r *DatabaseGrantResource) Delete(ctx context.Context, req resource.DeleteR
 	err := DeleteResourceWithRetry(ctx, func() error {
 		return CheckResponseErrAsError("delete", "DatabaseGrant",
 			r.client.Client.FromDatabase().Grants().Delete(ctx, ref))
-	}, "DatabaseGrant", grantID, r.client.ResourceTimeout, deletionChecker)
+	}, "DatabaseGrant", grantID, effectiveTimeout(data.Timeout, r.client.ResourceTimeout), deletionChecker)
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting DatabaseGrant", err.Error())
 		return
 	}
-	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "DatabaseGrant", grantID, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
+	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "DatabaseGrant", grantID, remainingTimeout(deleteStart, effectiveTimeout(data.Timeout, r.client.ResourceTimeout))); waitErr != nil {
 		resp.Diagnostics.AddError("Error waiting for DatabaseGrant deletion", waitErr.Error())
 		return
 	}

--- a/internal/provider/dbaas_resource.go
+++ b/internal/provider/dbaas_resource.go
@@ -31,6 +31,7 @@ type DBaaSResourceModel struct {
 	Storage       types.Object `tfsdk:"storage"`
 	Network       types.Object `tfsdk:"network"`
 	BillingPeriod types.String `tfsdk:"billing_period"`
+	Timeout       types.String `tfsdk:"timeout"`
 }
 
 type DBaaSResource struct {
@@ -165,6 +166,10 @@ func (r *DBaaSResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				MarkdownDescription: "Billing cycle. Accepted values: `Hour`, `Month`, `Year`.",
 				Optional:            true,
 				Validators:          []validator.String{stringvalidator.OneOf("Hour", "Month", "Year")},
+			},
+			"timeout": schema.StringAttribute{
+				MarkdownDescription: "Per-resource timeout override (e.g. `\"15m\"`, `\"1h\"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.",
+				Optional:            true,
 			},
 		},
 	}
@@ -333,7 +338,7 @@ func (r *DBaaSResource) Create(ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 
-	if waitErr := dbaas.WaitUntilReady(ctx, sdkWaitOptions(r.client.ResourceTimeout)...); waitErr != nil {
+	if waitErr := dbaas.WaitUntilReady(ctx, sdkWaitOptions(effectiveTimeout(data.Timeout, r.client.ResourceTimeout))...); waitErr != nil {
 		ReportWaitResult(&resp.Diagnostics, waitErr, "DBaaS", data.Id.ValueString())
 		return
 	}
@@ -567,12 +572,12 @@ func (r *DBaaSResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 	err := DeleteResourceWithRetry(ctx, func() error {
 		return CheckResponseErrAsError("delete", "DBaaS",
 			r.client.Client.FromDatabase().DBaaS().Delete(ctx, ref))
-	}, "DBaaS", dbaasID, r.client.ResourceTimeout, deletionChecker)
+	}, "DBaaS", dbaasID, effectiveTimeout(data.Timeout, r.client.ResourceTimeout), deletionChecker)
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting DBaaS", err.Error())
 		return
 	}
-	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "DBaaS", dbaasID, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
+	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "DBaaS", dbaasID, remainingTimeout(deleteStart, effectiveTimeout(data.Timeout, r.client.ResourceTimeout))); waitErr != nil {
 		resp.Diagnostics.AddError("Error waiting for DBaaS deletion", waitErr.Error())
 		return
 	}

--- a/internal/provider/dbaasuser_resource.go
+++ b/internal/provider/dbaasuser_resource.go
@@ -23,6 +23,7 @@ type DBaaSUserResourceModel struct {
 	DBaaSID   types.String `tfsdk:"dbaas_id"`
 	Username  types.String `tfsdk:"username"`
 	Password  types.String `tfsdk:"password"`
+	Timeout   types.String `tfsdk:"timeout"`
 }
 
 type DBaaSUserResource struct {
@@ -75,6 +76,10 @@ func (r *DBaaSUserResource) Schema(ctx context.Context, req resource.SchemaReque
 				Required:            true,
 				Sensitive:           true,
 			},
+			"timeout": schema.StringAttribute{
+				MarkdownDescription: "Per-resource timeout override (e.g. `\"15m\"`, `\"1h\"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.",
+				Optional:            true,
+			},
 		},
 	}
 }
@@ -124,7 +129,7 @@ func (r *DBaaSUserResource) Create(ctx context.Context, req resource.CreateReque
 				InDBaaS(aruba.URI(dbaasURI)),
 		)
 		return CheckResponseErrAsError("create", "DBaaSUser", err)
-	}, "DBaaSUser", username, r.client.ResourceTimeout); createErr != nil {
+	}, "DBaaSUser", username, effectiveTimeout(data.Timeout, r.client.ResourceTimeout)); createErr != nil {
 		resp.Diagnostics.AddError("Error creating DBaaS user", createErr.Error())
 		return
 	}
@@ -145,7 +150,7 @@ func (r *DBaaSUserResource) Create(ctx context.Context, req resource.CreateReque
 		}
 		return "Active", nil
 	}
-	if err := WaitForResourceActive(ctx, checker, "DBaaSUser", username, r.client.ResourceTimeout); err != nil {
+	if err := WaitForResourceActive(ctx, checker, "DBaaSUser", username, effectiveTimeout(data.Timeout, r.client.ResourceTimeout)); err != nil {
 		ReportWaitResult(&resp.Diagnostics, err, "DBaaSUser", username)
 		return
 	}
@@ -246,12 +251,12 @@ func (r *DBaaSUserResource) Delete(ctx context.Context, req resource.DeleteReque
 	err := DeleteResourceWithRetry(ctx, func() error {
 		return CheckResponseErrAsError("delete", "DBaaSUser",
 			r.client.Client.FromDatabase().Users().Delete(ctx, ref))
-	}, "DBaaSUser", username, r.client.ResourceTimeout, deletionChecker)
+	}, "DBaaSUser", username, effectiveTimeout(data.Timeout, r.client.ResourceTimeout), deletionChecker)
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting DBaaS user", err.Error())
 		return
 	}
-	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "DBaaSUser", username, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
+	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "DBaaSUser", username, remainingTimeout(deleteStart, effectiveTimeout(data.Timeout, r.client.ResourceTimeout))); waitErr != nil {
 		resp.Diagnostics.AddError("Error waiting for DBaaSUser deletion", waitErr.Error())
 		return
 	}

--- a/internal/provider/elasticip_resource.go
+++ b/internal/provider/elasticip_resource.go
@@ -37,6 +37,7 @@ type ElasticIPResourceModel struct {
 	BillingPeriod types.String `tfsdk:"billing_period"`
 	Address       types.String `tfsdk:"address"`
 	ProjectId     types.String `tfsdk:"project_id"`
+	Timeout       types.String `tfsdk:"timeout"`
 }
 
 func (r *ElasticIPResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -85,6 +86,10 @@ func (r *ElasticIPResource) Schema(ctx context.Context, req resource.SchemaReque
 				MarkdownDescription: "ID of the project that owns this resource. Changing this value forces a new resource.",
 				Required:            true,
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			},
+			"timeout": schema.StringAttribute{
+				MarkdownDescription: "Per-resource timeout override (e.g. `\"15m\"`, `\"1h\"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.",
+				Optional:            true,
 			},
 		},
 	}
@@ -140,7 +145,7 @@ func (r *ElasticIPResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	if waitErr := eip.WaitUntilReady(ctx, sdkWaitOptions(r.client.ResourceTimeout)...); waitErr != nil {
+	if waitErr := eip.WaitUntilReady(ctx, sdkWaitOptions(effectiveTimeout(data.Timeout, r.client.ResourceTimeout))...); waitErr != nil {
 		ReportWaitResult(&resp.Diagnostics, waitErr, "ElasticIP", data.Id.ValueString())
 		return
 	}
@@ -290,12 +295,12 @@ func (r *ElasticIPResource) Delete(ctx context.Context, req resource.DeleteReque
 	err := DeleteResourceWithRetry(ctx, func() error {
 		delErr := r.client.Client.FromNetwork().ElasticIPs().Delete(ctx, ref)
 		return CheckResponseErrAsError("delete", "ElasticIP", delErr)
-	}, "ElasticIP", eipID, r.client.ResourceTimeout, deletionChecker)
+	}, "ElasticIP", eipID, effectiveTimeout(data.Timeout, r.client.ResourceTimeout), deletionChecker)
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting ElasticIP", err.Error())
 		return
 	}
-	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "ElasticIP", eipID, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
+	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "ElasticIP", eipID, remainingTimeout(deleteStart, effectiveTimeout(data.Timeout, r.client.ResourceTimeout))); waitErr != nil {
 		resp.Diagnostics.AddError("Error waiting for ElasticIP deletion", waitErr.Error())
 		return
 	}

--- a/internal/provider/kaas_resource.go
+++ b/internal/provider/kaas_resource.go
@@ -43,6 +43,7 @@ type KaaSResourceModel struct {
 	Kubeconfig    types.String `tfsdk:"kubeconfig"`
 	Network       types.Object `tfsdk:"network"`
 	Settings      types.Object `tfsdk:"settings"`
+	Timeout       types.String `tfsdk:"timeout"`
 }
 
 type KaaSNodeCIDRModel struct {
@@ -162,6 +163,10 @@ func (r *KaaSResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 						Optional:            true,
 					},
 				},
+			},
+			"timeout": schema.StringAttribute{
+				MarkdownDescription: "Per-resource timeout override (e.g. `\"15m\"`, `\"1h\"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.",
+				Optional:            true,
 			},
 			"settings": schema.SingleNestedAttribute{
 				MarkdownDescription: "Kubernetes version and node-pool configuration.",
@@ -467,7 +472,7 @@ func (r *KaaSResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
-	if waitErr := kaas.WaitUntilReady(ctx, sdkWaitOptions(r.client.ResourceTimeout)...); waitErr != nil {
+	if waitErr := kaas.WaitUntilReady(ctx, sdkWaitOptions(effectiveTimeout(data.Timeout, r.client.ResourceTimeout))...); waitErr != nil {
 		ReportWaitResult(&resp.Diagnostics, waitErr, "KaaS", data.Id.ValueString())
 		data.Kubeconfig = types.StringNull()
 		data.ManagementIP = types.StringNull()
@@ -806,12 +811,12 @@ func (r *KaaSResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 	err := DeleteResourceWithRetry(ctx, func() error {
 		return CheckResponseErrAsError("delete", "KaaS",
 			r.client.Client.FromContainer().KaaS().Delete(ctx, ref))
-	}, "KaaS", kaasID, r.client.ResourceTimeout, deletionChecker)
+	}, "KaaS", kaasID, effectiveTimeout(data.Timeout, r.client.ResourceTimeout), deletionChecker)
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting KaaS cluster", err.Error())
 		return
 	}
-	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "KaaS", kaasID, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
+	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "KaaS", kaasID, remainingTimeout(deleteStart, effectiveTimeout(data.Timeout, r.client.ResourceTimeout))); waitErr != nil {
 		resp.Diagnostics.AddError("Error waiting for KaaS cluster deletion", waitErr.Error())
 		return
 	}

--- a/internal/provider/kaas_resource.go
+++ b/internal/provider/kaas_resource.go
@@ -121,7 +121,7 @@ func (r *KaaSResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				Computed:            true,
 			},
 			"kubeconfig": schema.StringAttribute{
-				MarkdownDescription: "Computed by the API. Kubeconfig YAML for kubectl access, downloaded when the cluster is active. Write-only — this value is sent to the API but is not returned in subsequent read responses.",
+				MarkdownDescription: "Kubeconfig YAML for `kubectl` access. Populated automatically when the cluster becomes active. Sensitive — stored in Terraform state but redacted from plan output.",
 				Computed:            true,
 				Sensitive:           true,
 			},

--- a/internal/provider/keypair_resource.go
+++ b/internal/provider/keypair_resource.go
@@ -23,6 +23,7 @@ type KeypairResourceModel struct {
 	ProjectID types.String `tfsdk:"project_id"`
 	Value     types.String `tfsdk:"value"`
 	Tags      types.List   `tfsdk:"tags"`
+	Timeout   types.String `tfsdk:"timeout"`
 }
 
 type KeypairResource struct {
@@ -78,6 +79,10 @@ func (r *KeypairResource) Schema(ctx context.Context, req resource.SchemaRequest
 			"tags": schema.ListAttribute{
 				ElementType:         types.StringType,
 				MarkdownDescription: "List of string tags attached to the resource for filtering and organisation.",
+				Optional:            true,
+			},
+			"timeout": schema.StringAttribute{
+				MarkdownDescription: "Per-resource timeout override (e.g. `\"15m\"`, `\"1h\"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.",
 				Optional:            true,
 			},
 		},
@@ -140,7 +145,7 @@ func (r *KeypairResource) Create(ctx context.Context, req resource.CreateRequest
 	keypairID := data.Id.ValueString()
 
 	// KeyPairs may go through a short provisioning phase; wait until ready.
-	if err := kp.WaitUntilReady(ctx, sdkWaitOptions(r.client.ResourceTimeout)...); err != nil {
+	if err := kp.WaitUntilReady(ctx, sdkWaitOptions(effectiveTimeout(data.Timeout, r.client.ResourceTimeout))...); err != nil {
 		ReportWaitResult(&resp.Diagnostics, err, "Keypair", keypairID)
 		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 		return
@@ -306,7 +311,7 @@ func (r *KeypairResource) Delete(ctx context.Context, req resource.DeleteRequest
 		},
 		"Keypair",
 		keypairID,
-		r.client.ResourceTimeout,
+		effectiveTimeout(data.Timeout, r.client.ResourceTimeout),
 		deletionChecker,
 	)
 	if err != nil {
@@ -314,7 +319,7 @@ func (r *KeypairResource) Delete(ctx context.Context, req resource.DeleteRequest
 		return
 	}
 
-	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "Keypair", keypairID, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
+	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "Keypair", keypairID, remainingTimeout(deleteStart, effectiveTimeout(data.Timeout, r.client.ResourceTimeout))); waitErr != nil {
 		resp.Diagnostics.AddError("Error waiting for Keypair deletion", waitErr.Error())
 		return
 	}

--- a/internal/provider/kms_resource.go
+++ b/internal/provider/kms_resource.go
@@ -25,6 +25,7 @@ type KMSResourceModel struct {
 	Location      types.String `tfsdk:"location"`
 	Tags          types.List   `tfsdk:"tags"`
 	BillingPeriod types.String `tfsdk:"billing_period"`
+	Timeout       types.String `tfsdk:"timeout"`
 }
 
 type KMSResource struct {
@@ -81,6 +82,10 @@ func (r *KMSResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 				Validators:          []validator.String{stringvalidator.OneOf("Hour", "Month", "Year")},
 				Computed:            true,
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"timeout": schema.StringAttribute{
+				MarkdownDescription: "Per-resource timeout override (e.g. `\"15m\"`, `\"1h\"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.",
+				Optional:            true,
 			},
 		},
 	}
@@ -169,7 +174,7 @@ func (r *KMSResource) Create(ctx context.Context, req resource.CreateRequest, re
 		return
 	}
 
-	if waitErr := kms.WaitUntilReady(ctx, sdkWaitOptions(r.client.ResourceTimeout)...); waitErr != nil {
+	if waitErr := kms.WaitUntilReady(ctx, sdkWaitOptions(effectiveTimeout(data.Timeout, r.client.ResourceTimeout))...); waitErr != nil {
 		ReportWaitResult(&resp.Diagnostics, waitErr, "KMS", data.Id.ValueString())
 		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 		return
@@ -301,12 +306,12 @@ func (r *KMSResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 	err := DeleteResourceWithRetry(ctx, func() error {
 		return CheckResponseErrAsError("delete", "KMS",
 			r.client.Client.FromSecurity().KMS().Delete(ctx, ref))
-	}, "KMS", kmsID, r.client.ResourceTimeout, deletionChecker)
+	}, "KMS", kmsID, effectiveTimeout(data.Timeout, r.client.ResourceTimeout), deletionChecker)
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting KMS", err.Error())
 		return
 	}
-	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "KMS", kmsID, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
+	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "KMS", kmsID, remainingTimeout(deleteStart, effectiveTimeout(data.Timeout, r.client.ResourceTimeout))); waitErr != nil {
 		resp.Diagnostics.AddError("Error waiting for KMS deletion", waitErr.Error())
 		return
 	}

--- a/internal/provider/project_resource.go
+++ b/internal/provider/project_resource.go
@@ -31,6 +31,7 @@ type ProjectResourceModel struct {
 	Description types.String `tfsdk:"description"`
 	Tags        types.List   `tfsdk:"tags"`
 	Id          types.String `tfsdk:"id"`
+	Timeout     types.String `tfsdk:"timeout"`
 }
 
 func (r *ProjectResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -58,6 +59,10 @@ func (r *ProjectResource) Schema(ctx context.Context, req resource.SchemaRequest
 				MarkdownDescription: "Computed by the API. Unique identifier for the resource.",
 				Computed:            true,
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"timeout": schema.StringAttribute{
+				MarkdownDescription: "Per-resource timeout override (e.g. `\"15m\"`, `\"1h\"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.",
+				Optional:            true,
 			},
 		},
 	}
@@ -229,13 +234,13 @@ func (r *ProjectResource) Delete(ctx context.Context, req resource.DeleteRequest
 	err := DeleteResourceWithRetry(ctx, func() error {
 		return CheckResponseErrAsError("delete", "Project",
 			r.client.Client.FromProject().Delete(ctx, ref))
-	}, "Project", projectID, r.client.ResourceTimeout, deletionChecker)
+	}, "Project", projectID, effectiveTimeout(data.Timeout, r.client.ResourceTimeout), deletionChecker)
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting project", err.Error())
 		return
 	}
 
-	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "Project", projectID, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
+	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "Project", projectID, remainingTimeout(deleteStart, effectiveTimeout(data.Timeout, r.client.ResourceTimeout))); waitErr != nil {
 		resp.Diagnostics.AddError("Error waiting for Project deletion", waitErr.Error())
 		return
 	}

--- a/internal/provider/provider_helpers.go
+++ b/internal/provider/provider_helpers.go
@@ -1,0 +1,20 @@
+package provider
+
+import (
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// effectiveTimeout returns the resource-level timeout if set and valid,
+// otherwise falls back to the provider-level timeout.
+func effectiveTimeout(resourceTimeout types.String, providerTimeout time.Duration) time.Duration {
+	if resourceTimeout.IsNull() || resourceTimeout.IsUnknown() || resourceTimeout.ValueString() == "" {
+		return providerTimeout
+	}
+	d, err := time.ParseDuration(resourceTimeout.ValueString())
+	if err != nil || d <= 0 {
+		return providerTimeout
+	}
+	return d
+}

--- a/internal/provider/restore_resource.go
+++ b/internal/provider/restore_resource.go
@@ -24,6 +24,7 @@ type RestoreResourceModel struct {
 	ProjectID types.String `tfsdk:"project_id"`
 	BackupID  types.String `tfsdk:"backup_id"`
 	VolumeID  types.String `tfsdk:"volume_id"`
+	Timeout   types.String `tfsdk:"timeout"`
 }
 
 type RestoreResource struct {
@@ -95,6 +96,10 @@ func (r *RestoreResource) Schema(ctx context.Context, req resource.SchemaRequest
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
+			},
+			"timeout": schema.StringAttribute{
+				MarkdownDescription: "Per-resource timeout override (e.g. `\"15m\"`, `\"1h\"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.",
+				Optional:            true,
 			},
 		},
 	}
@@ -174,7 +179,7 @@ func (r *RestoreResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
-	if waitErr := restore.WaitUntilReady(ctx, sdkWaitOptions(r.client.ResourceTimeout)...); waitErr != nil {
+	if waitErr := restore.WaitUntilReady(ctx, sdkWaitOptions(effectiveTimeout(data.Timeout, r.client.ResourceTimeout))...); waitErr != nil {
 		ReportWaitResult(&resp.Diagnostics, waitErr, "Restore", data.Id.ValueString())
 		return
 	}
@@ -321,12 +326,12 @@ func (r *RestoreResource) Delete(ctx context.Context, req resource.DeleteRequest
 	err := DeleteResourceWithRetry(ctx, func() error {
 		return CheckResponseErrAsError("delete", "Restore",
 			r.client.Client.FromStorage().Restores().Delete(ctx, ref))
-	}, "Restore", restoreID, r.client.ResourceTimeout, deletionChecker)
+	}, "Restore", restoreID, effectiveTimeout(data.Timeout, r.client.ResourceTimeout), deletionChecker)
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting Restore", err.Error())
 		return
 	}
-	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "Restore", restoreID, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
+	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "Restore", restoreID, remainingTimeout(deleteStart, effectiveTimeout(data.Timeout, r.client.ResourceTimeout))); waitErr != nil {
 		resp.Diagnostics.AddError("Error waiting for Restore deletion", waitErr.Error())
 		return
 	}

--- a/internal/provider/schedulejob_resource.go
+++ b/internal/provider/schedulejob_resource.go
@@ -25,6 +25,7 @@ type ScheduleJobResourceModel struct {
 	Tags       types.List   `tfsdk:"tags"`
 	Location   types.String `tfsdk:"location"`
 	Properties types.Object `tfsdk:"properties"`
+	Timeout    types.String `tfsdk:"timeout"`
 }
 
 type ScheduleJobResource struct {
@@ -76,6 +77,10 @@ func (r *ScheduleJobResource) Schema(ctx context.Context, req resource.SchemaReq
 			"location": schema.StringAttribute{
 				MarkdownDescription: "Region identifier (e.g., `ITBG-Bergamo`). See the [available locations and zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center).",
 				Required:            true,
+			},
+			"timeout": schema.StringAttribute{
+				MarkdownDescription: "Per-resource timeout override (e.g. `\"15m\"`, `\"1h\"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.",
+				Optional:            true,
 			},
 			"properties": schema.SingleNestedAttribute{
 				MarkdownDescription: "Job scheduling and execution configuration.",
@@ -446,7 +451,7 @@ func (r *ScheduleJobResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	if waitErr := job.WaitUntilReady(ctx, sdkWaitOptions(r.client.ResourceTimeout)...); waitErr != nil {
+	if waitErr := job.WaitUntilReady(ctx, sdkWaitOptions(effectiveTimeout(data.Timeout, r.client.ResourceTimeout))...); waitErr != nil {
 		ReportWaitResult(&resp.Diagnostics, waitErr, "ScheduleJob", data.Id.ValueString())
 		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 		return
@@ -599,13 +604,13 @@ func (r *ScheduleJobResource) Delete(ctx context.Context, req resource.DeleteReq
 	err := DeleteResourceWithRetry(ctx, func() error {
 		return CheckResponseErrAsError("delete", "ScheduleJob",
 			r.client.Client.FromSchedule().Jobs().Delete(ctx, ref))
-	}, "ScheduleJob", jobID, r.client.ResourceTimeout, deletionChecker)
+	}, "ScheduleJob", jobID, effectiveTimeout(data.Timeout, r.client.ResourceTimeout), deletionChecker)
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting schedule job", err.Error())
 		return
 	}
 
-	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "ScheduleJob", jobID, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
+	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "ScheduleJob", jobID, remainingTimeout(deleteStart, effectiveTimeout(data.Timeout, r.client.ResourceTimeout))); waitErr != nil {
 		if IsWaitTimeout(waitErr) {
 			resp.Diagnostics.AddWarning(
 				"ScheduleJob Deletion Pending",

--- a/internal/provider/securitygroup_resource.go
+++ b/internal/provider/securitygroup_resource.go
@@ -34,6 +34,7 @@ type SecurityGroupResourceModel struct {
 	Tags      types.List   `tfsdk:"tags"`
 	ProjectId types.String `tfsdk:"project_id"`
 	VpcId     types.String `tfsdk:"vpc_id"`
+	Timeout   types.String `tfsdk:"timeout"`
 }
 
 func (r *SecurityGroupResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -87,6 +88,10 @@ func (r *SecurityGroupResource) Schema(ctx context.Context, req resource.SchemaR
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
+			},
+			"timeout": schema.StringAttribute{
+				MarkdownDescription: "Per-resource timeout override (e.g. `\"15m\"`, `\"1h\"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.",
+				Optional:            true,
 			},
 		},
 	}
@@ -161,7 +166,7 @@ func (r *SecurityGroupResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
-	if waitErr := sg.WaitUntilReady(ctx, sdkWaitOptions(r.client.ResourceTimeout)...); waitErr != nil {
+	if waitErr := sg.WaitUntilReady(ctx, sdkWaitOptions(effectiveTimeout(data.Timeout, r.client.ResourceTimeout))...); waitErr != nil {
 		ReportWaitResult(&resp.Diagnostics, waitErr, "SecurityGroup", data.Id.ValueString())
 		return
 	}
@@ -295,12 +300,12 @@ func (r *SecurityGroupResource) Delete(ctx context.Context, req resource.DeleteR
 	err := DeleteResourceWithRetry(ctx, func() error {
 		return CheckResponseErrAsError("delete", "SecurityGroup",
 			r.client.Client.FromNetwork().SecurityGroups().Delete(ctx, ref))
-	}, "SecurityGroup", sgID, r.client.ResourceTimeout, deletionChecker)
+	}, "SecurityGroup", sgID, effectiveTimeout(data.Timeout, r.client.ResourceTimeout), deletionChecker)
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting SecurityGroup", err.Error())
 		return
 	}
-	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "SecurityGroup", sgID, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
+	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "SecurityGroup", sgID, remainingTimeout(deleteStart, effectiveTimeout(data.Timeout, r.client.ResourceTimeout))); waitErr != nil {
 		resp.Diagnostics.AddError("Error waiting for SecurityGroup deletion", waitErr.Error())
 		return
 	}

--- a/internal/provider/securityrule_resource.go
+++ b/internal/provider/securityrule_resource.go
@@ -89,6 +89,7 @@ type SecurityRuleResourceModel struct {
 	VpcId           types.String `tfsdk:"vpc_id"`
 	SecurityGroupId types.String `tfsdk:"security_group_id"`
 	Properties      types.Object `tfsdk:"properties"`
+	Timeout         types.String `tfsdk:"timeout"`
 }
 
 var _ resource.Resource = &SecurityRuleResource{}
@@ -155,6 +156,10 @@ func (r *SecurityRuleResource) Schema(ctx context.Context, req resource.SchemaRe
 			"tags": schema.ListAttribute{
 				ElementType:         types.StringType,
 				MarkdownDescription: "List of string tags attached to the resource for filtering and organisation.",
+				Optional:            true,
+			},
+			"timeout": schema.StringAttribute{
+				MarkdownDescription: "Per-resource timeout override (e.g. `\"15m\"`, `\"1h\"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.",
 				Optional:            true,
 			},
 			"properties": schema.SingleNestedAttribute{
@@ -418,7 +423,7 @@ func (r *SecurityRuleResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
-	if waitErr := rule.WaitUntilReady(ctx, sdkWaitOptions(r.client.ResourceTimeout)...); waitErr != nil {
+	if waitErr := rule.WaitUntilReady(ctx, sdkWaitOptions(effectiveTimeout(data.Timeout, r.client.ResourceTimeout))...); waitErr != nil {
 		ReportWaitResult(&resp.Diagnostics, waitErr, "SecurityRule", data.Id.ValueString())
 		return
 	}
@@ -558,12 +563,12 @@ func (r *SecurityRuleResource) Delete(ctx context.Context, req resource.DeleteRe
 	err := DeleteResourceWithRetry(ctx, func() error {
 		return CheckResponseErrAsError("delete", "SecurityRule",
 			r.client.Client.FromNetwork().SecurityGroupRules().Delete(ctx, ref))
-	}, "SecurityRule", ruleID, r.client.ResourceTimeout, deletionChecker)
+	}, "SecurityRule", ruleID, effectiveTimeout(data.Timeout, r.client.ResourceTimeout), deletionChecker)
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting SecurityRule", err.Error())
 		return
 	}
-	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "SecurityRule", ruleID, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
+	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "SecurityRule", ruleID, remainingTimeout(deleteStart, effectiveTimeout(data.Timeout, r.client.ResourceTimeout))); waitErr != nil {
 		resp.Diagnostics.AddError("Error waiting for SecurityRule deletion", waitErr.Error())
 		return
 	}

--- a/internal/provider/snapshot_resource.go
+++ b/internal/provider/snapshot_resource.go
@@ -34,6 +34,7 @@ type SnapshotResourceModel struct {
 	BillingPeriod types.String `tfsdk:"billing_period"`
 	VolumeUri     types.String `tfsdk:"volume_uri"`
 	Tags          types.List   `tfsdk:"tags"`
+	Timeout       types.String `tfsdk:"timeout"`
 }
 
 type SnapshotResource struct {
@@ -97,6 +98,10 @@ func (r *SnapshotResource) Schema(ctx context.Context, req resource.SchemaReques
 			"tags": schema.ListAttribute{
 				ElementType:         types.StringType,
 				MarkdownDescription: "List of string tags attached to the resource for filtering and organisation.",
+				Optional:            true,
+			},
+			"timeout": schema.StringAttribute{
+				MarkdownDescription: "Per-resource timeout override (e.g. `\"15m\"`, `\"1h\"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.",
 				Optional:            true,
 			},
 		},
@@ -166,7 +171,7 @@ func (r *SnapshotResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
-	if waitErr := snap.WaitUntilReady(ctx, sdkWaitOptions(r.client.ResourceTimeout)...); waitErr != nil {
+	if waitErr := snap.WaitUntilReady(ctx, sdkWaitOptions(effectiveTimeout(data.Timeout, r.client.ResourceTimeout))...); waitErr != nil {
 		ReportWaitResult(&resp.Diagnostics, waitErr, "Snapshot", data.Id.ValueString())
 		return
 	}
@@ -338,12 +343,12 @@ func (r *SnapshotResource) Delete(ctx context.Context, req resource.DeleteReques
 	err := DeleteResourceWithRetry(ctx, func() error {
 		return CheckResponseErrAsError("delete", "Snapshot",
 			r.client.Client.FromStorage().Snapshots().Delete(ctx, ref))
-	}, "Snapshot", snapshotID, r.client.ResourceTimeout, deletionChecker)
+	}, "Snapshot", snapshotID, effectiveTimeout(data.Timeout, r.client.ResourceTimeout), deletionChecker)
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting Snapshot", err.Error())
 		return
 	}
-	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "Snapshot", snapshotID, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
+	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "Snapshot", snapshotID, remainingTimeout(deleteStart, effectiveTimeout(data.Timeout, r.client.ResourceTimeout))); waitErr != nil {
 		resp.Diagnostics.AddError("Error waiting for Snapshot deletion", waitErr.Error())
 		return
 	}

--- a/internal/provider/subnet_resource.go
+++ b/internal/provider/subnet_resource.go
@@ -43,6 +43,7 @@ type SubnetResourceModel struct {
 	VpcId     types.String `tfsdk:"vpc_id"`
 	Type      types.String `tfsdk:"type"`
 	Network   types.Object `tfsdk:"network"`
+	Timeout   types.String `tfsdk:"timeout"`
 }
 
 type NetworkModel struct {
@@ -128,6 +129,10 @@ func (r *SubnetResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
+			},
+			"timeout": schema.StringAttribute{
+				MarkdownDescription: "Per-resource timeout override (e.g. `\"15m\"`, `\"1h\"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.",
+				Optional:            true,
 			},
 			"network": schema.SingleNestedAttribute{
 				MarkdownDescription: "Network configuration block. Required when `type` is `Advanced`.",
@@ -534,7 +539,7 @@ func (r *SubnetResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	if waitErr := subnet.WaitUntilReady(ctx, sdkWaitOptions(r.client.ResourceTimeout)...); waitErr != nil {
+	if waitErr := subnet.WaitUntilReady(ctx, sdkWaitOptions(effectiveTimeout(data.Timeout, r.client.ResourceTimeout))...); waitErr != nil {
 		ReportWaitResult(&resp.Diagnostics, waitErr, "Subnet", data.Id.ValueString())
 		return
 	}
@@ -706,12 +711,12 @@ func (r *SubnetResource) Delete(ctx context.Context, req resource.DeleteRequest,
 	err := DeleteResourceWithRetry(ctx, func() error {
 		return CheckResponseErrAsError("delete", "Subnet",
 			r.client.Client.FromNetwork().Subnets().Delete(ctx, ref))
-	}, "Subnet", subnetID, r.client.ResourceTimeout, deletionChecker)
+	}, "Subnet", subnetID, effectiveTimeout(data.Timeout, r.client.ResourceTimeout), deletionChecker)
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting Subnet", err.Error())
 		return
 	}
-	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "Subnet", subnetID, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
+	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "Subnet", subnetID, remainingTimeout(deleteStart, effectiveTimeout(data.Timeout, r.client.ResourceTimeout))); waitErr != nil {
 		resp.Diagnostics.AddError("Error waiting for Subnet deletion", waitErr.Error())
 		return
 	}

--- a/internal/provider/vpc_resource.go
+++ b/internal/provider/vpc_resource.go
@@ -26,6 +26,7 @@ type VPCResourceModel struct {
 	Location  types.String `tfsdk:"location"`
 	ProjectID types.String `tfsdk:"project_id"`
 	Tags      types.List   `tfsdk:"tags"`
+	Timeout   types.String `tfsdk:"timeout"`
 }
 
 var _ resource.Resource = &VPCResource{}
@@ -70,6 +71,10 @@ func (r *VPCResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 			"tags": schema.ListAttribute{
 				ElementType:         types.StringType,
 				MarkdownDescription: "List of string tags attached to the resource for filtering and organisation.",
+				Optional:            true,
+			},
+			"timeout": schema.StringAttribute{
+				MarkdownDescription: "Per-resource timeout override (e.g. `\"15m\"`, `\"1h\"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.",
 				Optional:            true,
 			},
 		},
@@ -124,7 +129,7 @@ func (r *VPCResource) Create(ctx context.Context, req resource.CreateRequest, re
 		return
 	}
 
-	if waitErr := vpc.WaitUntilReady(ctx, sdkWaitOptions(r.client.ResourceTimeout)...); waitErr != nil {
+	if waitErr := vpc.WaitUntilReady(ctx, sdkWaitOptions(effectiveTimeout(data.Timeout, r.client.ResourceTimeout))...); waitErr != nil {
 		ReportWaitResult(&resp.Diagnostics, waitErr, "VPC", data.Id.ValueString())
 		return
 	}
@@ -275,12 +280,12 @@ func (r *VPCResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 	err := DeleteResourceWithRetry(ctx, func() error {
 		delErr := r.client.Client.FromNetwork().VPCs().Delete(ctx, ref)
 		return CheckResponseErrAsError("delete", "VPC", delErr)
-	}, "VPC", vpcID, r.client.ResourceTimeout, deletionChecker)
+	}, "VPC", vpcID, effectiveTimeout(data.Timeout, r.client.ResourceTimeout), deletionChecker)
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting VPC", err.Error())
 		return
 	}
-	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "VPC", vpcID, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
+	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "VPC", vpcID, remainingTimeout(deleteStart, effectiveTimeout(data.Timeout, r.client.ResourceTimeout))); waitErr != nil {
 		resp.Diagnostics.AddError("Error waiting for VPC deletion", waitErr.Error())
 		return
 	}

--- a/internal/provider/vpcpeering_resource.go
+++ b/internal/provider/vpcpeering_resource.go
@@ -36,6 +36,7 @@ type VpcPeeringResourceModel struct {
 	ProjectId types.String `tfsdk:"project_id"`
 	VpcId     types.String `tfsdk:"vpc_id"`
 	PeerVpc   types.String `tfsdk:"peer_vpc"`
+	Timeout   types.String `tfsdk:"timeout"`
 }
 
 func (r *VpcPeeringResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -84,6 +85,10 @@ func (r *VpcPeeringResource) Schema(ctx context.Context, req resource.SchemaRequ
 			"peer_vpc": schema.StringAttribute{
 				MarkdownDescription: "ID or URI of the remote peer VPC to connect to.",
 				Required:            true,
+			},
+			"timeout": schema.StringAttribute{
+				MarkdownDescription: "Per-resource timeout override (e.g. `\"15m\"`, `\"1h\"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.",
+				Optional:            true,
 			},
 		},
 	}
@@ -168,7 +173,7 @@ func (r *VpcPeeringResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	if waitErr := peering.WaitUntilReady(ctx, sdkWaitOptions(r.client.ResourceTimeout)...); waitErr != nil {
+	if waitErr := peering.WaitUntilReady(ctx, sdkWaitOptions(effectiveTimeout(data.Timeout, r.client.ResourceTimeout))...); waitErr != nil {
 		ReportWaitResult(&resp.Diagnostics, waitErr, "VPCPeering", data.Id.ValueString())
 		return
 	}
@@ -309,12 +314,12 @@ func (r *VpcPeeringResource) Delete(ctx context.Context, req resource.DeleteRequ
 	err := DeleteResourceWithRetry(ctx, func() error {
 		return CheckResponseErrAsError("delete", "VPCPeering",
 			r.client.Client.FromNetwork().VPCPeerings().Delete(ctx, ref))
-	}, "VPCPeering", peeringID, r.client.ResourceTimeout, deletionChecker)
+	}, "VPCPeering", peeringID, effectiveTimeout(data.Timeout, r.client.ResourceTimeout), deletionChecker)
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting VPCPeering", err.Error())
 		return
 	}
-	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "VPCPeering", peeringID, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
+	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "VPCPeering", peeringID, remainingTimeout(deleteStart, effectiveTimeout(data.Timeout, r.client.ResourceTimeout))); waitErr != nil {
 		resp.Diagnostics.AddError("Error waiting for VPCPeering deletion", waitErr.Error())
 		return
 	}

--- a/internal/provider/vpcpeeringroute_resource.go
+++ b/internal/provider/vpcpeeringroute_resource.go
@@ -39,6 +39,7 @@ type VpcPeeringRouteResourceModel struct {
 	LocalNetworkAddress  types.String `tfsdk:"local_network_address"`
 	RemoteNetworkAddress types.String `tfsdk:"remote_network_address"`
 	BillingPeriod        types.String `tfsdk:"billing_period"`
+	Timeout              types.String `tfsdk:"timeout"`
 }
 
 func (r *VpcPeeringRouteResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -96,6 +97,10 @@ func (r *VpcPeeringRouteResource) Schema(ctx context.Context, req resource.Schem
 				MarkdownDescription: "Billing cycle for the resource. Accepted values: `Hour`, `Month`, `Year`.",
 				Required:            true,
 				Validators:          []validator.String{stringvalidator.OneOf("Hour", "Month", "Year")},
+			},
+			"timeout": schema.StringAttribute{
+				MarkdownDescription: "Per-resource timeout override (e.g. `\"15m\"`, `\"1h\"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.",
+				Optional:            true,
 			},
 		},
 	}
@@ -185,7 +190,7 @@ func (r *VpcPeeringRouteResource) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-	if waitErr := route.WaitUntilReady(ctx, sdkWaitOptions(r.client.ResourceTimeout)...); waitErr != nil {
+	if waitErr := route.WaitUntilReady(ctx, sdkWaitOptions(effectiveTimeout(data.Timeout, r.client.ResourceTimeout))...); waitErr != nil {
 		ReportWaitResult(&resp.Diagnostics, waitErr, "VPCPeeringRoute", data.Id.ValueString())
 		return
 	}
@@ -319,12 +324,12 @@ func (r *VpcPeeringRouteResource) Delete(ctx context.Context, req resource.Delet
 	err := DeleteResourceWithRetry(ctx, func() error {
 		return CheckResponseErrAsError("delete", "VPCPeeringRoute",
 			r.client.Client.FromNetwork().VPCPeeringRoutes().Delete(ctx, ref))
-	}, "VPCPeeringRoute", routeID, r.client.ResourceTimeout, deletionChecker)
+	}, "VPCPeeringRoute", routeID, effectiveTimeout(data.Timeout, r.client.ResourceTimeout), deletionChecker)
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting VPCPeeringRoute", err.Error())
 		return
 	}
-	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "VPCPeeringRoute", routeID, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
+	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "VPCPeeringRoute", routeID, remainingTimeout(deleteStart, effectiveTimeout(data.Timeout, r.client.ResourceTimeout))); waitErr != nil {
 		resp.Diagnostics.AddError("Error waiting for VPCPeeringRoute deletion", waitErr.Error())
 		return
 	}

--- a/internal/provider/vpnroute_resource.go
+++ b/internal/provider/vpnroute_resource.go
@@ -32,6 +32,7 @@ type VPNRouteResourceModel struct {
 	ProjectId   types.String `tfsdk:"project_id"`
 	VPNTunnelId types.String `tfsdk:"vpn_tunnel_id"`
 	Properties  types.Object `tfsdk:"properties"`
+	Timeout     types.String `tfsdk:"timeout"`
 }
 
 type VPNRouteResource struct {
@@ -80,6 +81,10 @@ func (r *VPNRouteResource) Schema(ctx context.Context, req resource.SchemaReques
 			"vpn_tunnel_id": schema.StringAttribute{
 				MarkdownDescription: "ID of the VPN tunnel this route is associated with.",
 				Required:            true,
+			},
+			"timeout": schema.StringAttribute{
+				MarkdownDescription: "Per-resource timeout override (e.g. `\"15m\"`, `\"1h\"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.",
+				Optional:            true,
 			},
 			"properties": schema.SingleNestedAttribute{
 				MarkdownDescription: "Routing properties for the VPN route.",
@@ -179,7 +184,7 @@ func (r *VPNRouteResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
-	if waitErr := route.WaitUntilReady(ctx, sdkWaitOptions(r.client.ResourceTimeout)...); waitErr != nil {
+	if waitErr := route.WaitUntilReady(ctx, sdkWaitOptions(effectiveTimeout(data.Timeout, r.client.ResourceTimeout))...); waitErr != nil {
 		ReportWaitResult(&resp.Diagnostics, waitErr, "VPNRoute", data.Id.ValueString())
 		return
 	}
@@ -349,12 +354,12 @@ func (r *VPNRouteResource) Delete(ctx context.Context, req resource.DeleteReques
 	err := DeleteResourceWithRetry(ctx, func() error {
 		return CheckResponseErrAsError("delete", "VPNRoute",
 			r.client.Client.FromNetwork().VPNRoutes().Delete(ctx, ref))
-	}, "VPNRoute", routeID, r.client.ResourceTimeout, deletionChecker)
+	}, "VPNRoute", routeID, effectiveTimeout(data.Timeout, r.client.ResourceTimeout), deletionChecker)
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting VPNRoute", err.Error())
 		return
 	}
-	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "VPNRoute", routeID, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
+	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "VPNRoute", routeID, remainingTimeout(deleteStart, effectiveTimeout(data.Timeout, r.client.ResourceTimeout))); waitErr != nil {
 		resp.Diagnostics.AddError("Error waiting for VPNRoute deletion", waitErr.Error())
 		return
 	}

--- a/internal/provider/vpntunnel_resource.go
+++ b/internal/provider/vpntunnel_resource.go
@@ -117,6 +117,10 @@ func (r *VPNTunnelResource) Schema(ctx context.Context, req resource.SchemaReque
 										MarkdownDescription: "ID of the subnet.",
 										Optional:            true,
 									},
+									"cidr": schema.StringAttribute{
+										MarkdownDescription: "CIDR block of the subnet (e.g. `192.168.10.0/24`). Required by the API.",
+										Optional:            true,
+									},
 								},
 							},
 							"public_ip": schema.SingleNestedAttribute{
@@ -152,8 +156,11 @@ func (r *VPNTunnelResource) Schema(ctx context.Context, req resource.SchemaReque
 										Optional:            true,
 									},
 									"dh_group": schema.StringAttribute{
-										MarkdownDescription: "IKE Diffie-Hellman group (e.g., `modp2048`).",
+										MarkdownDescription: "IKE Diffie-Hellman group. Use the numeric group identifier: `\"1\"`, `\"2\"`, `\"5\"`, `\"14\"` … `\"32\"`. The common choice for IKEv2 is `\"14\"` (MODP-2048).",
 										Optional:            true,
+										Validators: []validator.String{
+											stringvalidator.OneOf("1", "2", "5", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32"),
+										},
 									},
 									"dpd_action": schema.StringAttribute{
 										MarkdownDescription: "Dead Peer Detection action on failure (e.g., `restart`).",
@@ -186,8 +193,11 @@ func (r *VPNTunnelResource) Schema(ctx context.Context, req resource.SchemaReque
 										Optional:            true,
 									},
 									"pfs": schema.StringAttribute{
-										MarkdownDescription: "ESP Perfect Forward Secrecy group (e.g., `modp2048`).",
+										MarkdownDescription: "ESP Perfect Forward Secrecy group. Use `\"enable\"`, `\"disable\"`, or `\"dh-group<N>\"` (e.g. `\"dh-group14\"` for MODP-2048).",
 										Optional:            true,
+										Validators: []validator.String{
+											stringvalidator.OneOf("enable", "disable", "dh-group1", "dh-group2", "dh-group5", "dh-group14", "dh-group15", "dh-group16", "dh-group17", "dh-group18", "dh-group19", "dh-group20", "dh-group21", "dh-group22", "dh-group23", "dh-group24", "dh-group25", "dh-group26", "dh-group27", "dh-group28", "dh-group29", "dh-group30", "dh-group31", "dh-group32"),
+										},
 									},
 								},
 							},
@@ -295,11 +305,21 @@ func buildVPNTunnel(_ context.Context, data *VPNTunnelResourceModel, tags []stri
 			}
 			if subnetAttr, ok := ipCfgAttrs["subnet"]; ok {
 				if subnetObj, ok := subnetAttr.(types.Object); ok && !subnetObj.IsNull() {
-					if idAttr, ok := subnetObj.Attributes()["id"]; ok {
+					subnetAttrs := subnetObj.Attributes()
+					subnetName := ""
+					subnetCIDR := ""
+					if idAttr, ok := subnetAttrs["id"]; ok {
 						if s, ok := idAttr.(types.String); ok && !s.IsNull() {
-							// subnet name and CIDR — we use the id as name, CIDR left empty
-							ipCfg.WithSubnet(s.ValueString(), "")
+							subnetName = s.ValueString()
 						}
+					}
+					if cidrAttr, ok := subnetAttrs["cidr"]; ok {
+						if s, ok := cidrAttr.(types.String); ok && !s.IsNull() {
+							subnetCIDR = s.ValueString()
+						}
+					}
+					if subnetName != "" || subnetCIDR != "" {
+						ipCfg.WithSubnet(subnetName, subnetCIDR)
 					}
 				}
 			}

--- a/internal/provider/vpntunnel_resource.go
+++ b/internal/provider/vpntunnel_resource.go
@@ -33,6 +33,7 @@ type VPNTunnelResourceModel struct {
 	Tags       types.List   `tfsdk:"tags"`
 	ProjectId  types.String `tfsdk:"project_id"`
 	Properties types.Object `tfsdk:"properties"`
+	Timeout    types.String `tfsdk:"timeout"`
 }
 
 type VPNTunnelResource struct {
@@ -77,6 +78,10 @@ func (r *VPNTunnelResource) Schema(ctx context.Context, req resource.SchemaReque
 			"project_id": schema.StringAttribute{
 				MarkdownDescription: "ID of the project that owns this resource.",
 				Required:            true,
+			},
+			"timeout": schema.StringAttribute{
+				MarkdownDescription: "Per-resource timeout override (e.g. `\"15m\"`, `\"1h\"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.",
+				Optional:            true,
 			},
 			"properties": schema.SingleNestedAttribute{
 				MarkdownDescription: "Configuration properties for the VPN tunnel.",
@@ -476,7 +481,7 @@ func (r *VPNTunnelResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	if waitErr := tunnel.WaitUntilReady(ctx, sdkWaitOptions(r.client.ResourceTimeout)...); waitErr != nil {
+	if waitErr := tunnel.WaitUntilReady(ctx, sdkWaitOptions(effectiveTimeout(data.Timeout, r.client.ResourceTimeout))...); waitErr != nil {
 		ReportWaitResult(&resp.Diagnostics, waitErr, "VPNTunnel", data.Id.ValueString())
 		return
 	}
@@ -609,12 +614,12 @@ func (r *VPNTunnelResource) Delete(ctx context.Context, req resource.DeleteReque
 	err := DeleteResourceWithRetry(ctx, func() error {
 		return CheckResponseErrAsError("delete", "VPNTunnel",
 			r.client.Client.FromNetwork().VPNTunnels().Delete(ctx, ref))
-	}, "VPNTunnel", tunnelID, r.client.ResourceTimeout, deletionChecker)
+	}, "VPNTunnel", tunnelID, effectiveTimeout(data.Timeout, r.client.ResourceTimeout), deletionChecker)
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting VPNTunnel", err.Error())
 		return
 	}
-	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "VPNTunnel", tunnelID, remainingTimeout(deleteStart, r.client.ResourceTimeout)); waitErr != nil {
+	if waitErr := WaitForResourceDeleted(ctx, deletionChecker, "VPNTunnel", tunnelID, remainingTimeout(deleteStart, effectiveTimeout(data.Timeout, r.client.ResourceTimeout))); waitErr != nil {
 		resp.Diagnostics.AddError("Error waiting for VPNTunnel deletion", waitErr.Error())
 		return
 	}


### PR DESCRIPTION
## Summary

Three bug fixes targeting the v0.4.0 milestone, closing #159, #174, and #175.

### #159 — : three bugs that blocked VPN tunnel creation

**Root cause 1 — missing subnet CIDR field**
The  nested attribute only had an uid=1000(amedeopalopoli) gid=1000(amedeopalopoli) groups=1000(amedeopalopoli),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),100(users) field. The SDK's  call always received an empty string for , causing the API to return:
> 

**Fix:** Added a  attribute to the  nested schema and wired it into .

**Root cause 2 — wrong  format**
The schema described  (OpenVPN/Linux notation). The API expects numeric group identifiers (, , …). The SDK constants confirm: .
> 

**Fix:** Updated description to document the correct numeric format. Added  enforcing groups , , , –.

**Root cause 3 — wrong  format**
The schema described . The API expects , enable .
enable :
enable [
enable alias
enable bg
enable bind
enable break
enable builtin
enable caller
enable cd
enable command
enable compgen
enable complete
enable compopt
enable continue
enable declare
enable dirs
enable disown
enable echo
enable enable
enable eval
enable exec
enable exit
enable export
enable false
enable fc
enable fg
enable getopts
enable hash
enable help
enable history
enable jobs
enable kill
enable let
enable local
enable logout
enable mapfile
enable popd
enable printf
enable pushd
enable pwd
enable read
enable readarray
enable readonly
enable return
enable set
enable shift
enable shopt
enable source
enable suspend
enable test
enable times
enable trap
enable true
enable type
enable typeset
enable ulimit
enable umask
enable unalias
enable unset
enable wait, or . The SDK constants confirm: .
> 

**Fix:** Updated description to document the correct  format. Added  enforcing the full valid set.

### #174 — : kubeconfig description was wrong

The  attribute had . This was incorrect:  is downloaded from the API on every  via .

**Fix:** Replaced with an accurate description: computed by the API, populated when the cluster becomes active, sensitive.

### #175 — : no wait after Update

 submitted the update request and immediately wrote state, without waiting for the server to return to a ready state. CloudServer updates (e.g. flavor resize) can trigger a reboot/reconfiguration, leaving the server in / temporarily.

**Fix:** Added  after the  call, matching the pattern used by Create.

## Test plan

- [ ]  with , ,  provisions successfully
- [ ] Setting  is now rejected at plan time with a clear validator error
- [ ] Setting  is now rejected at plan time with a clear validator error
- [ ]  description is correct in 
- [ ]  update (name/tag change) does not leave the provider in a dirty state

🤖 Generated with [Claude Code](https://claude.com/claude-code)