### PR TITLE
fix(containerregistry): read settings via Attributes() and use valid admin username

### DIFF
--- a/internal/provider/containerregistry_data_source_test.go
+++ b/internal/provider/containerregistry_data_source_test.go
@@ -114,7 +114,7 @@ resource "arubacloud_containerregistry" "test" {
   }
 
   settings = {
-    admin_user              = "registryadmin"
+    admin_user              = "adminuser"
     concurrent_users_flavor = "Small"
   }
 }

--- a/internal/provider/containerregistry_resource.go
+++ b/internal/provider/containerregistry_resource.go
@@ -269,16 +269,16 @@ func (r *ContainerRegistryResource) Create(ctx context.Context, req resource.Cre
 	}
 
 	if !data.Settings.IsNull() && !data.Settings.IsUnknown() {
-		var settingsModel ContainerRegistrySettingsModel
-		resp.Diagnostics.Append(data.Settings.As(ctx, &settingsModel, basetypes.ObjectAsOptions{})...)
-		if resp.Diagnostics.HasError() {
-			return
+		settingsAttrs := data.Settings.Attributes()
+		if v, ok := settingsAttrs["admin_user"]; ok {
+			if s, ok2 := v.(types.String); ok2 && !s.IsNull() && !s.IsUnknown() {
+				builder = builder.WithAdminUsername(s.ValueString())
+			}
 		}
-		if !settingsModel.AdminUser.IsNull() && !settingsModel.AdminUser.IsUnknown() {
-			builder = builder.WithAdminUsername(settingsModel.AdminUser.ValueString())
-		}
-		if !settingsModel.ConcurrentUsersFlavor.IsNull() && !settingsModel.ConcurrentUsersFlavor.IsUnknown() {
-			builder = builder.OfSize(aruba.ContainerRegistrySizeFlavor(settingsModel.ConcurrentUsersFlavor.ValueString()))
+		if v, ok := settingsAttrs["concurrent_users_flavor"]; ok {
+			if s, ok2 := v.(types.String); ok2 && !s.IsNull() && !s.IsUnknown() {
+				builder = builder.OfSize(aruba.ContainerRegistrySizeFlavor(s.ValueString()))
+			}
 		}
 	}
 
@@ -416,16 +416,16 @@ func (r *ContainerRegistryResource) Update(ctx context.Context, req resource.Upd
 	}
 
 	if !data.Settings.IsNull() && !data.Settings.IsUnknown() {
-		var settingsModel ContainerRegistrySettingsModel
-		resp.Diagnostics.Append(data.Settings.As(ctx, &settingsModel, basetypes.ObjectAsOptions{})...)
-		if resp.Diagnostics.HasError() {
-			return
+		settingsAttrs := data.Settings.Attributes()
+		if v, ok := settingsAttrs["admin_user"]; ok {
+			if s, ok2 := v.(types.String); ok2 && !s.IsNull() && !s.IsUnknown() {
+				registry.WithAdminUsername(s.ValueString())
+			}
 		}
-		if !settingsModel.AdminUser.IsNull() {
-			registry.WithAdminUsername(settingsModel.AdminUser.ValueString())
-		}
-		if !settingsModel.ConcurrentUsersFlavor.IsNull() {
-			registry.OfSize(aruba.ContainerRegistrySizeFlavor(settingsModel.ConcurrentUsersFlavor.ValueString()))
+		if v, ok := settingsAttrs["concurrent_users_flavor"]; ok {
+			if s, ok2 := v.(types.String); ok2 && !s.IsNull() && !s.IsUnknown() {
+				registry.OfSize(aruba.ContainerRegistrySizeFlavor(s.ValueString()))
+			}
 		}
 	}
 

--- a/internal/provider/containerregistry_resource_test.go
+++ b/internal/provider/containerregistry_resource_test.go
@@ -149,7 +149,7 @@ resource "arubacloud_containerregistry" "test" {
   }
 
   settings = {
-    admin_user              = "registryadmin"
+    admin_user              = "adminuser"
     concurrent_users_flavor = "Small"
   }
 }


### PR DESCRIPTION
## Summary

- Replace `data.Settings.As(ctx, &settingsModel, ObjectAsOptions{})` with direct `Attributes()` map access in Create and Update, matching the pattern used by dbaas_resource.go for storage/network. This prevents admin_user from being silently null if As() encounters a type mismatch during plan deserialization.
- Change test username from `"registryadmin"` to `"adminuser"` — the value used by the SDK example — to avoid any potential reserved-substring rejection.

Closes #207

## Test plan
- [ ] TestAccContainerregistryResource passes (admin_user reaches the API)
- [ ] TestAccContainerregistryDataSource passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)