### PR TITLE
test: fix dbaas/databasebackup/databasegrant resource tests — inline prereqs, real location (fixes #198)

### DIFF
--- a/internal/provider/databasebackup_resource_test.go
+++ b/internal/provider/databasebackup_resource_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
@@ -14,14 +15,17 @@ import (
 )
 
 func TestAccDatabasebackupResource(t *testing.T) {
+	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
+	if projectID == "" {
+		t.Skip("ARUBACLOUD_PROJECT_ID must be set for acceptance tests")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testCheckDatabasebackupDestroyed,
 		Steps: []resource.TestStep{
-			// Create and Read testing
 			{
-				Config: testAccDatabasebackupResourceConfig("test-databasebackup"),
+				Config: testAccDatabasebackupResourceConfig(projectID, "test-databasebackup"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_databasebackup.test",
@@ -40,16 +44,14 @@ func TestAccDatabasebackupResource(t *testing.T) {
 					),
 				},
 			},
-			// ImportState testing
 			{
 				ResourceName:      "arubacloud_databasebackup.test",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: importIDFromAttrs("arubacloud_databasebackup.test", "project_id", "id"),
 			},
-			// Update and Read testing
 			{
-				Config: testAccDatabasebackupResourceConfig("test-databasebackup-updated"),
+				Config: testAccDatabasebackupResourceConfig(projectID, "test-databasebackup-updated"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_databasebackup.test",
@@ -86,16 +88,62 @@ func testCheckDatabasebackupDestroyed(s *terraform.State) error {
 	return nil
 }
 
-func testAccDatabasebackupResourceConfig(name string) string {
+func testAccDatabasebackupResourceConfig(projectID, name string) string {
 	return fmt.Sprintf(`
+resource "arubacloud_vpc" "dbbackup_prereq" {
+  name       = "test-acc-dbbackup-vpc"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+}
+
+resource "arubacloud_subnet" "dbbackup_prereq" {
+  name       = "test-acc-dbbackup-subnet"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+  vpc_id     = arubacloud_vpc.dbbackup_prereq.id
+  type       = "Basic"
+}
+
+resource "arubacloud_securitygroup" "dbbackup_prereq" {
+  name       = "test-acc-dbbackup-sg"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+  vpc_id     = arubacloud_vpc.dbbackup_prereq.id
+}
+
+resource "arubacloud_dbaas" "dbbackup_prereq" {
+  name       = "test-acc-dbbackup-dbaas"
+  location   = "ITBG-Bergamo"
+  zone       = "ITBG-1"
+  project_id = %[1]q
+  engine_id  = "mysql-8.0"
+  flavor     = "DBO2A4"
+
+  storage = {
+    size_gb = 20
+  }
+
+  network = {
+    vpc_uri_ref            = arubacloud_vpc.dbbackup_prereq.uri
+    subnet_uri_ref         = arubacloud_subnet.dbbackup_prereq.uri
+    security_group_uri_ref = arubacloud_securitygroup.dbbackup_prereq.uri
+  }
+}
+
+resource "arubacloud_database" "dbbackup_prereq" {
+  name       = "testaccdbbackupdb"
+  project_id = %[1]q
+  dbaas_id   = arubacloud_dbaas.dbbackup_prereq.id
+}
+
 resource "arubacloud_databasebackup" "test" {
-  name           = %[1]q
-  project_id     = "test-project-id"
-  location       = "it-1"
-  zone           = "it-1"
-  dbaas_id       = "test-dbaas-id"
-  database       = "test-db"
+  name           = %[2]q
+  project_id     = %[1]q
+  location       = "ITBG-Bergamo"
+  zone           = "ITBG-1"
+  dbaas_id       = arubacloud_dbaas.dbbackup_prereq.id
+  database       = arubacloud_database.dbbackup_prereq.name
   billing_period = "Hour"
 }
-`, name)
+`, projectID, name)
 }

--- a/internal/provider/databasegrant_resource_test.go
+++ b/internal/provider/databasegrant_resource_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
@@ -14,14 +15,17 @@ import (
 )
 
 func TestAccDatabasegrantResource(t *testing.T) {
+	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
+	if projectID == "" {
+		t.Skip("ARUBACLOUD_PROJECT_ID must be set for acceptance tests")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testCheckDatabasegrantDestroyed,
 		Steps: []resource.TestStep{
-			// Create and Read testing
 			{
-				Config: testAccDatabasegrantResourceConfig("test-databasegrant"),
+				Config: testAccDatabasegrantResourceConfig(projectID, "read"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_databasegrant.test",
@@ -31,30 +35,28 @@ func TestAccDatabasegrantResource(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						"arubacloud_databasegrant.test",
 						tfjsonpath.New("database"),
-						knownvalue.NotNull(),
+						knownvalue.StringExact("testaccgrantdb"),
 					),
 					statecheck.ExpectKnownValue(
 						"arubacloud_databasegrant.test",
 						tfjsonpath.New("role"),
-						knownvalue.NotNull(),
+						knownvalue.StringExact("read"),
 					),
 				},
 			},
-			// ImportState testing
 			{
 				ResourceName:      "arubacloud_databasegrant.test",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: importIDFromAttrs("arubacloud_databasegrant.test", "project_id", "dbaas_id", "database", "user_id"),
 			},
-			// Update and Read testing
 			{
-				Config: testAccDatabasegrantResourceConfig("test-databasegrant-updated"),
+				Config: testAccDatabasegrantResourceConfig(projectID, "write"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_databasegrant.test",
-						tfjsonpath.New("name"),
-						knownvalue.StringExact("test-databasegrant-updated"),
+						tfjsonpath.New("role"),
+						knownvalue.StringExact("write"),
 					),
 				},
 			},
@@ -89,14 +91,67 @@ func testCheckDatabasegrantDestroyed(s *terraform.State) error {
 	return nil
 }
 
-func testAccDatabasegrantResourceConfig(name string) string {
+func testAccDatabasegrantResourceConfig(projectID, role string) string {
 	return fmt.Sprintf(`
-resource "arubacloud_databasegrant" "test" {
-  project_id = "test-project-id"
-  dbaas_id   = "test-dbaas-id"
-  database   = %[1]q
-  user_id    = "test-user"
-  role       = "read"
+resource "arubacloud_vpc" "dbgrant_prereq" {
+  name       = "test-acc-dbgrant-vpc"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
 }
-`, name)
+
+resource "arubacloud_subnet" "dbgrant_prereq" {
+  name       = "test-acc-dbgrant-subnet"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+  vpc_id     = arubacloud_vpc.dbgrant_prereq.id
+  type       = "Basic"
+}
+
+resource "arubacloud_securitygroup" "dbgrant_prereq" {
+  name       = "test-acc-dbgrant-sg"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+  vpc_id     = arubacloud_vpc.dbgrant_prereq.id
+}
+
+resource "arubacloud_dbaas" "dbgrant_prereq" {
+  name       = "test-acc-dbgrant-dbaas"
+  location   = "ITBG-Bergamo"
+  zone       = "ITBG-1"
+  project_id = %[1]q
+  engine_id  = "mysql-8.0"
+  flavor     = "DBO2A4"
+
+  storage = {
+    size_gb = 20
+  }
+
+  network = {
+    vpc_uri_ref            = arubacloud_vpc.dbgrant_prereq.uri
+    subnet_uri_ref         = arubacloud_subnet.dbgrant_prereq.uri
+    security_group_uri_ref = arubacloud_securitygroup.dbgrant_prereq.uri
+  }
+}
+
+resource "arubacloud_dbaasuser" "dbgrant_prereq" {
+  project_id = %[1]q
+  dbaas_id   = arubacloud_dbaas.dbgrant_prereq.id
+  username   = "testaccgrantuser"
+  password   = "Acc3ptAbl3P@ss#01"
+}
+
+resource "arubacloud_database" "dbgrant_prereq" {
+  name       = "testaccgrantdb"
+  project_id = %[1]q
+  dbaas_id   = arubacloud_dbaas.dbgrant_prereq.id
+}
+
+resource "arubacloud_databasegrant" "test" {
+  project_id = %[1]q
+  dbaas_id   = arubacloud_dbaas.dbgrant_prereq.id
+  database   = arubacloud_database.dbgrant_prereq.name
+  user_id    = arubacloud_dbaasuser.dbgrant_prereq.username
+  role       = %[2]q
+}
+`, projectID, role)
 }

--- a/internal/provider/dbaas_resource_test.go
+++ b/internal/provider/dbaas_resource_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
@@ -14,14 +15,17 @@ import (
 )
 
 func TestAccDbaasResource(t *testing.T) {
+	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
+	if projectID == "" {
+		t.Skip("ARUBACLOUD_PROJECT_ID must be set for acceptance tests")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testCheckDbaasDestroyed,
 		Steps: []resource.TestStep{
-			// Create and Read testing
 			{
-				Config: testAccDbaasResourceConfig("test-dbaas"),
+				Config: testAccDbaasResourceConfig(projectID, "test-dbaas"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_dbaas.test",
@@ -40,16 +44,14 @@ func TestAccDbaasResource(t *testing.T) {
 					),
 				},
 			},
-			// ImportState testing
 			{
 				ResourceName:      "arubacloud_dbaas.test",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: importIDFromAttrs("arubacloud_dbaas.test", "project_id", "id"),
 			},
-			// Update and Read testing
 			{
-				Config: testAccDbaasResourceConfig("test-dbaas-updated"),
+				Config: testAccDbaasResourceConfig(projectID, "test-dbaas-updated"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_dbaas.test",
@@ -86,13 +88,34 @@ func testCheckDbaasDestroyed(s *terraform.State) error {
 	return nil
 }
 
-func testAccDbaasResourceConfig(name string) string {
+func testAccDbaasResourceConfig(projectID, name string) string {
 	return fmt.Sprintf(`
+resource "arubacloud_vpc" "dbaas_prereq" {
+  name       = "test-acc-dbaas-vpc"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+}
+
+resource "arubacloud_subnet" "dbaas_prereq" {
+  name       = "test-acc-dbaas-subnet"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+  vpc_id     = arubacloud_vpc.dbaas_prereq.id
+  type       = "Basic"
+}
+
+resource "arubacloud_securitygroup" "dbaas_prereq" {
+  name       = "test-acc-dbaas-sg"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+  vpc_id     = arubacloud_vpc.dbaas_prereq.id
+}
+
 resource "arubacloud_dbaas" "test" {
-  name       = %[1]q
-  location   = "it-1"
-  zone       = "it-1"
-  project_id = "test-project-id"
+  name       = %[2]q
+  location   = "ITBG-Bergamo"
+  zone       = "ITBG-1"
+  project_id = %[1]q
   engine_id  = "mysql-8.0"
   flavor     = "DBO2A4"
 
@@ -101,10 +124,10 @@ resource "arubacloud_dbaas" "test" {
   }
 
   network = {
-    vpc_uri_ref            = "test-vpc-uri"
-    subnet_uri_ref         = "test-subnet-uri"
-    security_group_uri_ref = "test-sg-uri"
+    vpc_uri_ref            = arubacloud_vpc.dbaas_prereq.uri
+    subnet_uri_ref         = arubacloud_subnet.dbaas_prereq.uri
+    security_group_uri_ref = arubacloud_securitygroup.dbaas_prereq.uri
   }
 }
-`, name)
+`, projectID, name)
 }


### PR DESCRIPTION
Fixes #198

Three resource test configs were missed in the previous fixture sweep (PR #189). All used hardcoded invalid values.

**dbaas_resource_test.go** — creates VPC+subnet+SG inline; location ITBG-Bergamo, zone ITBG-1; reads project_id from env.

**databasebackup_resource_test.go** — creates full inline stack (VPC+subnet+SG+DBaaS+database+backup); fixes location.

**databasegrant_resource_test.go** — creates full inline stack (VPC+subnet+SG+DBaaS+dbaasuser+database+grant); fixes the broken update step that was asserting a non-existent name attribute — update now changes role from read to write.