### PR TITLE
fix(tests): require ARUBACLOUD_DBAAS_ID for DBaaS-dependent resource tests

### DIFF
--- a/docs/guides/acceptance-testing.md
+++ b/docs/guides/acceptance-testing.md
@@ -89,7 +89,7 @@ Some resource tests have additional prerequisites:
 | Variable | Required by |
 |---|---|
 | `ARUBACLOUD_OS_IMAGE_ID` | `TestAccBlockStorageResource_Bootable`, `TestAccCloudserverResource` — OS image used to create a bootable disk |
-| `ARUBACLOUD_DBAAS_ID` | `TestAccDatabaseResource` — existing DBaaS cluster to create a database in |
+| `ARUBACLOUD_DBAAS_ID` | `TestAccDatabaseResource`, `TestAccDatabasebackupResource`, `TestAccDatabasegrantResource`, `TestAccDbaasuserResource` — existing DBaaS cluster used as a prerequisite to avoid zone-capacity conflicts when multiple DBaaS tests run sequentially |
 
 ### Data Source Tests
 

--- a/internal/provider/databasebackup_resource_test.go
+++ b/internal/provider/databasebackup_resource_test.go
@@ -16,8 +16,9 @@ import (
 
 func TestAccDatabasebackupResource(t *testing.T) {
 	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
-	if projectID == "" {
-		t.Skip("ARUBACLOUD_PROJECT_ID must be set for acceptance tests")
+	dbaasID := os.Getenv("ARUBACLOUD_DBAAS_ID")
+	if projectID == "" || dbaasID == "" {
+		t.Skip("ARUBACLOUD_PROJECT_ID and ARUBACLOUD_DBAAS_ID must be set for acceptance tests")
 	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -25,7 +26,7 @@ func TestAccDatabasebackupResource(t *testing.T) {
 		CheckDestroy:             testCheckDatabasebackupDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatabasebackupResourceConfig(projectID, "test-databasebackup"),
+				Config: testAccDatabasebackupResourceConfig(projectID, dbaasID, "test-databasebackup"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_databasebackup.test",
@@ -51,7 +52,7 @@ func TestAccDatabasebackupResource(t *testing.T) {
 				ImportStateIdFunc: importIDFromAttrs("arubacloud_databasebackup.test", "project_id", "id"),
 			},
 			{
-				Config: testAccDatabasebackupResourceConfig(projectID, "test-databasebackup-updated"),
+				Config: testAccDatabasebackupResourceConfig(projectID, dbaasID, "test-databasebackup-updated"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_databasebackup.test",
@@ -88,62 +89,22 @@ func testCheckDatabasebackupDestroyed(s *terraform.State) error {
 	return nil
 }
 
-func testAccDatabasebackupResourceConfig(projectID, name string) string {
+func testAccDatabasebackupResourceConfig(projectID, dbaasID, name string) string {
 	return fmt.Sprintf(`
-resource "arubacloud_vpc" "dbbackup_prereq" {
-  name       = "test-acc-dbbackup-vpc"
-  location   = "ITBG-Bergamo"
-  project_id = %[1]q
-}
-
-resource "arubacloud_subnet" "dbbackup_prereq" {
-  name       = "test-acc-dbbackup-subnet"
-  location   = "ITBG-Bergamo"
-  project_id = %[1]q
-  vpc_id     = arubacloud_vpc.dbbackup_prereq.id
-  type       = "Basic"
-}
-
-resource "arubacloud_securitygroup" "dbbackup_prereq" {
-  name       = "test-acc-dbbackup-sg"
-  location   = "ITBG-Bergamo"
-  project_id = %[1]q
-  vpc_id     = arubacloud_vpc.dbbackup_prereq.id
-}
-
-resource "arubacloud_dbaas" "dbbackup_prereq" {
-  name       = "test-acc-dbbackup-dbaas"
-  location   = "ITBG-Bergamo"
-  zone       = "ITBG-1"
-  project_id = %[1]q
-  engine_id  = "mysql-8.0"
-  flavor     = "DBO2A4"
-
-  storage = {
-    size_gb = 20
-  }
-
-  network = {
-    vpc_uri_ref            = arubacloud_vpc.dbbackup_prereq.uri
-    subnet_uri_ref         = arubacloud_subnet.dbbackup_prereq.uri
-    security_group_uri_ref = arubacloud_securitygroup.dbbackup_prereq.uri
-  }
-}
-
 resource "arubacloud_database" "dbbackup_prereq" {
   name       = "testaccdbbackupdb"
   project_id = %[1]q
-  dbaas_id   = arubacloud_dbaas.dbbackup_prereq.id
+  dbaas_id   = %[2]q
 }
 
 resource "arubacloud_databasebackup" "test" {
-  name           = %[2]q
+  name           = %[3]q
   project_id     = %[1]q
   location       = "ITBG-Bergamo"
   zone           = "ITBG-1"
-  dbaas_id       = arubacloud_dbaas.dbbackup_prereq.id
+  dbaas_id       = %[2]q
   database       = arubacloud_database.dbbackup_prereq.name
   billing_period = "Hour"
 }
-`, projectID, name)
+`, projectID, dbaasID, name)
 }

--- a/internal/provider/databasegrant_resource_test.go
+++ b/internal/provider/databasegrant_resource_test.go
@@ -16,8 +16,9 @@ import (
 
 func TestAccDatabasegrantResource(t *testing.T) {
 	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
-	if projectID == "" {
-		t.Skip("ARUBACLOUD_PROJECT_ID must be set for acceptance tests")
+	dbaasID := os.Getenv("ARUBACLOUD_DBAAS_ID")
+	if projectID == "" || dbaasID == "" {
+		t.Skip("ARUBACLOUD_PROJECT_ID and ARUBACLOUD_DBAAS_ID must be set for acceptance tests")
 	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -25,7 +26,7 @@ func TestAccDatabasegrantResource(t *testing.T) {
 		CheckDestroy:             testCheckDatabasegrantDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatabasegrantResourceConfig(projectID, "read"),
+				Config: testAccDatabasegrantResourceConfig(projectID, dbaasID, "read"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_databasegrant.test",
@@ -51,7 +52,7 @@ func TestAccDatabasegrantResource(t *testing.T) {
 				ImportStateIdFunc: importIDFromAttrs("arubacloud_databasegrant.test", "project_id", "dbaas_id", "database", "user_id"),
 			},
 			{
-				Config: testAccDatabasegrantResourceConfig(projectID, "write"),
+				Config: testAccDatabasegrantResourceConfig(projectID, dbaasID, "write"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_databasegrant.test",
@@ -91,51 +92,11 @@ func testCheckDatabasegrantDestroyed(s *terraform.State) error {
 	return nil
 }
 
-func testAccDatabasegrantResourceConfig(projectID, role string) string {
+func testAccDatabasegrantResourceConfig(projectID, dbaasID, role string) string {
 	return fmt.Sprintf(`
-resource "arubacloud_vpc" "dbgrant_prereq" {
-  name       = "test-acc-dbgrant-vpc"
-  location   = "ITBG-Bergamo"
-  project_id = %[1]q
-}
-
-resource "arubacloud_subnet" "dbgrant_prereq" {
-  name       = "test-acc-dbgrant-subnet"
-  location   = "ITBG-Bergamo"
-  project_id = %[1]q
-  vpc_id     = arubacloud_vpc.dbgrant_prereq.id
-  type       = "Basic"
-}
-
-resource "arubacloud_securitygroup" "dbgrant_prereq" {
-  name       = "test-acc-dbgrant-sg"
-  location   = "ITBG-Bergamo"
-  project_id = %[1]q
-  vpc_id     = arubacloud_vpc.dbgrant_prereq.id
-}
-
-resource "arubacloud_dbaas" "dbgrant_prereq" {
-  name       = "test-acc-dbgrant-dbaas"
-  location   = "ITBG-Bergamo"
-  zone       = "ITBG-1"
-  project_id = %[1]q
-  engine_id  = "mysql-8.0"
-  flavor     = "DBO2A4"
-
-  storage = {
-    size_gb = 20
-  }
-
-  network = {
-    vpc_uri_ref            = arubacloud_vpc.dbgrant_prereq.uri
-    subnet_uri_ref         = arubacloud_subnet.dbgrant_prereq.uri
-    security_group_uri_ref = arubacloud_securitygroup.dbgrant_prereq.uri
-  }
-}
-
 resource "arubacloud_dbaasuser" "dbgrant_prereq" {
   project_id = %[1]q
-  dbaas_id   = arubacloud_dbaas.dbgrant_prereq.id
+  dbaas_id   = %[2]q
   username   = "testaccgrantuser"
   password   = "Acc3ptAbl3P@ss#01"
 }
@@ -143,15 +104,15 @@ resource "arubacloud_dbaasuser" "dbgrant_prereq" {
 resource "arubacloud_database" "dbgrant_prereq" {
   name       = "testaccgrantdb"
   project_id = %[1]q
-  dbaas_id   = arubacloud_dbaas.dbgrant_prereq.id
+  dbaas_id   = %[2]q
 }
 
 resource "arubacloud_databasegrant" "test" {
   project_id = %[1]q
-  dbaas_id   = arubacloud_dbaas.dbgrant_prereq.id
+  dbaas_id   = %[2]q
   database   = arubacloud_database.dbgrant_prereq.name
   user_id    = arubacloud_dbaasuser.dbgrant_prereq.username
-  role       = %[2]q
+  role       = %[3]q
 }
-`, projectID, role)
+`, projectID, dbaasID, role)
 }

--- a/internal/provider/dbaasuser_resource_test.go
+++ b/internal/provider/dbaasuser_resource_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
@@ -14,14 +15,18 @@ import (
 )
 
 func TestAccDbaasuserResource(t *testing.T) {
+	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
+	dbaasID := os.Getenv("ARUBACLOUD_DBAAS_ID")
+	if projectID == "" || dbaasID == "" {
+		t.Skip("ARUBACLOUD_PROJECT_ID and ARUBACLOUD_DBAAS_ID must be set for acceptance tests")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testCheckDbaasuserDestroyed,
 		Steps: []resource.TestStep{
-			// Create and Read testing
 			{
-				Config: testAccDbaasuserResourceConfig("test-dbaasuser"),
+				Config: testAccDbaasuserResourceConfig(projectID, dbaasID, "testaccdbuser"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_dbaasuser.test",
@@ -31,33 +36,21 @@ func TestAccDbaasuserResource(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						"arubacloud_dbaasuser.test",
 						tfjsonpath.New("username"),
-						knownvalue.NotNull(),
+						knownvalue.StringExact("testaccdbuser"),
 					),
 					statecheck.ExpectKnownValue(
 						"arubacloud_dbaasuser.test",
 						tfjsonpath.New("dbaas_id"),
-						knownvalue.NotNull(),
+						knownvalue.StringExact(dbaasID),
 					),
 				},
 			},
-			// ImportState testing
 			{
 				ResourceName:            "arubacloud_dbaasuser.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"password"},
 				ImportStateIdFunc:       importIDFromAttrs("arubacloud_dbaasuser.test", "project_id", "dbaas_id", "id"),
-			},
-			// Update and Read testing
-			{
-				Config: testAccDbaasuserResourceConfig("test-dbaasuser-updated"),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(
-						"arubacloud_dbaasuser.test",
-						tfjsonpath.New("name"),
-						knownvalue.StringExact("test-dbaasuser-updated"),
-					),
-				},
 			},
 		},
 	})
@@ -88,13 +81,13 @@ func testCheckDbaasuserDestroyed(s *terraform.State) error {
 	return nil
 }
 
-func testAccDbaasuserResourceConfig(name string) string {
+func testAccDbaasuserResourceConfig(projectID, dbaasID, username string) string {
 	return fmt.Sprintf(`
 resource "arubacloud_dbaasuser" "test" {
-  project_id = "test-project-id"
-  dbaas_id   = "test-dbaas-id"
-  username   = %[1]q
-  password   = "test-password-123"
+  project_id = %[1]q
+  dbaas_id   = %[2]q
+  username   = %[3]q
+  password   = "Acc3ptAbl3P@ss#01"
 }
-`, name)
+`, projectID, dbaasID, username)
 }

--- a/templates/guides/acceptance-testing.md
+++ b/templates/guides/acceptance-testing.md
@@ -89,7 +89,7 @@ Some resource tests have additional prerequisites:
 | Variable | Required by |
 |---|---|
 | `ARUBACLOUD_OS_IMAGE_ID` | `TestAccBlockStorageResource_Bootable`, `TestAccCloudserverResource` — OS image used to create a bootable disk |
-| `ARUBACLOUD_DBAAS_ID` | `TestAccDatabaseResource` — existing DBaaS cluster to create a database in |
+| `ARUBACLOUD_DBAAS_ID` | `TestAccDatabaseResource`, `TestAccDatabasebackupResource`, `TestAccDatabasegrantResource`, `TestAccDbaasuserResource` — existing DBaaS cluster used as a prerequisite to avoid zone-capacity conflicts when multiple DBaaS tests run sequentially |
 
 ### Data Source Tests
 


### PR DESCRIPTION
Switch databasebackup, databasegrant, and dbaasuser resource tests to use a pre-existing DBaaS via ARUBACLOUD_DBAAS_ID (same pattern as TestAccDatabaseResource) to avoid zone-capacity conflicts when DBaaS data source test teardowns are still in progress. Also rewrites the broken TestAccDbaasuserResource that had hardcoded placeholder IDs. Docs updated. Closes #211