### PR TITLE
fix: mark dbaas billing_period as Computed to prevent perpetual plan diff (fixes #195)

### DIFF
--- a/docs/resources/dbaas.md
+++ b/docs/resources/dbaas.md
@@ -67,7 +67,7 @@ The following arguments are supported:
 
 #### Optional
 
-- `billing_period` (String) Billing cycle. Accepted values: `Hour`, `Month`, `Year`.
+- `billing_period` (String) Billing cycle. Accepted values: `Hour`, `Month`, `Year`. If omitted, the value returned by the API is used (Computed).
 - `tags` (List of String) List of string tags attached to the resource for filtering and organisation.
 - `timeout` (String) Per-resource timeout override (e.g. `"15m"`, `"1h"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.
 

--- a/internal/provider/dbaas_resource.go
+++ b/internal/provider/dbaas_resource.go
@@ -163,8 +163,9 @@ func (r *DBaaSResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				},
 			},
 			"billing_period": schema.StringAttribute{
-				MarkdownDescription: "Billing cycle. Accepted values: `Hour`, `Month`, `Year`.",
+				MarkdownDescription: "Billing cycle. Accepted values: `Hour`, `Month`, `Year`. If omitted, the value returned by the API is used (Computed).",
 				Optional:            true,
+				Computed:            true,
 				Validators:          []validator.String{stringvalidator.OneOf("Hour", "Month", "Year")},
 			},
 			"timeout": schema.StringAttribute{


### PR DESCRIPTION
Fixes #195

The API always returns a  value (defaulting to ) even when the field is omitted from config. With  only, every refresh showed a plan to remove the field because state had  but config had .

**Root cause:**  without  means Terraform expects the user to always supply the value. When they do not, any API-returned value creates a drift.

**Fix:** Add  so Terraform treats the API response as authoritative when the user omits the field.

This also fixes  and  which both failed with the same non-empty refresh plan.