### PR TITLE
fix(containerregistry): prefer ID-based Ref to avoid SDK path mismatch

### DIFF
--- a/internal/provider/containerregistry_resource.go
+++ b/internal/provider/containerregistry_resource.go
@@ -176,11 +176,18 @@ func (r *ContainerRegistryResource) Configure(ctx context.Context, req resource.
 }
 
 func containerRegistryRef(data *ContainerRegistryResourceModel) aruba.Ref {
+	// Prefer the ID-based path so the SDK can always extract the resource ID.
+	// The API returns URIs with "containerRegistries" in the path, but the SDK
+	// expects the "registries" path segment — using the stored URI verbatim
+	// would cause "cannot determine registry ID from Ref" errors.
+	if !data.Id.IsNull() && !data.Id.IsUnknown() && data.Id.ValueString() != "" {
+		return aruba.URI("/projects/" + data.ProjectID.ValueString() +
+			"/providers/Aruba.Container/registries/" + data.Id.ValueString())
+	}
 	if !data.Uri.IsNull() && data.Uri.ValueString() != "" {
 		return aruba.URI(data.Uri.ValueString())
 	}
-	return aruba.URI("/projects/" + data.ProjectID.ValueString() +
-		"/providers/Aruba.Container/registries/" + data.Id.ValueString())
+	return aruba.URI("")
 }
 
 func applyContainerRegistryToModel(reg *aruba.ContainerRegistry, data *ContainerRegistryResourceModel) {


### PR DESCRIPTION
## Summary

- The ArubaCloud API returns container registry URIs with `containerRegistries` in the path (e.g. `.../providers/Aruba.Container/containerRegistries/<id>`)
- The SDK's `Get()` parser expects the path segment `registries`, not `containerRegistries`; passing the stored URI verbatim caused: _"cannot determine registry ID from Ref"_ on every post-test destroy
- Fix: prefer an ID-constructed Ref (using `registries`) when the resource ID is known; fall back to the stored URI only for the import flow where ID is empty

## Test plan
- [ ] `TestAccContainerregistryResource` completes without dangling-resource warning on destroy

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)