### PR TITLE
fix(testacc): fix backup type/tags validation and cloudserver import verify

### DIFF
--- a/internal/provider/backup_resource_test.go
+++ b/internal/provider/backup_resource_test.go
@@ -61,7 +61,7 @@ func TestAccBackupResource(t *testing.T) {
 				ImportStateIdFunc: importIDFromAttrs("arubacloud_backup.test", "project_id", "id"),
 			},
 			{
-				Config: testAccBackupResourceConfig(projectID, "test-backup-updated", "ITBG-Bergamo", "Incremental", 60),
+				Config: testAccBackupResourceConfig(projectID, "test-backup-updated", "ITBG-Bergamo", "Full", 60),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_backup.test",
@@ -71,7 +71,7 @@ func TestAccBackupResource(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						"arubacloud_backup.test",
 						tfjsonpath.New("type"),
-						knownvalue.StringExact("Incremental"),
+						knownvalue.StringExact("Full"),
 					),
 					statecheck.ExpectKnownValue(
 						"arubacloud_backup.test",
@@ -181,7 +181,7 @@ resource "arubacloud_backup" "test" {
   volume_id      = arubacloud_blockstorage.backup_vol.id
   billing_period = "Month"
   retention_days = 30
-  tags           = ["env:test", "managed:terraform"]
+  tags           = ["acceptance-test", "terraform"]
 }
 `, projectID, name, location)
 }

--- a/internal/provider/cloudserver_resource_test.go
+++ b/internal/provider/cloudserver_resource_test.go
@@ -57,7 +57,7 @@ func TestAccCloudserverResource(t *testing.T) {
 				ResourceName:            "arubacloud_cloudserver.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"settings.user_data"},
+				ImportStateVerifyIgnore: []string{"settings.user_data", "network.securitygroup_uri_refs", "network.subnet_uri_refs"},
 				ImportStateIdFunc:       importIDFromAttrs("arubacloud_cloudserver.test", "project_id", "id"),
 			},
 			// Update and Read testing


### PR DESCRIPTION
## Summary

Three acceptance-test failures identified from the test run log:

- **TestAccBackupResource step 3/3** — update step changed  from  to . Since  has , Terraform destroys and recreates with , but the API rejects it with 400 . Fixed by keeping  in the update step and only changing name and .

- **TestAccBackupResource_WithTags step 1/1** — tags containing colons (, ) are rejected by the API with . Fixed by using simple tag strings without colons.

- **TestAccCloudserverResource step 2/3 (import)** — after import,  and  are null because the API does not return them in a Get response (the code already documents this). Added both to  alongside the existing  entry.

## Test plan

- [ ] Run  — all 3 steps should pass
- [ ] Run  — step 1 should pass
- [ ] Run  — import step should no longer fail on missing refs

🤖 Generated with [Claude Code](https://claude.com/claude-code)