### PR TITLE
fix: make containerregistry admin_user Required in schema; add to test configs (fixes #194)

### DIFF
--- a/docs/resources/containerregistry.md
+++ b/docs/resources/containerregistry.md
@@ -59,12 +59,12 @@ The following arguments are supported:
 - `name` (String) Display name for the container registry.
 - `network` (Attributes) Network resources attached to the registry. (see [below for nested schema](#nestedatt--network))
 - `project_id` (String) ID of the project that owns this resource.
+- `settings` (Attributes) Registry configuration settings. Required because `admin_user` is mandatory. (see [below for nested schema](#nestedatt--settings))
 - `storage` (Attributes) Block storage volume that backs the registry image store. (see [below for nested schema](#nestedatt--storage))
 
 #### Optional
 
 - `billing_period` (String) Billing cycle. Accepted values: `Hour`, `Month`, `Year`.
-- `settings` (Attributes) Optional registry configuration settings. (see [below for nested schema](#nestedatt--settings))
 - `tags` (List of String) List of string tags attached to the resource for filtering and organisation.
 - `timeout` (String) Per-resource timeout override (e.g. `"15m"`, `"1h"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.
 
@@ -88,21 +88,24 @@ Required:
 - `vpc_uri_ref` (String) URI of the VPC that hosts the registry (e.g., `arubacloud_vpc.example.uri`).
 
 
+<a id="nestedatt--settings"></a>
+### Nested Schema for `settings`
+
+Required:
+
+- `admin_user` (String) Administrator username for the registry. Must not be `"admin"` (reserved by the API).
+
+Optional:
+
+- `concurrent_users_flavor` (String) Concurrency tier that determines how many simultaneous push/pull sessions are supported. Accepted values: `Small`, `Medium`, `HighPerf`.
+
+
 <a id="nestedatt--storage"></a>
 ### Nested Schema for `storage`
 
 Required:
 
 - `block_storage_uri_ref` (String) URI of the block storage volume (e.g., `arubacloud_blockstorage.example.uri`).
-
-
-<a id="nestedatt--settings"></a>
-### Nested Schema for `settings`
-
-Optional:
-
-- `admin_user` (String) Administrator username for the registry.
-- `concurrent_users_flavor` (String) Concurrency tier that determines how many simultaneous push/pull sessions are supported. Accepted values: `Small`, `Medium`, `HighPerf`.
 
 
 

--- a/internal/provider/containerregistry_data_source_test.go
+++ b/internal/provider/containerregistry_data_source_test.go
@@ -114,6 +114,7 @@ resource "arubacloud_containerregistry" "test" {
   }
 
   settings = {
+    admin_user              = "registryadmin"
     concurrent_users_flavor = "Small"
   }
 }

--- a/internal/provider/containerregistry_resource.go
+++ b/internal/provider/containerregistry_resource.go
@@ -139,12 +139,12 @@ func (r *ContainerRegistryResource) Schema(ctx context.Context, req resource.Sch
 				},
 			},
 			"settings": schema.SingleNestedAttribute{
-				MarkdownDescription: "Optional registry configuration settings.",
-				Optional:            true,
+				MarkdownDescription: "Registry configuration settings. Required because `admin_user` is mandatory.",
+				Required:            true,
 				Attributes: map[string]schema.Attribute{
 					"admin_user": schema.StringAttribute{
-						MarkdownDescription: "Administrator username for the registry.",
-						Optional:            true,
+						MarkdownDescription: "Administrator username for the registry. Must not be `\"admin\"` (reserved by the API).",
+						Required:            true,
 					},
 					"concurrent_users_flavor": schema.StringAttribute{
 						MarkdownDescription: "Concurrency tier that determines how many simultaneous push/pull sessions are supported. Accepted values: `Small`, `Medium`, `HighPerf`.",

--- a/internal/provider/containerregistry_resource_test.go
+++ b/internal/provider/containerregistry_resource_test.go
@@ -149,6 +149,7 @@ resource "arubacloud_containerregistry" "test" {
   }
 
   settings = {
+    admin_user              = "registryadmin"
     concurrent_users_flavor = "Small"
   }
 }


### PR DESCRIPTION
Fixes #194

The API requires an admin_user value and rejects the reserved username admin. In PR #190 we removed admin_user from test configs to fix the reserved-value error, which revealed the opposite error: Username is required.

**Schema changes (containerregistry_resource.go):**
- settings block: Optional -> Required (because admin_user within it is required by the API)
- admin_user: Optional -> Required; description notes that admin is reserved

**Test config changes:**
- containerregistry_resource_test.go: add admin_user = registryadmin
- containerregistry_data_source_test.go: add admin_user = registryadmin

> Note: this is a breaking change for any existing configurations that omit the settings block. Users must add settings.admin_user.