### PR TITLE
test: make all data source acceptance tests self-contained

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,34 +105,14 @@ Some resource tests require additional variables for prerequisites they provisio
 
 #### Data source tests
 
-Data source tests look up an **existing** resource by ID. Each data source test skips (rather than fails) when its variable is absent — set only the ones you need.
+All data source tests create their own infrastructure inline and tear it down on completion — only `ARUBACLOUD_PROJECT_ID` is required for most.
 
-| Variable | Data source(s) |
-|---|---|
-| `ARUBACLOUD_PROJECT_ID` | All data sources |
-| `ARUBACLOUD_VPC_ID` | vpc, subnet, securitygroup, securityrule, vpcpeering, vpcpeeringroute |
-| `ARUBACLOUD_OS_IMAGE_ID` | cloudserver |
-| `ARUBACLOUD_KEYPAIR_ID` | keypair |
-| `ARUBACLOUD_BLOCKSTORAGE_ID` | blockstorage |
-| `ARUBACLOUD_SNAPSHOT_ID` | snapshot |
-| `ARUBACLOUD_ELASTICIP_ID` | elasticip |
-| `ARUBACLOUD_BACKUP_ID` | backup, restore |
-| `ARUBACLOUD_RESTORE_ID` | restore |
-| `ARUBACLOUD_DBAAS_ID` | dbaas, dbaasuser, database, databasegrant |
-| `ARUBACLOUD_DATABASE_ID` | database, databasegrant |
-| `ARUBACLOUD_DATABASE_BACKUP_ID` | databasebackup |
-| `ARUBACLOUD_DBAAS_USERNAME` | dbaasuser |
-| `ARUBACLOUD_DBAAS_USER_ID` | databasegrant |
-| `ARUBACLOUD_KAAS_ID` | kaas |
-| `ARUBACLOUD_CONTAINERREGISTRY_ID` | containerregistry |
-| `ARUBACLOUD_SECURITYGROUP_ID` | securitygroup, securityrule |
-| `ARUBACLOUD_SECURITYRULE_ID` | securityrule |
-| `ARUBACLOUD_KMS_ID` | kms |
-| `ARUBACLOUD_SCHEDULEJOB_ID` | schedulejob |
-| `ARUBACLOUD_VPNTUNNEL_ID` | vpntunnel, vpnroute |
-| `ARUBACLOUD_VPNROUTE_ID` | vpnroute |
-| `ARUBACLOUD_VPCPEERING_ID` | vpcpeering, vpcpeeringroute |
-| `ARUBACLOUD_VPCPEERINGROUTE_ID` | vpcpeeringroute |
+| Variable | Required by | Notes |
+|---|---|---|
+| `ARUBACLOUD_PROJECT_ID` | All data sources | |
+| `ARUBACLOUD_OS_IMAGE_ID` | cloudserver, schedulejob | OS image slug for bootable disk (e.g. `ubuntu-22.04`) |
+| `ARUBACLOUD_VPNTUNNEL_ID` | vpntunnel, vpnroute | Pre-existing VPN tunnel — inline provisioning not feasible |
+| `ARUBACLOUD_VPNROUTE_ID` | vpnroute | Pre-existing VPN route within the above tunnel |
 
 ## When to regenerate docs
 

--- a/docs/guides/acceptance-testing.md
+++ b/docs/guides/acceptance-testing.md
@@ -93,34 +93,14 @@ Some resource tests have additional prerequisites:
 
 ### Data Source Tests
 
-Data source tests look up an **existing** resource by ID. A data source test skips gracefully when its variable is missing — set only the variables for the resources you want to test.
+All data source tests create their own infrastructure inline and destroy it on completion — only `ARUBACLOUD_PROJECT_ID` is required for most. Two additional variables are needed for tests that provision a cloud server as a prerequisite, and two VPN tests are exceptions that read pre-existing fixtures because VPN tunnels are too complex to provision inline.
 
-| Variable | Data source(s) tested |
-|---|---|
-| `ARUBACLOUD_PROJECT_ID` | All data sources |
-| `ARUBACLOUD_VPC_ID` | `arubacloud_vpc`, `arubacloud_subnet`, `arubacloud_securitygroup`, `arubacloud_securityrule`, `arubacloud_vpcpeering`, `arubacloud_vpcpeeringroute` |
-| `ARUBACLOUD_OS_IMAGE_ID` | `arubacloud_cloudserver` |
-| `ARUBACLOUD_KEYPAIR_ID` | `arubacloud_keypair` |
-| `ARUBACLOUD_BLOCKSTORAGE_ID` | `arubacloud_blockstorage` |
-| `ARUBACLOUD_SNAPSHOT_ID` | `arubacloud_snapshot` |
-| `ARUBACLOUD_ELASTICIP_ID` | `arubacloud_elasticip` |
-| `ARUBACLOUD_BACKUP_ID` | `arubacloud_backup`, `arubacloud_restore` |
-| `ARUBACLOUD_RESTORE_ID` | `arubacloud_restore` |
-| `ARUBACLOUD_DBAAS_ID` | `arubacloud_dbaas`, `arubacloud_dbaasuser`, `arubacloud_database`, `arubacloud_databasegrant` |
-| `ARUBACLOUD_DATABASE_ID` | `arubacloud_database`, `arubacloud_databasegrant` |
-| `ARUBACLOUD_DATABASE_BACKUP_ID` | `arubacloud_databasebackup` |
-| `ARUBACLOUD_DBAAS_USERNAME` | `arubacloud_dbaasuser` |
-| `ARUBACLOUD_DBAAS_USER_ID` | `arubacloud_databasegrant` |
-| `ARUBACLOUD_KAAS_ID` | `arubacloud_kaas` |
-| `ARUBACLOUD_CONTAINERREGISTRY_ID` | `arubacloud_containerregistry` |
-| `ARUBACLOUD_SECURITYGROUP_ID` | `arubacloud_securitygroup`, `arubacloud_securityrule` |
-| `ARUBACLOUD_SECURITYRULE_ID` | `arubacloud_securityrule` |
-| `ARUBACLOUD_KMS_ID` | `arubacloud_kms` |
-| `ARUBACLOUD_SCHEDULEJOB_ID` | `arubacloud_schedulejob` |
-| `ARUBACLOUD_VPNTUNNEL_ID` | `arubacloud_vpntunnel`, `arubacloud_vpnroute` |
-| `ARUBACLOUD_VPNROUTE_ID` | `arubacloud_vpnroute` |
-| `ARUBACLOUD_VPCPEERING_ID` | `arubacloud_vpcpeering`, `arubacloud_vpcpeeringroute` |
-| `ARUBACLOUD_VPCPEERINGROUTE_ID` | `arubacloud_vpcpeeringroute` |
+| Variable | Required by | Notes |
+|---|---|---|
+| `ARUBACLOUD_PROJECT_ID` | All data sources | |
+| `ARUBACLOUD_OS_IMAGE_ID` | `arubacloud_cloudserver`, `arubacloud_schedulejob` | OS image slug for bootable disk (e.g. `ubuntu-22.04`) |
+| `ARUBACLOUD_VPNTUNNEL_ID` | `arubacloud_vpntunnel`, `arubacloud_vpnroute` | Pre-existing VPN tunnel — inline provisioning not feasible |
+| `ARUBACLOUD_VPNROUTE_ID` | `arubacloud_vpnroute` | Pre-existing VPN route within the above tunnel |
 
 ## GitHub Actions Secrets
 

--- a/internal/provider/database_data_source_test.go
+++ b/internal/provider/database_data_source_test.go
@@ -13,9 +13,8 @@ import (
 
 func TestAccDatabaseDataSource(t *testing.T) {
 	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
-	dbaasID := os.Getenv("ARUBACLOUD_DBAAS_ID")
-	if projectID == "" || dbaasID == "" {
-		t.Skip("ARUBACLOUD_PROJECT_ID and ARUBACLOUD_DBAAS_ID must be set for acceptance tests")
+	if projectID == "" {
+		t.Skip("ARUBACLOUD_PROJECT_ID must be set for acceptance tests")
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -23,7 +22,7 @@ func TestAccDatabaseDataSource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatabaseDataSourceConfig(projectID, dbaasID),
+				Config: testAccDatabaseDataSourceConfig(projectID),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"data.arubacloud_database.test",
@@ -33,7 +32,7 @@ func TestAccDatabaseDataSource(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						"data.arubacloud_database.test",
 						tfjsonpath.New("name"),
-						knownvalue.NotNull(),
+						knownvalue.StringExact("testdsdb"),
 					),
 					statecheck.ExpectKnownValue(
 						"data.arubacloud_database.test",
@@ -43,7 +42,7 @@ func TestAccDatabaseDataSource(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						"data.arubacloud_database.test",
 						tfjsonpath.New("dbaas_id"),
-						knownvalue.StringExact(dbaasID),
+						knownvalue.NotNull(),
 					),
 				},
 			},
@@ -51,18 +50,58 @@ func TestAccDatabaseDataSource(t *testing.T) {
 	})
 }
 
-func testAccDatabaseDataSourceConfig(projectID, dbaasID string) string {
+func testAccDatabaseDataSourceConfig(projectID string) string {
 	return fmt.Sprintf(`
+resource "arubacloud_vpc" "test" {
+  name       = "test-ds-database-vpc"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+}
+
+resource "arubacloud_subnet" "test" {
+  name       = "test-ds-database-subnet"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+  vpc_id     = arubacloud_vpc.test.id
+  type       = "Basic"
+}
+
+resource "arubacloud_securitygroup" "test" {
+  name       = "test-ds-database-sg"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+  vpc_id     = arubacloud_vpc.test.id
+}
+
+resource "arubacloud_dbaas" "test" {
+  name       = "test-ds-database-dbaas"
+  location   = "ITBG-Bergamo"
+  zone       = "ITBG-1"
+  project_id = %[1]q
+  engine_id  = "mysql-8.0"
+  flavor     = "DBO2A4"
+
+  storage = {
+    size_gb = 20
+  }
+
+  network = {
+    vpc_uri_ref            = arubacloud_vpc.test.uri
+    subnet_uri_ref         = arubacloud_subnet.test.uri
+    security_group_uri_ref = arubacloud_securitygroup.test.uri
+  }
+}
+
 resource "arubacloud_database" "test" {
   name       = "testdsdb"
   project_id = %[1]q
-  dbaas_id   = %[2]q
+  dbaas_id   = arubacloud_dbaas.test.id
 }
 
 data "arubacloud_database" "test" {
   id         = arubacloud_database.test.id
   project_id = %[1]q
-  dbaas_id   = %[2]q
+  dbaas_id   = arubacloud_dbaas.test.id
 }
-`, projectID, dbaasID)
+`, projectID)
 }

--- a/internal/provider/databasegrant_data_source_test.go
+++ b/internal/provider/databasegrant_data_source_test.go
@@ -13,9 +13,8 @@ import (
 
 func TestAccDatabasegrantDataSource(t *testing.T) {
 	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
-	dbaasID := os.Getenv("ARUBACLOUD_DBAAS_ID")
-	if projectID == "" || dbaasID == "" {
-		t.Skip("ARUBACLOUD_PROJECT_ID and ARUBACLOUD_DBAAS_ID must be set for acceptance tests")
+	if projectID == "" {
+		t.Skip("ARUBACLOUD_PROJECT_ID must be set for acceptance tests")
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -23,7 +22,7 @@ func TestAccDatabasegrantDataSource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatabasegrantDataSourceConfig(projectID, dbaasID),
+				Config: testAccDatabasegrantDataSourceConfig(projectID),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"data.arubacloud_databasegrant.test",
@@ -38,22 +37,22 @@ func TestAccDatabasegrantDataSource(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						"data.arubacloud_databasegrant.test",
 						tfjsonpath.New("dbaas_id"),
-						knownvalue.StringExact(dbaasID),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						"data.arubacloud_databasegrant.test",
 						tfjsonpath.New("database"),
-						knownvalue.NotNull(),
+						knownvalue.StringExact("testdsgrantdb"),
 					),
 					statecheck.ExpectKnownValue(
 						"data.arubacloud_databasegrant.test",
 						tfjsonpath.New("user_id"),
-						knownvalue.NotNull(),
+						knownvalue.StringExact("test-ds-grantuser"),
 					),
 					statecheck.ExpectKnownValue(
 						"data.arubacloud_databasegrant.test",
 						tfjsonpath.New("role"),
-						knownvalue.NotNull(),
+						knownvalue.StringExact("read"),
 					),
 				},
 			},
@@ -61,11 +60,51 @@ func TestAccDatabasegrantDataSource(t *testing.T) {
 	})
 }
 
-func testAccDatabasegrantDataSourceConfig(projectID, dbaasID string) string {
+func testAccDatabasegrantDataSourceConfig(projectID string) string {
 	return fmt.Sprintf(`
+resource "arubacloud_vpc" "test" {
+  name       = "test-ds-dbgrant-vpc"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+}
+
+resource "arubacloud_subnet" "test" {
+  name       = "test-ds-dbgrant-subnet"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+  vpc_id     = arubacloud_vpc.test.id
+  type       = "Basic"
+}
+
+resource "arubacloud_securitygroup" "test" {
+  name       = "test-ds-dbgrant-sg"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+  vpc_id     = arubacloud_vpc.test.id
+}
+
+resource "arubacloud_dbaas" "test" {
+  name       = "test-ds-dbgrant-dbaas"
+  location   = "ITBG-Bergamo"
+  zone       = "ITBG-1"
+  project_id = %[1]q
+  engine_id  = "mysql-8.0"
+  flavor     = "DBO2A4"
+
+  storage = {
+    size_gb = 20
+  }
+
+  network = {
+    vpc_uri_ref            = arubacloud_vpc.test.uri
+    subnet_uri_ref         = arubacloud_subnet.test.uri
+    security_group_uri_ref = arubacloud_securitygroup.test.uri
+  }
+}
+
 resource "arubacloud_dbaasuser" "test" {
   project_id = %[1]q
-  dbaas_id   = %[2]q
+  dbaas_id   = arubacloud_dbaas.test.id
   username   = "test-ds-grantuser"
   password   = "TestPassword123!"
 }
@@ -73,12 +112,12 @@ resource "arubacloud_dbaasuser" "test" {
 resource "arubacloud_database" "test" {
   name       = "testdsgrantdb"
   project_id = %[1]q
-  dbaas_id   = %[2]q
+  dbaas_id   = arubacloud_dbaas.test.id
 }
 
 resource "arubacloud_databasegrant" "test" {
   project_id = %[1]q
-  dbaas_id   = %[2]q
+  dbaas_id   = arubacloud_dbaas.test.id
   database   = arubacloud_database.test.name
   user_id    = arubacloud_dbaasuser.test.username
   role       = "read"
@@ -86,9 +125,9 @@ resource "arubacloud_databasegrant" "test" {
 
 data "arubacloud_databasegrant" "test" {
   project_id = %[1]q
-  dbaas_id   = %[2]q
+  dbaas_id   = arubacloud_dbaas.test.id
   database   = arubacloud_database.test.name
   user_id    = arubacloud_dbaasuser.test.username
 }
-`, projectID, dbaasID)
+`, projectID)
 }

--- a/internal/provider/dbaasuser_data_source_test.go
+++ b/internal/provider/dbaasuser_data_source_test.go
@@ -13,9 +13,8 @@ import (
 
 func TestAccDbaasuserDataSource(t *testing.T) {
 	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
-	dbaasID := os.Getenv("ARUBACLOUD_DBAAS_ID")
-	if projectID == "" || dbaasID == "" {
-		t.Skip("ARUBACLOUD_PROJECT_ID and ARUBACLOUD_DBAAS_ID must be set for acceptance tests")
+	if projectID == "" {
+		t.Skip("ARUBACLOUD_PROJECT_ID must be set for acceptance tests")
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -23,7 +22,7 @@ func TestAccDbaasuserDataSource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDbaasuserDataSourceConfig(projectID, dbaasID),
+				Config: testAccDbaasuserDataSourceConfig(projectID),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"data.arubacloud_dbaasuser.test",
@@ -33,7 +32,7 @@ func TestAccDbaasuserDataSource(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						"data.arubacloud_dbaasuser.test",
 						tfjsonpath.New("username"),
-						knownvalue.NotNull(),
+						knownvalue.StringExact("test-ds-user"),
 					),
 					statecheck.ExpectKnownValue(
 						"data.arubacloud_dbaasuser.test",
@@ -43,7 +42,7 @@ func TestAccDbaasuserDataSource(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						"data.arubacloud_dbaasuser.test",
 						tfjsonpath.New("dbaas_id"),
-						knownvalue.StringExact(dbaasID),
+						knownvalue.NotNull(),
 					),
 				},
 			},
@@ -51,11 +50,51 @@ func TestAccDbaasuserDataSource(t *testing.T) {
 	})
 }
 
-func testAccDbaasuserDataSourceConfig(projectID, dbaasID string) string {
+func testAccDbaasuserDataSourceConfig(projectID string) string {
 	return fmt.Sprintf(`
+resource "arubacloud_vpc" "test" {
+  name       = "test-ds-dbaasuser-vpc"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+}
+
+resource "arubacloud_subnet" "test" {
+  name       = "test-ds-dbaasuser-subnet"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+  vpc_id     = arubacloud_vpc.test.id
+  type       = "Basic"
+}
+
+resource "arubacloud_securitygroup" "test" {
+  name       = "test-ds-dbaasuser-sg"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+  vpc_id     = arubacloud_vpc.test.id
+}
+
+resource "arubacloud_dbaas" "test" {
+  name       = "test-ds-dbaasuser-dbaas"
+  location   = "ITBG-Bergamo"
+  zone       = "ITBG-1"
+  project_id = %[1]q
+  engine_id  = "mysql-8.0"
+  flavor     = "DBO2A4"
+
+  storage = {
+    size_gb = 20
+  }
+
+  network = {
+    vpc_uri_ref            = arubacloud_vpc.test.uri
+    subnet_uri_ref         = arubacloud_subnet.test.uri
+    security_group_uri_ref = arubacloud_securitygroup.test.uri
+  }
+}
+
 resource "arubacloud_dbaasuser" "test" {
   project_id = %[1]q
-  dbaas_id   = %[2]q
+  dbaas_id   = arubacloud_dbaas.test.id
   username   = "test-ds-user"
   password   = "TestPassword123!"
 }
@@ -63,7 +102,7 @@ resource "arubacloud_dbaasuser" "test" {
 data "arubacloud_dbaasuser" "test" {
   username   = arubacloud_dbaasuser.test.username
   project_id = %[1]q
-  dbaas_id   = %[2]q
+  dbaas_id   = arubacloud_dbaas.test.id
 }
-`, projectID, dbaasID)
+`, projectID)
 }

--- a/internal/provider/restore_data_source_test.go
+++ b/internal/provider/restore_data_source_test.go
@@ -76,7 +76,7 @@ resource "arubacloud_backup" "test" {
   name           = "test-ds-restore-backup"
   location       = "ITBG-Bergamo"
   project_id     = %[1]q
-  type           = "full"
+  type           = "Full"
   volume_id      = arubacloud_blockstorage.source.id
   billing_period = "Hour"
   retention_days = 7

--- a/internal/provider/schedulejob_data_source_test.go
+++ b/internal/provider/schedulejob_data_source_test.go
@@ -13,12 +13,9 @@ import (
 
 func TestAccSchedulejobDataSource(t *testing.T) {
 	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
-	if projectID == "" {
-		t.Skip("ARUBACLOUD_PROJECT_ID must be set for acceptance tests")
-	}
-	cloudserverID := os.Getenv("ARUBACLOUD_CLOUDSERVER_ID")
-	if cloudserverID == "" {
-		t.Skip("ARUBACLOUD_CLOUDSERVER_ID must be set for schedulejob acceptance tests (step resource_uri requires an existing cloud server)")
+	osImageID := os.Getenv("ARUBACLOUD_OS_IMAGE_ID")
+	if projectID == "" || osImageID == "" {
+		t.Skip("ARUBACLOUD_PROJECT_ID and ARUBACLOUD_OS_IMAGE_ID must be set for acceptance tests")
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -26,7 +23,7 @@ func TestAccSchedulejobDataSource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSchedulejobDataSourceConfig(projectID, cloudserverID),
+				Config: testAccSchedulejobDataSourceConfig(projectID, osImageID),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"data.arubacloud_schedulejob.test",
@@ -36,7 +33,7 @@ func TestAccSchedulejobDataSource(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						"data.arubacloud_schedulejob.test",
 						tfjsonpath.New("name"),
-						knownvalue.NotNull(),
+						knownvalue.StringExact("test-ds-schedulejob"),
 					),
 					statecheck.ExpectKnownValue(
 						"data.arubacloud_schedulejob.test",
@@ -49,8 +46,62 @@ func TestAccSchedulejobDataSource(t *testing.T) {
 	})
 }
 
-func testAccSchedulejobDataSourceConfig(projectID, cloudserverID string) string {
+func testAccSchedulejobDataSourceConfig(projectID, osImageID string) string {
 	return fmt.Sprintf(`
+resource "arubacloud_vpc" "sj_prereq" {
+  name       = "test-ds-sj-vpc"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+}
+
+resource "arubacloud_subnet" "sj_prereq" {
+  name       = "test-ds-sj-subnet"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+  vpc_id     = arubacloud_vpc.sj_prereq.id
+  type       = "Basic"
+}
+
+resource "arubacloud_securitygroup" "sj_prereq" {
+  name       = "test-ds-sj-sg"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+  vpc_id     = arubacloud_vpc.sj_prereq.id
+}
+
+resource "arubacloud_blockstorage" "sj_boot" {
+  name           = "test-ds-sj-boot"
+  project_id     = %[1]q
+  location       = "ITBG-Bergamo"
+  size_gb        = 30
+  billing_period = "Hour"
+  zone           = "ITBG-1"
+  type           = "Standard"
+  bootable       = true
+  image          = %[2]q
+}
+
+resource "arubacloud_cloudserver" "sj_prereq" {
+  name       = "test-ds-sj-server"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+  zone       = "ITBG-1"
+
+  network = {
+    vpc_uri_ref            = arubacloud_vpc.sj_prereq.uri
+    subnet_uri_refs        = [arubacloud_subnet.sj_prereq.uri]
+    securitygroup_uri_refs = [arubacloud_securitygroup.sj_prereq.uri]
+  }
+
+  settings = {
+    flavor_name = "CSO4A8"
+  }
+
+  storage = {
+    boot_volume_uri_ref = arubacloud_blockstorage.sj_boot.uri
+  }
+}
+
 resource "arubacloud_schedulejob" "test" {
   name       = "test-ds-schedulejob"
   project_id = %[1]q
@@ -64,7 +115,7 @@ resource "arubacloud_schedulejob" "test" {
     steps = [
       {
         name         = "Power Off Server"
-        resource_uri = "/projects/%[1]s/providers/Aruba.Compute/cloudServers/%[2]s"
+        resource_uri = "/projects/%[1]s/providers/Aruba.Compute/cloudServers/${arubacloud_cloudserver.sj_prereq.id}"
         action_uri   = "/poweroff"
         http_verb    = "POST"
         body         = null
@@ -77,5 +128,5 @@ data "arubacloud_schedulejob" "test" {
   id         = arubacloud_schedulejob.test.id
   project_id = %[1]q
 }
-`, projectID, cloudserverID)
+`, projectID, osImageID)
 }

--- a/templates/guides/acceptance-testing.md
+++ b/templates/guides/acceptance-testing.md
@@ -93,34 +93,14 @@ Some resource tests have additional prerequisites:
 
 ### Data Source Tests
 
-Data source tests look up an **existing** resource by ID. A data source test skips gracefully when its variable is missing — set only the variables for the resources you want to test.
+All data source tests create their own infrastructure inline and destroy it on completion — only `ARUBACLOUD_PROJECT_ID` is required for most. Two additional variables are needed for tests that provision a cloud server as a prerequisite, and two VPN tests are exceptions that read pre-existing fixtures because VPN tunnels are too complex to provision inline.
 
-| Variable | Data source(s) tested |
-|---|---|
-| `ARUBACLOUD_PROJECT_ID` | All data sources |
-| `ARUBACLOUD_VPC_ID` | `arubacloud_vpc`, `arubacloud_subnet`, `arubacloud_securitygroup`, `arubacloud_securityrule`, `arubacloud_vpcpeering`, `arubacloud_vpcpeeringroute` |
-| `ARUBACLOUD_OS_IMAGE_ID` | `arubacloud_cloudserver` |
-| `ARUBACLOUD_KEYPAIR_ID` | `arubacloud_keypair` |
-| `ARUBACLOUD_BLOCKSTORAGE_ID` | `arubacloud_blockstorage` |
-| `ARUBACLOUD_SNAPSHOT_ID` | `arubacloud_snapshot` |
-| `ARUBACLOUD_ELASTICIP_ID` | `arubacloud_elasticip` |
-| `ARUBACLOUD_BACKUP_ID` | `arubacloud_backup`, `arubacloud_restore` |
-| `ARUBACLOUD_RESTORE_ID` | `arubacloud_restore` |
-| `ARUBACLOUD_DBAAS_ID` | `arubacloud_dbaas`, `arubacloud_dbaasuser`, `arubacloud_database`, `arubacloud_databasegrant` |
-| `ARUBACLOUD_DATABASE_ID` | `arubacloud_database`, `arubacloud_databasegrant` |
-| `ARUBACLOUD_DATABASE_BACKUP_ID` | `arubacloud_databasebackup` |
-| `ARUBACLOUD_DBAAS_USERNAME` | `arubacloud_dbaasuser` |
-| `ARUBACLOUD_DBAAS_USER_ID` | `arubacloud_databasegrant` |
-| `ARUBACLOUD_KAAS_ID` | `arubacloud_kaas` |
-| `ARUBACLOUD_CONTAINERREGISTRY_ID` | `arubacloud_containerregistry` |
-| `ARUBACLOUD_SECURITYGROUP_ID` | `arubacloud_securitygroup`, `arubacloud_securityrule` |
-| `ARUBACLOUD_SECURITYRULE_ID` | `arubacloud_securityrule` |
-| `ARUBACLOUD_KMS_ID` | `arubacloud_kms` |
-| `ARUBACLOUD_SCHEDULEJOB_ID` | `arubacloud_schedulejob` |
-| `ARUBACLOUD_VPNTUNNEL_ID` | `arubacloud_vpntunnel`, `arubacloud_vpnroute` |
-| `ARUBACLOUD_VPNROUTE_ID` | `arubacloud_vpnroute` |
-| `ARUBACLOUD_VPCPEERING_ID` | `arubacloud_vpcpeering`, `arubacloud_vpcpeeringroute` |
-| `ARUBACLOUD_VPCPEERINGROUTE_ID` | `arubacloud_vpcpeeringroute` |
+| Variable | Required by | Notes |
+|---|---|---|
+| `ARUBACLOUD_PROJECT_ID` | All data sources | |
+| `ARUBACLOUD_OS_IMAGE_ID` | `arubacloud_cloudserver`, `arubacloud_schedulejob` | OS image slug for bootable disk (e.g. `ubuntu-22.04`) |
+| `ARUBACLOUD_VPNTUNNEL_ID` | `arubacloud_vpntunnel`, `arubacloud_vpnroute` | Pre-existing VPN tunnel — inline provisioning not feasible |
+| `ARUBACLOUD_VPNROUTE_ID` | `arubacloud_vpnroute` | Pre-existing VPN route within the above tunnel |
 
 ## GitHub Actions Secrets
 


### PR DESCRIPTION
## Inventory

Audited all 25 data source acceptance tests against the self-contained standard.

| Classification | Count | Tests |
|---|---|---|
| **Already self-contained** | 20 | vpc, subnet, securitygroup, securityrule, vpcpeering, vpcpeeringroute, blockstorage, elasticip, keypair, snapshot, backup, restore*, kms, kaas, dbaas, databasebackup, containerregistry, cloudserver |
| **Fixed in this PR** | 5 | restore (enum bug), schedulejob, database, dbaasuser, databasegrant |
| **Accepted exceptions** | 3 | project (no managed resource), vpntunnel (IPsec complexity), vpnroute (depends on vpntunnel) |

*restore was already structurally correct but had a wrong enum value

## Changes

**`restore_data_source_test.go`** — `type = "full"` → `"Full"` (schema `OneOf` validator requires PascalCase).

**`schedulejob_data_source_test.go`** — Replaced `ARUBACLOUD_CLOUDSERVER_ID` dependency with a full inline stack (VPC → subnet → SG → bootable block storage → cloud server). The step `resource_uri` is built via HCL template interpolation: `/projects/%s/providers/.../cloudServers/${arubacloud_cloudserver.sj_prereq.id}`. Now requires `ARUBACLOUD_OS_IMAGE_ID`; skips when absent.

**`database_data_source_test.go`** — Removed `ARUBACLOUD_DBAAS_ID` dependency. Now provisions a full DBaaS stack inline (VPC → subnet → SG → dbaas cluster → database). Only requires `ARUBACLOUD_PROJECT_ID`.

**`dbaasuser_data_source_test.go`** — Same: full DBaaS stack inline. Removed `ARUBACLOUD_DBAAS_ID`.

**`databasegrant_data_source_test.go`** — Same: full DBaaS stack inline (+ dbaasuser + database + grant). Assertions strengthened — `database`, `user_id`, and `role` use `StringExact` instead of `NotNull`.

**Docs** (`CONTRIBUTING.md`, `docs/guides/acceptance-testing.md`, `templates/guides/acceptance-testing.md`) — Data source env var table reduced from 24 entries to 4. Stale variables that tests never actually read (e.g. `ARUBACLOUD_VPC_ID`, `ARUBACLOUD_BLOCKSTORAGE_ID`, `ARUBACLOUD_DBAAS_USERNAME`, etc.) removed. VPN exceptions documented with justification.

## Accepted exceptions

| Test | Reason |
|---|---|
| `TestAccProjectDataSource` | No `arubacloud_project` managed resource exists — projects are external entities |
| `TestAccVpntunnelDataSource` | VPN tunnel creation requires complex IPsec/IKE configuration and a reachable VPN peer; not automatable inline |
| `TestAccVpnrouteDataSource` | Inherits VPN tunnel dependency |

## Test plan

- [x] Unit tests (`make test`) pass
- [ ] `TestAccSchedulejobDataSource` passes with `ARUBACLOUD_PROJECT_ID` + `ARUBACLOUD_OS_IMAGE_ID`
- [ ] `TestAccDatabaseDataSource` passes with `ARUBACLOUD_PROJECT_ID`
- [ ] `TestAccDbaasuserDataSource` passes with `ARUBACLOUD_PROJECT_ID`
- [ ] `TestAccDatabasegrantDataSource` passes with `ARUBACLOUD_PROJECT_ID`
- [ ] `TestAccRestoreDataSource` passes with `ARUBACLOUD_PROJECT_ID`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)