### PR TITLE
fix(schedulejob): stop Delete from hanging when job is in Failed state

### DIFF
--- a/internal/provider/schedulejob_resource.go
+++ b/internal/provider/schedulejob_resource.go
@@ -590,12 +590,17 @@ func (r *ScheduleJobResource) Delete(ctx context.Context, req resource.DeleteReq
 	jobID := data.Id.ValueString()
 
 	deletionChecker := func(ctx context.Context) (bool, error) {
-		_, getErr := r.client.Client.FromSchedule().Jobs().Get(ctx, ref)
+		job, getErr := r.client.Client.FromSchedule().Jobs().Get(ctx, ref)
 		if provErr := CheckResponseErr("get", "ScheduleJob", getErr); provErr != nil {
 			if IsNotFound(provErr) {
 				return true, nil
 			}
 			return false, provErr
+		}
+		if job != nil && isFailedState(string(job.State())) {
+			tflog.Info(ctx, "ScheduleJob is in terminal failure state after delete; treating as deleted",
+				map[string]interface{}{"job_id": jobID})
+			return true, nil
 		}
 		return false, nil
 	}


### PR DESCRIPTION
## Summary

-  in  only returned  on 404; if the job entered a terminal failure state after the delete call,  polled forever and killed the **entire test suite** at the 2h timeout
- Capture the job object from  and treat  as confirmed deleted — identical pattern to the ContainerRegistry fix (PR #227)

## Test plan
- [ ] Run  — verify it completes (pass or fail) without hanging until suite timeout
- [ ] Confirm all tests after schedulejob in alphabetical run order now execute

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)