### PR TITLE
fix(containerregistry): stop Delete from hanging when registry is in Failed state

### DIFF
--- a/internal/provider/containerregistry_resource.go
+++ b/internal/provider/containerregistry_resource.go
@@ -456,12 +456,20 @@ func (r *ContainerRegistryResource) Delete(ctx context.Context, req resource.Del
 	registryID := data.Id.ValueString()
 
 	deletionChecker := func(ctx context.Context) (bool, error) {
-		_, getErr := r.client.Client.FromContainer().ContainerRegistry().Get(ctx, ref)
+		reg, getErr := r.client.Client.FromContainer().ContainerRegistry().Get(ctx, ref)
 		if provErr := CheckResponseErr("get", "ContainerRegistry", getErr); provErr != nil {
 			if IsNotFound(provErr) {
 				return true, nil
 			}
 			return false, provErr
+		}
+		// A "Failed" registry will never recover; after the delete call has been
+		// issued treat it as gone so WaitForResourceDeleted does not block until
+		// timeout (the API continues returning 200 for the stuck resource).
+		if isFailedState(string(reg.State())) {
+			tflog.Info(ctx, "ContainerRegistry is in terminal failure state after delete; treating as deleted",
+				map[string]interface{}{"containerregistry_id": registryID})
+			return true, nil
 		}
 		return false, nil
 	}


### PR DESCRIPTION
## Summary

**Bug B from issue #225**: `ContainerRegistryResource.Delete` called `WaitForResourceDeleted`, which polls until 404. When the registry is stuck in the `"Failed"` state after the delete API call, the API continues returning the resource (never a 404), causing the wait to block for the full 30-minute timeout and leaving a dangling resource.

### Root cause

The `deletionChecker` closure only returned `true` on a 404 response:

```go
// Before
deletionChecker := func(ctx context.Context) (bool, error) {
    _, getErr := r.client.Client.FromContainer().ContainerRegistry().Get(ctx, ref)
    if provErr := CheckResponseErr("get", "ContainerRegistry", getErr); provErr != nil {
        if IsNotFound(provErr) {
            return true, nil  // only exit: 404
        }
        return false, provErr
    }
    return false, nil  // resource still exists → keep polling
}
```

A registry in `"Failed"` state is never removed by the API within the polling window, so `WaitForResourceDeleted` (30 min timeout) exhausts before the resource disappears.

### Fix

Extended `deletionChecker` to also return `true` when the registry is in a terminal failure state (`Failed`, `Error`, `Errored`, `Faulted`):

```go
// After
if isFailedState(string(reg.State())) {
    tflog.Info(ctx, "ContainerRegistry is in terminal failure state after delete; treating as deleted", ...)
    return true, nil
}
```

Since the delete API call has already been issued before the checker runs inside `WaitForResourceDeleted`, a resource in that state will never recover and there is no point blocking on its disappearance.

> **Note**: Bug A (registry entering `Failed` on create due to missing security rules) was fixed in PR #226.

## Test plan

- [ ] Manually put a registry in `Failed` state, run `terraform destroy` — should complete in seconds instead of timing out after 30 minutes
- [ ] Run `TestAccContainerregistryDataSource` and `TestAccContainerregistryResource` — destroy step should not hang

Fixes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)
