### PR TITLE
fix(dbaas): prevent billing_period drift with useStateIfConfigNull plan modifier

### DIFF
--- a/internal/provider/dbaas_resource.go
+++ b/internal/provider/dbaas_resource.go
@@ -166,6 +166,7 @@ func (r *DBaaSResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				MarkdownDescription: "Billing cycle. Accepted values: `Hour`, `Month`, `Year`. If omitted, the value returned by the API is used (Computed).",
 				Optional:            true,
 				Computed:            true,
+				PlanModifiers:       []planmodifier.String{useStateIfConfigNull{}},
 				Validators:          []validator.String{stringvalidator.OneOf("Hour", "Month", "Year")},
 			},
 			"timeout": schema.StringAttribute{

--- a/internal/provider/provider_helpers.go
+++ b/internal/provider/provider_helpers.go
@@ -1,10 +1,41 @@
 package provider
 
 import (
+	"context"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+// useStateIfConfigNull is a string plan modifier that preserves the prior state
+// value when the configuration omits the attribute (config value is null).
+//
+// Without this modifier, Optional+Computed attributes cause a perpetual plan diff
+// when the API always returns a value (e.g. billing_period="Hour") but the user's
+// config does not set the attribute: the Terraform Plugin Framework uses the
+// config null as the planned value, overwriting the state on every refresh.
+type useStateIfConfigNull struct{}
+
+var _ planmodifier.String = useStateIfConfigNull{}
+
+func (m useStateIfConfigNull) Description(_ context.Context) string {
+	return "Use the prior state value when the configuration does not set the attribute."
+}
+
+func (m useStateIfConfigNull) MarkdownDescription(_ context.Context) string {
+	return "Use the prior state value when the configuration does not set the attribute."
+}
+
+func (m useStateIfConfigNull) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	if !req.ConfigValue.IsNull() {
+		return // config explicitly sets a value; use it
+	}
+	if req.StateValue.IsNull() || req.StateValue.IsUnknown() {
+		return // nothing in state to preserve
+	}
+	resp.PlanValue = req.StateValue
+}
 
 // effectiveTimeout returns the resource-level timeout if set and valid,
 // otherwise falls back to the provider-level timeout.


### PR DESCRIPTION
## Summary

With `Optional+Computed` and no plan modifier, Terraform Plugin Framework uses the config null value as the planned value, overwriting the API-returned state on every refresh cycle. Both `TestAccDbaasDataSource` and `TestAccDatabaseDataSource` fail with:

    ~ resource arubacloud_dbaas test {
        - billing_period = "Hour" -> null

**Fix**: Add a reusable `useStateIfConfigNull` plan modifier (in `provider_helpers.go`) that preserves the prior state value when the config omits the attribute. Apply it to `billing_period` in the DBaaS resource schema.

Closes #208

## Test plan
- [ ] TestAccDbaasDataSource passes (no billing_period drift in refresh plan)
- [ ] TestAccDatabaseDataSource passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)