### PR TITLE
fix(testacc): add missing security rules to container registry test configs

### DIFF
--- a/internal/provider/containerregistry_data_source_test.go
+++ b/internal/provider/containerregistry_data_source_test.go
@@ -78,6 +78,40 @@ resource "arubacloud_securitygroup" "test" {
   vpc_id     = arubacloud_vpc.test.id
 }
 
+resource "arubacloud_securityrule" "test_https_ingress" {
+  name              = "test-ds-cr-https-ingress"
+  location          = "ITBG-Bergamo"
+  project_id        = %[1]q
+  vpc_id            = arubacloud_vpc.test.id
+  security_group_id = arubacloud_securitygroup.test.id
+  properties = {
+    direction = "Ingress"
+    protocol  = "TCP"
+    port      = "443"
+    target = {
+      kind  = "Ip"
+      value = "0.0.0.0/0"
+    }
+  }
+}
+
+resource "arubacloud_securityrule" "test_egress" {
+  name              = "test-ds-cr-egress"
+  location          = "ITBG-Bergamo"
+  project_id        = %[1]q
+  vpc_id            = arubacloud_vpc.test.id
+  security_group_id = arubacloud_securitygroup.test.id
+  properties = {
+    direction = "Egress"
+    protocol  = "ANY"
+    port      = "*"
+    target = {
+      kind  = "Ip"
+      value = "0.0.0.0/0"
+    }
+  }
+}
+
 resource "arubacloud_elasticip" "test" {
   name           = "test-ds-cr-eip"
   location       = "ITBG-Bergamo"

--- a/internal/provider/containerregistry_resource_test.go
+++ b/internal/provider/containerregistry_resource_test.go
@@ -114,6 +114,40 @@ resource "arubacloud_securitygroup" "cr_prereq" {
   vpc_id     = arubacloud_vpc.cr_prereq.id
 }
 
+resource "arubacloud_securityrule" "cr_prereq_https_ingress" {
+  name              = "test-acc-cr-https-ingress"
+  location          = "ITBG-Bergamo"
+  project_id        = %[1]q
+  vpc_id            = arubacloud_vpc.cr_prereq.id
+  security_group_id = arubacloud_securitygroup.cr_prereq.id
+  properties = {
+    direction = "Ingress"
+    protocol  = "TCP"
+    port      = "443"
+    target = {
+      kind  = "Ip"
+      value = "0.0.0.0/0"
+    }
+  }
+}
+
+resource "arubacloud_securityrule" "cr_prereq_egress" {
+  name              = "test-acc-cr-egress"
+  location          = "ITBG-Bergamo"
+  project_id        = %[1]q
+  vpc_id            = arubacloud_vpc.cr_prereq.id
+  security_group_id = arubacloud_securitygroup.cr_prereq.id
+  properties = {
+    direction = "Egress"
+    protocol  = "ANY"
+    port      = "*"
+    target = {
+      kind  = "Ip"
+      value = "0.0.0.0/0"
+    }
+  }
+}
+
 resource "arubacloud_elasticip" "cr_prereq" {
   name           = "test-acc-cr-eip"
   location       = "ITBG-Bergamo"


### PR DESCRIPTION
## Summary

- Container registry acceptance tests ( and ) were always failing with .
- Root cause: both test HCL configs created a security group but attached **no security rules** to it — blocking all ingress and egress traffic, so the registry cannot provision.
- Added the two rules present in  to both test helper functions: TCP ingress on port 443 from  and ANY egress to .

## Test plan

- [ ] Run  and confirm it reaches  state instead of 
- [ ] Run  and confirm create/import/update steps all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)