### PR TITLE
test: fix dbaasuser/databasegrant username format and password strength (fixes #196)

### DIFF
--- a/internal/provider/databasegrant_data_source_test.go
+++ b/internal/provider/databasegrant_data_source_test.go
@@ -47,7 +47,7 @@ func TestAccDatabasegrantDataSource(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						"data.arubacloud_databasegrant.test",
 						tfjsonpath.New("user_id"),
-						knownvalue.StringExact("test-ds-grantuser"),
+						knownvalue.StringExact("testdsgrantuser"),
 					),
 					statecheck.ExpectKnownValue(
 						"data.arubacloud_databasegrant.test",
@@ -105,8 +105,8 @@ resource "arubacloud_dbaas" "test" {
 resource "arubacloud_dbaasuser" "test" {
   project_id = %[1]q
   dbaas_id   = arubacloud_dbaas.test.id
-  username   = "test-ds-grantuser"
-  password   = "TestPassword123!"
+  username   = "testdsgrantuser"
+  password   = "Acc3ptAbl3P@ss#01"
 }
 
 resource "arubacloud_database" "test" {

--- a/internal/provider/dbaasuser_data_source_test.go
+++ b/internal/provider/dbaasuser_data_source_test.go
@@ -32,7 +32,7 @@ func TestAccDbaasuserDataSource(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						"data.arubacloud_dbaasuser.test",
 						tfjsonpath.New("username"),
-						knownvalue.StringExact("test-ds-user"),
+						knownvalue.StringExact("testdsuser"),
 					),
 					statecheck.ExpectKnownValue(
 						"data.arubacloud_dbaasuser.test",
@@ -95,8 +95,8 @@ resource "arubacloud_dbaas" "test" {
 resource "arubacloud_dbaasuser" "test" {
   project_id = %[1]q
   dbaas_id   = arubacloud_dbaas.test.id
-  username   = "test-ds-user"
-  password   = "TestPassword123!"
+  username   = "testdsuser"
+  password   = "Acc3ptAbl3P@ss#01"
 }
 
 data "arubacloud_dbaasuser" "test" {


### PR DESCRIPTION
Fixes #196

API rejects usernames that contain hyphens and the test password does not meet DBaaS minimum requirements.

**Changes:**
- `test-ds-user` → `testdsuser` (alphanumeric only)
- `test-ds-grantuser` → `testdsgrantuser` (alphanumeric only)  
- Password `TestPassword123!` → `Acc3ptAbl3P@ss#01` (mixed case + digits + specials, 17 chars)