### PR TITLE
fix: blockstorage type RequiresReplace; refresh state after Update; fix CheckDestroy URI (fixes #193)

### DIFF
--- a/docs/resources/blockstorage.md
+++ b/docs/resources/blockstorage.md
@@ -55,7 +55,7 @@ The following arguments are supported:
 - `name` (String) Display name for the block storage volume.
 - `project_id` (String) ID of the project that owns this resource. (Immutable — changing this value forces the resource to be destroyed and re-created.)
 - `size_gb` (Number) Size of the block storage volume in GiB. Must be a positive integer.
-- `type` (String) Storage type. Accepted values: `Standard`, `Performance`.
+- `type` (String) Storage type. Accepted values: `Standard`, `Performance`. (Immutable — changing this value forces the resource to be destroyed and re-created.)
 
 #### Optional
 

--- a/internal/provider/blockstorage_resource.go
+++ b/internal/provider/blockstorage_resource.go
@@ -95,8 +95,11 @@ func (r *BlockStorageResource) Schema(ctx context.Context, req resource.SchemaRe
 				Optional:            true,
 			},
 			"type": schema.StringAttribute{
-				MarkdownDescription: "Storage type. Accepted values: `Standard`, `Performance`.",
+				MarkdownDescription: "Storage type. Accepted values: `Standard`, `Performance`. (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"bootable": schema.BoolAttribute{
 				MarkdownDescription: "Whether this volume can be used as a boot volume for an `arubacloud_cloudserver`. Must be `true` when `image` is set.",
@@ -344,18 +347,28 @@ func (r *BlockStorageResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
-	data.Id = state.Id
-	data.ProjectID = state.ProjectID
-	data.Uri = state.Uri
-	data.Zone = state.Zone
-	data.Location = state.Location
-	data.Type = state.Type
-	data.Bootable = state.Bootable
-	data.Image = state.Image
-	data.Name = types.StringValue(updated.Name())
-	data.Tags = TagsToListPreserveNull(updated.Tags(), data.Tags)
-	data.SizeGB = types.Int64Value(int64(updated.SizeGB()))
-	data.BillingPeriod = strVal(string(updated.BillingPeriod()))
+	// Re-read from the API to ensure all computed fields reflect the server's actual state.
+	fresh, freshErr := r.client.Client.FromStorage().Volumes().Get(ctx, blockStorageRef(&state))
+	if freshErr != nil {
+		tflog.Warn(ctx, fmt.Sprintf("Failed to refresh BlockStorage after update: %v", freshErr))
+		// Fall back to combining state immutables with updated response fields.
+		data.Id = state.Id
+		data.ProjectID = state.ProjectID
+		data.Uri = state.Uri
+		data.Zone = state.Zone
+		data.Location = state.Location
+		data.Type = state.Type
+		data.Bootable = state.Bootable
+		data.Image = state.Image
+		data.Name = types.StringValue(updated.Name())
+		data.Tags = TagsToListPreserveNull(updated.Tags(), data.Tags)
+		data.SizeGB = types.Int64Value(int64(updated.SizeGB()))
+		data.BillingPeriod = strVal(string(updated.BillingPeriod()))
+	} else {
+		projectID := state.ProjectID
+		applyBlockStorageToModel(fresh, &data)
+		data.ProjectID = projectID
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/blockstorage_resource_test.go
+++ b/internal/provider/blockstorage_resource_test.go
@@ -137,9 +137,13 @@ func testCheckBlockstorageDestroyed(s *terraform.State) error {
 		if rs.Type != "arubacloud_blockstorage" {
 			continue
 		}
-		projectID := rs.Primary.Attributes["project_id"]
-		ref := aruba.URI("/projects/" + projectID + "/providers/Aruba.Storage/volumes/" + rs.Primary.ID)
-		_, err = client.Client.FromStorage().Volumes().Get(ctx, ref)
+		// Use the stored URI directly rather than reconstructing the path,
+		// since the SDK path format (/blockStorages/ vs /volumes/) can differ.
+		uri := rs.Primary.Attributes["uri"]
+		if uri == "" {
+			continue
+		}
+		_, err = client.Client.FromStorage().Volumes().Get(ctx, aruba.URI(uri))
 		if provErr := CheckResponseErr("get", "Blockstorage", err); provErr != nil {
 			if IsNotFound(provErr) {
 				continue


### PR DESCRIPTION
Fixes #193

Three bugs fixed in a single commit.

**1. type field — RequiresReplace**
The type field was not sent to the API in Update and cannot be changed in-place. The Update function was copying  (old value) back to  unconditionally, so when a plan showed a type change Terraform detected an inconsistency after apply. Adding  makes Terraform destroy + recreate on type change, which is the correct behaviour.

**2. Update — fresh GET after apply**
After a successful update the provider built state from a hand-coded mix of old state fields and the updated object response. This is fragile and prone to drift. Fix: perform a fresh GET after every successful update and call ; fall back to the manual merge only if the GET itself fails.

**3. CheckDestroy — wrong URI path**
The helper reconstructed the URI as  but the SDK internally routes on , causing the error . Fix: use  (already stored in state by the resource) directly.