### PR TITLE
fix(tests): replace hardcoded placeholder location/project_id in 11 resource tests

### DIFF
--- a/docs/guides/acceptance-testing.md
+++ b/docs/guides/acceptance-testing.md
@@ -90,6 +90,8 @@ Some resource tests have additional prerequisites:
 |---|---|
 | `ARUBACLOUD_OS_IMAGE_ID` | `TestAccBlockStorageResource_Bootable`, `TestAccCloudserverResource` — OS image used to create a bootable disk |
 | `ARUBACLOUD_DBAAS_ID` | `TestAccDatabaseResource`, `TestAccDatabasebackupResource`, `TestAccDatabasegrantResource`, `TestAccDbaasuserResource` — existing DBaaS cluster used as a prerequisite to avoid zone-capacity conflicts when multiple DBaaS tests run sequentially |
+| `ARUBACLOUD_BACKUP_ID` | `TestAccRestoreResource` — existing block storage backup to restore from |
+| `ARUBACLOUD_VPNTUNNEL_ID` | `TestAccVpnrouteResource` — existing VPN tunnel to attach routes to |
 
 ### Data Source Tests
 

--- a/internal/provider/restore_resource_test.go
+++ b/internal/provider/restore_resource_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
@@ -14,6 +15,11 @@ import (
 )
 
 func TestAccRestoreResource(t *testing.T) {
+	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
+	backupID := os.Getenv("ARUBACLOUD_BACKUP_ID")
+	if projectID == "" || backupID == "" {
+		t.Skip("ARUBACLOUD_PROJECT_ID and ARUBACLOUD_BACKUP_ID must be set for acceptance tests")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -21,7 +27,7 @@ func TestAccRestoreResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccRestoreResourceConfig("test-restore"),
+				Config: testAccRestoreResourceConfig(projectID, backupID, "test-restore"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_restore.test",
@@ -49,7 +55,7 @@ func TestAccRestoreResource(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: testAccRestoreResourceConfig("test-restore-updated"),
+				Config: testAccRestoreResourceConfig(projectID, backupID, "test-restore-updated"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_restore.test",
@@ -87,14 +93,24 @@ func testCheckRestoreDestroyed(s *terraform.State) error {
 	return nil
 }
 
-func testAccRestoreResourceConfig(name string) string {
+func testAccRestoreResourceConfig(projectID, backupID, name string) string {
 	return fmt.Sprintf(`
-resource "arubacloud_restore" "test" {
-  name       = %[1]q
-  location   = "it-1"
-  project_id = "test-project-id"
-  backup_id  = "test-backup-id"
-  volume_id  = "test-volume-id"
+resource "arubacloud_blockstorage" "restore_target" {
+  name           = "test-acc-restore-vol"
+  project_id     = %[1]q
+  location       = "ITBG-Bergamo"
+  size_gb        = 10
+  billing_period = "Hour"
+  zone           = "ITBG-1"
+  type           = "Standard"
 }
-`, name)
+
+resource "arubacloud_restore" "test" {
+  name       = %[3]q
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+  backup_id  = %[2]q
+  volume_id  = arubacloud_blockstorage.restore_target.id
+}
+`, projectID, backupID, name)
 }

--- a/internal/provider/schedulejob_resource_test.go
+++ b/internal/provider/schedulejob_resource_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
@@ -14,6 +15,10 @@ import (
 )
 
 func TestAccSchedulejobResource(t *testing.T) {
+	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
+	if projectID == "" {
+		t.Skip("ARUBACLOUD_PROJECT_ID must be set for acceptance tests")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -21,7 +26,7 @@ func TestAccSchedulejobResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccSchedulejobResourceConfig("test-schedulejob"),
+				Config: testAccSchedulejobResourceConfig(projectID, "test-schedulejob"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_schedulejob.test",
@@ -49,7 +54,7 @@ func TestAccSchedulejobResource(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: testAccSchedulejobResourceConfig("test-schedulejob-updated"),
+				Config: testAccSchedulejobResourceConfig(projectID, "test-schedulejob-updated"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_schedulejob.test",
@@ -86,18 +91,18 @@ func testCheckSchedulejobDestroyed(s *terraform.State) error {
 	return nil
 }
 
-func testAccSchedulejobResourceConfig(name string) string {
+func testAccSchedulejobResourceConfig(projectID, name string) string {
 	return fmt.Sprintf(`
 resource "arubacloud_schedulejob" "test" {
-  name       = %[1]q
-  project_id = "test-project-id"
-  location   = "it-1"
+  name       = %[2]q
+  project_id = %[1]q
+  location   = "ITBG-Bergamo"
 
   properties = {
     schedule_job_type = "OneShot"
-    schedule_at       = "2025-12-31T23:59:59Z"
+    schedule_at       = "2030-12-31T23:59:59Z"
     steps             = []
   }
 }
-`, name)
+`, projectID, name)
 }

--- a/internal/provider/securitygroup_resource_test.go
+++ b/internal/provider/securitygroup_resource_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
@@ -14,6 +15,10 @@ import (
 )
 
 func TestAccSecuritygroupResource(t *testing.T) {
+	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
+	if projectID == "" {
+		t.Skip("ARUBACLOUD_PROJECT_ID must be set for acceptance tests")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -21,7 +26,7 @@ func TestAccSecuritygroupResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccSecuritygroupResourceConfig("test-securitygroup"),
+				Config: testAccSecuritygroupResourceConfig(projectID, "test-securitygroup"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_securitygroup.test",
@@ -49,7 +54,7 @@ func TestAccSecuritygroupResource(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: testAccSecuritygroupResourceConfig("test-securitygroup-updated"),
+				Config: testAccSecuritygroupResourceConfig(projectID, "test-securitygroup-updated"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_securitygroup.test",
@@ -87,13 +92,19 @@ func testCheckSecuritygroupDestroyed(s *terraform.State) error {
 	return nil
 }
 
-func testAccSecuritygroupResourceConfig(name string) string {
+func testAccSecuritygroupResourceConfig(projectID, name string) string {
 	return fmt.Sprintf(`
-resource "arubacloud_securitygroup" "test" {
-  name       = %[1]q
-  location   = "it-1"
-  project_id = "test-project-id"
-  vpc_id     = "test-vpc-id"
+resource "arubacloud_vpc" "sg_prereq" {
+  name       = "test-acc-sg-vpc"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
 }
-`, name)
+
+resource "arubacloud_securitygroup" "test" {
+  name       = %[2]q
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+  vpc_id     = arubacloud_vpc.sg_prereq.id
+}
+`, projectID, name)
 }

--- a/internal/provider/securityrule_resource_test.go
+++ b/internal/provider/securityrule_resource_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
@@ -124,6 +125,10 @@ func TestProtocolNormalizePlanModifier(t *testing.T) {
 }
 
 func TestAccSecurityruleResource(t *testing.T) {
+	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
+	if projectID == "" {
+		t.Skip("ARUBACLOUD_PROJECT_ID must be set for acceptance tests")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -131,7 +136,7 @@ func TestAccSecurityruleResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccSecurityruleResourceConfig("test-securityrule"),
+				Config: testAccSecurityruleResourceConfig(projectID, "test-securityrule"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_securityrule.test",
@@ -164,7 +169,7 @@ func TestAccSecurityruleResource(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: testAccSecurityruleResourceConfig("test-securityrule-updated"),
+				Config: testAccSecurityruleResourceConfig(projectID, "test-securityrule-updated"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_securityrule.test",
@@ -203,24 +208,37 @@ func testCheckSecurityruleDestroyed(s *terraform.State) error {
 	return nil
 }
 
-func testAccSecurityruleResourceConfig(name string) string {
+func testAccSecurityruleResourceConfig(projectID, name string) string {
 	return fmt.Sprintf(`
+resource "arubacloud_vpc" "sr_prereq" {
+  name       = "test-acc-sr-vpc"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+}
+
+resource "arubacloud_securitygroup" "sr_prereq" {
+  name       = "test-acc-sr-sg"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+  vpc_id     = arubacloud_vpc.sr_prereq.id
+}
+
 resource "arubacloud_securityrule" "test" {
-  name               = %[1]q
-  location           = "it-1"
-  project_id         = "test-project-id"
-  vpc_id             = "test-vpc-id"
-  security_group_id  = "test-sg-id"
-  
+  name              = %[2]q
+  location          = "ITBG-Bergamo"
+  project_id        = %[1]q
+  vpc_id            = arubacloud_vpc.sr_prereq.id
+  security_group_id = arubacloud_securitygroup.sr_prereq.id
+
   properties = {
     direction = "Ingress"
     protocol  = "TCP"
     port      = "80"
     target = {
-      kind  = "IP"
+      kind  = "Ip"
       value = "0.0.0.0/0"
     }
   }
 }
-`, name)
+`, projectID, name)
 }

--- a/internal/provider/snapshot_resource_test.go
+++ b/internal/provider/snapshot_resource_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
@@ -14,6 +15,10 @@ import (
 )
 
 func TestAccSnapshotResource(t *testing.T) {
+	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
+	if projectID == "" {
+		t.Skip("ARUBACLOUD_PROJECT_ID must be set for acceptance tests")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -21,7 +26,7 @@ func TestAccSnapshotResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccSnapshotResourceConfig("test-snapshot"),
+				Config: testAccSnapshotResourceConfig(projectID, "test-snapshot"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_snapshot.test",
@@ -49,7 +54,7 @@ func TestAccSnapshotResource(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: testAccSnapshotResourceConfig("test-snapshot-updated"),
+				Config: testAccSnapshotResourceConfig(projectID, "test-snapshot-updated"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_snapshot.test",
@@ -86,14 +91,24 @@ func testCheckSnapshotDestroyed(s *terraform.State) error {
 	return nil
 }
 
-func testAccSnapshotResourceConfig(name string) string {
+func testAccSnapshotResourceConfig(projectID, name string) string {
 	return fmt.Sprintf(`
-resource "arubacloud_snapshot" "test" {
-  name           = %[1]q
-  project_id     = "test-project-id"
-  location       = "it-1"
+resource "arubacloud_blockstorage" "snap_prereq" {
+  name           = "test-acc-snap-vol"
+  project_id     = %[1]q
+  location       = "ITBG-Bergamo"
+  size_gb        = 10
   billing_period = "Hour"
-  volume_uri     = "/projects/test-project-id/providers/Aruba.Storage/volumes/test-volume-id"
+  zone           = "ITBG-1"
+  type           = "Standard"
 }
-`, name)
+
+resource "arubacloud_snapshot" "test" {
+  name           = %[2]q
+  project_id     = %[1]q
+  location       = "ITBG-Bergamo"
+  billing_period = "Hour"
+  volume_uri     = arubacloud_blockstorage.snap_prereq.uri
+}
+`, projectID, name)
 }

--- a/internal/provider/subnet_resource_test.go
+++ b/internal/provider/subnet_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
 	"testing"
 
 	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
@@ -15,6 +16,10 @@ import (
 )
 
 func TestAccSubnetResource(t *testing.T) {
+	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
+	if projectID == "" {
+		t.Skip("ARUBACLOUD_PROJECT_ID must be set for acceptance tests")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -22,7 +27,7 @@ func TestAccSubnetResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccSubnetResourceConfig("test-subnet"),
+				Config: testAccSubnetResourceConfig(projectID, "test-subnet"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_subnet.test",
@@ -55,7 +60,7 @@ func TestAccSubnetResource(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: testAccSubnetResourceConfig("test-subnet-updated"),
+				Config: testAccSubnetResourceConfig(projectID, "test-subnet-updated"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_subnet.test",
@@ -93,20 +98,26 @@ func testCheckSubnetDestroyed(s *terraform.State) error {
 	return nil
 }
 
-func testAccSubnetResourceConfig(name string) string {
+func testAccSubnetResourceConfig(projectID, name string) string {
 	return fmt.Sprintf(`
+resource "arubacloud_vpc" "subnet_prereq" {
+  name       = "test-acc-subnet-vpc"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+}
+
 resource "arubacloud_subnet" "test" {
-  name       = %[1]q
-  location   = "it-1"
-  project_id = "test-project-id"
-  vpc_id     = "test-vpc-id"
+  name       = %[2]q
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+  vpc_id     = arubacloud_vpc.subnet_prereq.id
   type       = "Basic"
 
   network = {
     address = "10.0.0.0/24"
   }
 }
-`, name)
+`, projectID, name)
 }
 
 // ── cidrContains ──────────────────────────────────────────────────────────────

--- a/internal/provider/vpc_resource_test.go
+++ b/internal/provider/vpc_resource_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
@@ -14,6 +15,10 @@ import (
 )
 
 func TestAccVpcResource(t *testing.T) {
+	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
+	if projectID == "" {
+		t.Skip("ARUBACLOUD_PROJECT_ID must be set for acceptance tests")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -21,7 +26,7 @@ func TestAccVpcResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccVpcResourceConfig("test-vpc"),
+				Config: testAccVpcResourceConfig(projectID, "test-vpc"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_vpc.test",
@@ -54,7 +59,7 @@ func TestAccVpcResource(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: testAccVpcResourceConfig("test-vpc-updated"),
+				Config: testAccVpcResourceConfig(projectID, "test-vpc-updated"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_vpc.test",
@@ -91,12 +96,12 @@ func testCheckVpcDestroyed(s *terraform.State) error {
 	return nil
 }
 
-func testAccVpcResourceConfig(name string) string {
+func testAccVpcResourceConfig(projectID, name string) string {
 	return fmt.Sprintf(`
 resource "arubacloud_vpc" "test" {
-  name       = %[1]q
-  location   = "it-1"
-  project_id = "test-project-id"
+  name       = %[2]q
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
 }
 `, name)
 }

--- a/internal/provider/vpc_resource_test.go
+++ b/internal/provider/vpc_resource_test.go
@@ -103,5 +103,5 @@ resource "arubacloud_vpc" "test" {
   location   = "ITBG-Bergamo"
   project_id = %[1]q
 }
-`, name)
+`, projectID, name)
 }

--- a/internal/provider/vpcpeering_resource_test.go
+++ b/internal/provider/vpcpeering_resource_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
@@ -14,6 +15,10 @@ import (
 )
 
 func TestAccVpcpeeringResource(t *testing.T) {
+	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
+	if projectID == "" {
+		t.Skip("ARUBACLOUD_PROJECT_ID must be set for acceptance tests")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -21,7 +26,7 @@ func TestAccVpcpeeringResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccVpcpeeringResourceConfig("test-vpcpeering"),
+				Config: testAccVpcpeeringResourceConfig(projectID, "test-vpcpeering"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_vpcpeering.test",
@@ -49,7 +54,7 @@ func TestAccVpcpeeringResource(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: testAccVpcpeeringResourceConfig("test-vpcpeering-updated"),
+				Config: testAccVpcpeeringResourceConfig(projectID, "test-vpcpeering-updated"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_vpcpeering.test",
@@ -87,14 +92,26 @@ func testCheckVpcpeeringDestroyed(s *terraform.State) error {
 	return nil
 }
 
-func testAccVpcpeeringResourceConfig(name string) string {
+func testAccVpcpeeringResourceConfig(projectID, name string) string {
 	return fmt.Sprintf(`
-resource "arubacloud_vpcpeering" "test" {
-  name       = %[1]q
-  location   = "it-1"
-  project_id = "test-project-id"
-  vpc_id     = "test-vpc-id"
-  peer_vpc   = "peer-vpc-id"
+resource "arubacloud_vpc" "peering_local" {
+  name       = "test-acc-peering-local-vpc"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
 }
-`, name)
+
+resource "arubacloud_vpc" "peering_peer" {
+  name       = "test-acc-peering-peer-vpc"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+}
+
+resource "arubacloud_vpcpeering" "test" {
+  name       = %[2]q
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+  vpc_id     = arubacloud_vpc.peering_local.id
+  peer_vpc   = arubacloud_vpc.peering_peer.id
+}
+`, projectID, name)
 }

--- a/internal/provider/vpcpeeringroute_resource_test.go
+++ b/internal/provider/vpcpeeringroute_resource_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
@@ -14,6 +15,10 @@ import (
 )
 
 func TestAccVpcpeeringrouteResource(t *testing.T) {
+	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
+	if projectID == "" {
+		t.Skip("ARUBACLOUD_PROJECT_ID must be set for acceptance tests")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -21,7 +26,7 @@ func TestAccVpcpeeringrouteResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccVpcpeeringrouteResourceConfig("test-vpcpeeringroute"),
+				Config: testAccVpcpeeringrouteResourceConfig(projectID, "test-vpcpeeringroute"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_vpcpeeringroute.test",
@@ -49,7 +54,7 @@ func TestAccVpcpeeringrouteResource(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: testAccVpcpeeringrouteResourceConfig("test-vpcpeeringroute-updated"),
+				Config: testAccVpcpeeringrouteResourceConfig(projectID, "test-vpcpeeringroute-updated"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_vpcpeeringroute.test",
@@ -88,16 +93,36 @@ func testCheckVpcpeeringrouteDestroyed(s *terraform.State) error {
 	return nil
 }
 
-func testAccVpcpeeringrouteResourceConfig(name string) string {
+func testAccVpcpeeringrouteResourceConfig(projectID, name string) string {
 	return fmt.Sprintf(`
+resource "arubacloud_vpc" "prtroute_local" {
+  name       = "test-acc-prtroute-local"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+}
+
+resource "arubacloud_vpc" "prtroute_peer" {
+  name       = "test-acc-prtroute-peer"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+}
+
+resource "arubacloud_vpcpeering" "prtroute_prereq" {
+  name       = "test-acc-prtroute-peering"
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
+  vpc_id     = arubacloud_vpc.prtroute_local.id
+  peer_vpc   = arubacloud_vpc.prtroute_peer.id
+}
+
 resource "arubacloud_vpcpeeringroute" "test" {
-  name                   = %[1]q
-  project_id             = "test-project-id"
-  vpc_id                 = "test-vpc-id"
-  vpc_peering_id         = "test-peering-id"
+  name                   = %[2]q
+  project_id             = %[1]q
+  vpc_id                 = arubacloud_vpc.prtroute_local.id
+  vpc_peering_id         = arubacloud_vpcpeering.prtroute_prereq.id
   local_network_address  = "10.0.0.0/24"
   remote_network_address = "10.1.0.0/24"
   billing_period         = "Hour"
 }
-`, name)
+`, projectID, name)
 }

--- a/internal/provider/vpnroute_resource_test.go
+++ b/internal/provider/vpnroute_resource_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
@@ -14,6 +15,11 @@ import (
 )
 
 func TestAccVpnrouteResource(t *testing.T) {
+	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
+	vpnTunnelID := os.Getenv("ARUBACLOUD_VPNTUNNEL_ID")
+	if projectID == "" || vpnTunnelID == "" {
+		t.Skip("ARUBACLOUD_PROJECT_ID and ARUBACLOUD_VPNTUNNEL_ID must be set for acceptance tests")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -21,7 +27,7 @@ func TestAccVpnrouteResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccVpnrouteResourceConfig("test-vpnroute"),
+				Config: testAccVpnrouteResourceConfig(projectID, vpnTunnelID, "test-vpnroute"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_vpnroute.test",
@@ -49,7 +55,7 @@ func TestAccVpnrouteResource(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: testAccVpnrouteResourceConfig("test-vpnroute-updated"),
+				Config: testAccVpnrouteResourceConfig(projectID, vpnTunnelID, "test-vpnroute-updated"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_vpnroute.test",
@@ -87,18 +93,18 @@ func testCheckVpnrouteDestroyed(s *terraform.State) error {
 	return nil
 }
 
-func testAccVpnrouteResourceConfig(name string) string {
+func testAccVpnrouteResourceConfig(projectID, vpnTunnelID, name string) string {
 	return fmt.Sprintf(`
 resource "arubacloud_vpnroute" "test" {
-  name           = %[1]q
-  location       = "it-1"
-  project_id     = "test-project-id"
-  vpn_tunnel_id  = "test-tunnel-id"
+  name          = %[3]q
+  location      = "ITBG-Bergamo"
+  project_id    = %[1]q
+  vpn_tunnel_id = %[2]q
 
   properties = {
     cloud_subnet   = "10.0.0.0/24"
     on_prem_subnet = "192.168.0.0/24"
   }
 }
-`, name)
+`, projectID, vpnTunnelID, name)
 }

--- a/internal/provider/vpntunnel_resource_test.go
+++ b/internal/provider/vpntunnel_resource_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
@@ -14,6 +15,10 @@ import (
 )
 
 func TestAccVpntunnelResource(t *testing.T) {
+	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
+	if projectID == "" {
+		t.Skip("ARUBACLOUD_PROJECT_ID must be set for acceptance tests")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -21,7 +26,7 @@ func TestAccVpntunnelResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccVpntunnelResourceConfig("test-vpntunnel"),
+				Config: testAccVpntunnelResourceConfig(projectID, "test-vpntunnel"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_vpntunnel.test",
@@ -49,7 +54,7 @@ func TestAccVpntunnelResource(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: testAccVpntunnelResourceConfig("test-vpntunnel-updated"),
+				Config: testAccVpntunnelResourceConfig(projectID, "test-vpntunnel-updated"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_vpntunnel.test",
@@ -86,16 +91,16 @@ func testCheckVpntunnelDestroyed(s *terraform.State) error {
 	return nil
 }
 
-func testAccVpntunnelResourceConfig(name string) string {
+func testAccVpntunnelResourceConfig(projectID, name string) string {
 	return fmt.Sprintf(`
 resource "arubacloud_vpntunnel" "test" {
-  name       = %[1]q
-  location   = "it-1"
-  project_id = "test-project-id"
+  name       = %[2]q
+  location   = "ITBG-Bergamo"
+  project_id = %[1]q
 
   properties = {
     vpn_type = "Site-To-Site"
   }
 }
-`, name)
+`, projectID, name)
 }

--- a/templates/guides/acceptance-testing.md
+++ b/templates/guides/acceptance-testing.md
@@ -90,6 +90,8 @@ Some resource tests have additional prerequisites:
 |---|---|
 | `ARUBACLOUD_OS_IMAGE_ID` | `TestAccBlockStorageResource_Bootable`, `TestAccCloudserverResource` — OS image used to create a bootable disk |
 | `ARUBACLOUD_DBAAS_ID` | `TestAccDatabaseResource`, `TestAccDatabasebackupResource`, `TestAccDatabasegrantResource`, `TestAccDbaasuserResource` — existing DBaaS cluster used as a prerequisite to avoid zone-capacity conflicts when multiple DBaaS tests run sequentially |
+| `ARUBACLOUD_BACKUP_ID` | `TestAccRestoreResource` — existing block storage backup to restore from |
+| `ARUBACLOUD_VPNTUNNEL_ID` | `TestAccVpnrouteResource` — existing VPN tunnel to attach routes to |
 
 ### Data Source Tests
 


### PR DESCRIPTION
11 resource acceptance tests used location="it-1" and project_id="test-project-id" as placeholder values that were never replaced. All fail immediately because the API rejects both the fake location and fake project. Fixes each by reading ARUBACLOUD_PROJECT_ID from env, using ITBG-Bergamo, and creating inline prerequisites. Complex tests now require ARUBACLOUD_BACKUP_ID or ARUBACLOUD_VPNTUNNEL_ID. Closes #218