### PR TITLE
fix(backup): keep plan retention_days in Update and send it to the API

### DIFF
--- a/internal/provider/backup_resource.go
+++ b/internal/provider/backup_resource.go
@@ -346,6 +346,9 @@ func (r *BackupResource) Update(ctx context.Context, req resource.UpdateRequest,
 	} else {
 		backup.RetaggedAs(backup.Tags()...)
 	}
+	if !data.RetentionDays.IsNull() && !data.RetentionDays.IsUnknown() {
+		backup.RetainedForDays(int(data.RetentionDays.ValueInt64()))
+	}
 
 	updated, err := r.client.Client.FromStorage().Backups().Update(ctx, backup)
 	if provErr := CheckResponseErr("update", "Backup", err); provErr != nil {
@@ -353,14 +356,15 @@ func (r *BackupResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
+	// Preserve truly immutable fields from state.
 	data.Id = state.Id
 	data.ProjectID = state.ProjectID
 	data.Uri = state.Uri
 	data.VolumeID = state.VolumeID
 	data.Type = state.Type
-	data.RetentionDays = state.RetentionDays
 	data.BillingPeriod = state.BillingPeriod
 	data.Location = state.Location
+	// retention_days is mutable: keep the plan value (already in data).
 	data.Name = types.StringValue(updated.Name())
 	data.Tags = TagsToListPreserveNull(updated.Tags(), data.Tags)
 


### PR DESCRIPTION
## Summary

- `BackupResource.Update` was doing `data.RetentionDays = state.RetentionDays`, clobbering the plan value with the old state value
- When step 3 changed `retention_days` from 30 → 60, state would still show 30 after the update, producing: _".retention_days: was 60, but now 30"_
- Fix: remove the state copy (plan value already in `data`) and call `backup.RetainedForDays()` before `Update` so the API actually persists the new value

## Test plan
- [ ] `TestAccBackupResource` step 3/3 passes (retention_days update from 30 → 60)

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)