### PR TITLE
fix(dbaasuser): poll for user API readiness before Create (propagation delay)

### DIFF
--- a/internal/provider/dbaasuser_resource.go
+++ b/internal/provider/dbaasuser_resource.go
@@ -119,6 +119,39 @@ func (r *DBaaSUserResource) Create(ctx context.Context, req resource.CreateReque
 
 	dbaasURI := "/projects/" + projectID + "/providers/Aruba.Database/dbaas/" + dbaasID
 
+	// Poll until the DBaaS user management API is ready to accept requests.
+	// After WaitUntilReady the DBaaS may still reject user creation with a
+	// misleading "Username invalid / Password requirements" error while the
+	// user API initialises. Probe by attempting to GET the not-yet-existing
+	// user and wait for a 404 response, which proves the API is up.
+	const dbaasUserReadyInterval = 5 * time.Second
+	const dbaasUserReadyMaxAttempts = 30 // up to 150 s
+
+	for attempt := 0; attempt < dbaasUserReadyMaxAttempts; attempt++ {
+		_, probeErr := r.client.Client.FromDatabase().Users().Get(ctx,
+			aruba.URI(dbaasURI+"/users/"+username))
+		pe := CheckResponseErr("get", "DBaaSUser", probeErr)
+		if pe != nil && IsNotFound(pe) {
+			break // 404 means the user API is responding; user does not exist yet (expected)
+		}
+		if probeErr == nil {
+			break // user somehow already exists
+		}
+		if attempt == dbaasUserReadyMaxAttempts-1 {
+			break // timed out; proceed and let Create report any remaining error
+		}
+		tflog.Info(ctx, "waiting for DBaaS user API to become ready", map[string]interface{}{
+			"dbaas_id": dbaasID,
+			"attempt":  attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Context cancelled", "Cancelled while waiting for DBaaS user API readiness")
+			return
+		case <-time.After(dbaasUserReadyInterval):
+		}
+	}
+
 	var user *aruba.User
 	if createErr := CreateWithTransientRetry(ctx, func() error {
 		var err error


### PR DESCRIPTION
## Summary

After `WaitUntilReady` the DBaaS cluster may still reject user creation with a misleading validation error (`Username contains invalid character / Password requirements not met`) while the user management API initialises internally. This is the same class of propagation delay that was fixed for DatabaseBackup (PR #205).

**Fix**: Before calling `Users().Create()`, probe the user API by attempting to GET the not-yet-existing user. A 404 response proves the API is up and accepting requests. Poll up to 150 s (30 × 5 s).

Closes #209

## Test plan
- [ ] TestAccDbaasuserDataSource passes (user created successfully after wait)
- [ ] TestAccDatabasegrantDataSource passes (user part of grant stack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)