### PR TITLE
fix(dbaas): populate billing_period from API after Create

### DIFF
--- a/internal/provider/dbaas_resource.go
+++ b/internal/provider/dbaas_resource.go
@@ -345,12 +345,20 @@ func (r *DBaaSResource) Create(ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 
-	// Refresh URI from re-read and preserve network from plan.
+	// Refresh URI and billing_period from re-read; preserve network from plan.
 	fresh, freshErr := r.client.Client.FromDatabase().DBaaS().Get(ctx, dbaasRef(&data))
 	if freshErr == nil {
 		data.Uri = strVal(fresh.URI())
+		if bp := billingPeriodFromAPI(string(fresh.BillingPeriod())); bp != "" {
+			data.BillingPeriod = types.StringValue(bp)
+		} else if data.BillingPeriod.IsUnknown() {
+			data.BillingPeriod = types.StringNull()
+		}
 	} else {
 		tflog.Warn(ctx, fmt.Sprintf("Failed to refresh DBaaS after creation: %v", freshErr))
+		if data.BillingPeriod.IsUnknown() {
+			data.BillingPeriod = types.StringNull()
+		}
 	}
 
 	data.Network = buildNetworkObject(vpc, subnet, sg, eip)


### PR DESCRIPTION
## Summary

- After `WaitUntilReady` in `DBaaSResource.Create`, the re-read refreshed `Uri` but did not set `billing_period`
- Since the field is `Optional+Computed`, Terraform requires the provider to return a known value after every apply; any `Unknown` left in state causes: _"provider still indicated an unknown value for arubacloud_dbaas.test.billing_period"_
- Populate `billing_period` from the API response after the re-read (or `null` when the API returns none / refresh fails)

## Test plan
- [ ] `TestAccDbaasResource` passes
- [ ] `TestAccDbaasDataSource` passes
- [ ] `TestAccDatabaseDataSource` passes
- [ ] `TestAccDatabasebackupDataSource` passes
- [ ] `TestAccDatabasegrantDataSource` passes
- [ ] `TestAccDbaasuserDataSource` passes

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)