### PR TITLE
fix(vpcpeering): normalize peer_vpc to ID; remove unsupported location from vpcpeeringroute test

### DIFF
--- a/internal/provider/vpcpeering_resource.go
+++ b/internal/provider/vpcpeering_resource.go
@@ -121,8 +121,11 @@ func applyVPCPeeringToModel(p *aruba.VPCPeering, data *VpcPeeringResourceModel) 
 	data.Uri = strVal(p.URI())
 	data.Name = types.StringValue(p.Name())
 	data.Tags = TagsToListPreserveNull(p.Tags(), data.Tags)
-	if p.RemoteVPCURI() != "" {
-		data.PeerVpc = types.StringValue(p.RemoteVPCURI())
+	if remoteURI := p.RemoteVPCURI(); remoteURI != "" {
+		// Always store the short VPC ID (last path segment) so that state
+		// matches the user-provided value (arubacloud_vpc.peer.id).
+		parts := strings.Split(strings.TrimRight(remoteURI, "/"), "/")
+		data.PeerVpc = types.StringValue(parts[len(parts)-1])
 	}
 	raw := p.Raw()
 	if raw != nil && raw.Metadata.LocationResponse != nil {

--- a/internal/provider/vpcpeeringroute_data_source_test.go
+++ b/internal/provider/vpcpeeringroute_data_source_test.go
@@ -79,7 +79,6 @@ resource "arubacloud_vpcpeering" "test" {
 
 resource "arubacloud_vpcpeeringroute" "test" {
   name                   = "test-ds-vpcpeeringroute"
-  location               = "ITBG-Bergamo"
   project_id             = %[1]q
   vpc_id                 = arubacloud_vpc.local.id
   vpc_peering_id         = arubacloud_vpcpeering.test.id


### PR DESCRIPTION
Fixes two related VPCPeering bugs. #219: applyVPCPeeringToModel was storing peer_vpc as the full URI from the API while the config provided just the short VPC ID, causing inconsistent result after apply. Fix: extract the last path segment. #220: vpcpeeringroute data source test config had location = ITBG-Bergamo on the resource block but the schema has no location attribute. Fix: remove the unsupported argument. Closes #219 #220