### PR TITLE
fix(cloudserver): send security groups in Update request

### DIFF
--- a/internal/provider/cloudserver_resource.go
+++ b/internal/provider/cloudserver_resource.go
@@ -582,6 +582,21 @@ func (r *CloudServerResource) Update(ctx context.Context, req resource.UpdateReq
 		server.RetaggedAs(server.Tags()...)
 	}
 
+	// Security groups are not returned by the API on Get, so the server object
+	// would send securityGroup=null in the update payload without this call.
+	if !planNetworkModel.SecurityGroupUriRefs.IsNull() && !planNetworkModel.SecurityGroupUriRefs.IsUnknown() {
+		var sgURIs []string
+		resp.Diagnostics.Append(planNetworkModel.SecurityGroupUriRefs.ElementsAs(ctx, &sgURIs, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		sgRefs := make([]aruba.Ref, len(sgURIs))
+		for i, u := range sgURIs {
+			sgRefs[i] = aruba.URI(u)
+		}
+		server.WithSecurityGroups(sgRefs...)
+	}
+
 	updated, err := r.client.Client.FromCompute().CloudServers().Update(ctx, server)
 	if provErr := CheckResponseErr("update", "CloudServer", err); provErr != nil {
 		resp.Diagnostics.AddError("API Error", provErr.Error())


### PR DESCRIPTION
## Summary

- The API rejects a CloudServer update when `securityGroup` is null
- The SDK's `CloudServer` object fetched by `Get()` does not carry security group info (the API does not return it in the response)
- Without explicitly setting them, `Update` was sending `securityGroup=null`, causing: _"securityGroup cannot be null, fieldName: GenericResource"_
- Fix: call `server.WithSecurityGroups()` with values from the plan before calling `Update`

## Test plan
- [ ] `TestAccCloudserverResource` step 3/3 (name update) passes without 400 error

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)