### PR TITLE
test: read location from ARUBACLOUD_LOCATION env var

### DIFF
--- a/internal/provider/elasticip_resource_test.go
+++ b/internal/provider/elasticip_resource_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
@@ -14,6 +15,11 @@ import (
 )
 
 func TestAccElasticipResource(t *testing.T) {
+	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
+	location := os.Getenv("ARUBACLOUD_LOCATION")
+	if projectID == "" || location == "" {
+		t.Skip("ARUBACLOUD_PROJECT_ID and ARUBACLOUD_LOCATION must be set for acceptance tests")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -21,7 +27,7 @@ func TestAccElasticipResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccElasticipResourceConfig("test-elasticip"),
+				Config: testAccElasticipResourceConfig(projectID, location, "test-elasticip"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_elasticip.test",
@@ -49,7 +55,7 @@ func TestAccElasticipResource(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: testAccElasticipResourceConfig("test-elasticip-updated"),
+				Config: testAccElasticipResourceConfig(projectID, location, "test-elasticip-updated"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_elasticip.test",
@@ -86,12 +92,12 @@ func testCheckElasticipDestroyed(s *terraform.State) error {
 	return nil
 }
 
-func testAccElasticipResourceConfig(name string) string {
+func testAccElasticipResourceConfig(projectID, location, name string) string {
 	return fmt.Sprintf(`
 resource "arubacloud_elasticip" "test" {
-  name       = %[1]q
-  location   = "it-1"
-  project_id = "test-project-id"
+  name       = %[3]q
+  location   = %[2]q
+  project_id = %[1]q
 }
-`, name)
+`, projectID, location, name)
 }

--- a/internal/provider/keypair_resource_test.go
+++ b/internal/provider/keypair_resource_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
@@ -14,6 +15,11 @@ import (
 )
 
 func TestAccKeypairResource(t *testing.T) {
+	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
+	location := os.Getenv("ARUBACLOUD_LOCATION")
+	if projectID == "" || location == "" {
+		t.Skip("ARUBACLOUD_PROJECT_ID and ARUBACLOUD_LOCATION must be set for acceptance tests")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -21,7 +27,7 @@ func TestAccKeypairResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccKeypairResourceConfig("test-keypair"),
+				Config: testAccKeypairResourceConfig(projectID, location, "test-keypair"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_keypair.test",
@@ -45,7 +51,7 @@ func TestAccKeypairResource(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: testAccKeypairResourceConfig("test-keypair-updated"),
+				Config: testAccKeypairResourceConfig(projectID, location, "test-keypair-updated"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_keypair.test",
@@ -82,13 +88,13 @@ func testCheckKeypairDestroyed(s *terraform.State) error {
 	return nil
 }
 
-func testAccKeypairResourceConfig(name string) string {
+func testAccKeypairResourceConfig(projectID, location, name string) string {
 	return fmt.Sprintf(`
 resource "arubacloud_keypair" "test" {
-  name       = %[1]q
-  location   = "it-1"
-  project_id = "test-project-id"
+  name       = %[3]q
+  location   = %[2]q
+  project_id = %[1]q
   value      = "ssh-rsa AAAAB3NzaC1yc2EAAAA..."
 }
-`, name)
+`, projectID, location, name)
 }

--- a/internal/provider/kms_resource_test.go
+++ b/internal/provider/kms_resource_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
@@ -14,13 +15,18 @@ import (
 )
 
 func TestAccKmsResource(t *testing.T) {
+	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
+	location := os.Getenv("ARUBACLOUD_LOCATION")
+	if projectID == "" || location == "" {
+		t.Skip("ARUBACLOUD_PROJECT_ID and ARUBACLOUD_LOCATION must be set for acceptance tests")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testCheckKmsDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKmsResourceConfig("test-kms"),
+				Config: testAccKmsResourceConfig(projectID, location, "test-kms"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue("arubacloud_kms.test", tfjsonpath.New("name"), knownvalue.StringExact("test-kms")),
 					statecheck.ExpectKnownValue("arubacloud_kms.test", tfjsonpath.New("id"), knownvalue.NotNull()),
@@ -34,7 +40,7 @@ func TestAccKmsResource(t *testing.T) {
 				ImportStateIdFunc: importIDFromAttrs("arubacloud_kms.test", "project_id", "id"),
 			},
 			{
-				Config: testAccKmsResourceConfig("test-kms-updated"),
+				Config: testAccKmsResourceConfig(projectID, location, "test-kms-updated"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue("arubacloud_kms.test", tfjsonpath.New("name"), knownvalue.StringExact("test-kms-updated")),
 				},
@@ -67,13 +73,13 @@ func testCheckKmsDestroyed(s *terraform.State) error {
 	return nil
 }
 
-func testAccKmsResourceConfig(name string) string {
+func testAccKmsResourceConfig(projectID, location, name string) string {
 	return fmt.Sprintf(`
 resource "arubacloud_kms" "test" {
-  name           = %[1]q
-  project_id     = "test-project-id"
-  location       = "it-1"
+  name           = %[3]q
+  project_id     = %[1]q
+  location       = %[2]q
   billing_period = "Hour"
 }
-`, name)
+`, projectID, location, name)
 }

--- a/internal/provider/provider_drift_test.go
+++ b/internal/provider/provider_drift_test.go
@@ -25,18 +25,19 @@ import (
 
 func TestAccVpcResource_DetectsDriftAfterOutOfBandDelete(t *testing.T) {
 	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
-	if projectID == "" {
-		t.Skip("ARUBACLOUD_PROJECT_ID must be set for drift tests")
+	location := os.Getenv("ARUBACLOUD_LOCATION")
+	if projectID == "" || location == "" {
+		t.Skip("ARUBACLOUD_PROJECT_ID and ARUBACLOUD_LOCATION must be set for drift tests")
 	}
 
 	var capturedID string
 	cfg := fmt.Sprintf(`
 resource "arubacloud_vpc" "drift" {
   name       = "tf-drift-vpc"
-  location   = "it-1"
+  location   = %q
   project_id = %q
 }
-`, projectID)
+`, location, projectID)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },

--- a/run-acceptance-tests.sh
+++ b/run-acceptance-tests.sh
@@ -11,6 +11,8 @@
 #   ARUBACLOUD_PROJECT_ID      Target project
 #
 # Optional env vars (prompt if missing; tests skip gracefully when absent)
+#   ARUBACLOUD_LOCATION             TestAccElasticipResource, TestAccKeypairResource,
+#                                   TestAccKmsResource, TestAccVpcResource_DetectsDriftAfterOutOfBandDelete
 #   ARUBACLOUD_ZONE                 TestAccKaasResource, TestAccKaasDataSource
 #   ARUBACLOUD_KAAS_NODE_INSTANCE   TestAccKaasResource, TestAccKaasDataSource
 #   ARUBACLOUD_OS_IMAGE_ID          TestAccCloudserverResource, TestAccBlockStorageResource_Bootable,
@@ -92,6 +94,7 @@ fi
 # ── optional env vars ─────────────────────────────────────────────────────────
 # Ordered list of optional vars and the tests they gate.
 OPT_VAR_NAMES=(
+    ARUBACLOUD_LOCATION
     ARUBACLOUD_ZONE
     ARUBACLOUD_KAAS_NODE_INSTANCE
     ARUBACLOUD_OS_IMAGE_ID
@@ -100,6 +103,7 @@ OPT_VAR_NAMES=(
     ARUBACLOUD_VPNROUTE_ID
 )
 OPT_VAR_TESTS=(
+    "TestAccElasticipResource, TestAccKeypairResource, TestAccKmsResource, TestAccVpcResource_DetectsDriftAfterOutOfBandDelete"
     "TestAccKaasResource, TestAccKaasDataSource"
     "TestAccKaasResource, TestAccKaasDataSource"
     "TestAccCloudserverResource, TestAccBlockStorageResource_Bootable, TestAccCloudserverDataSource, TestAccSchedulejobDataSource"


### PR DESCRIPTION
## Summary

- Four tests hardcoded `location = "it-1"` and `project_id = "test-project-id"`, causing immediate 400 failures in any project where that location is unavailable
- Replace with env vars `ARUBACLOUD_LOCATION` / `ARUBACLOUD_PROJECT_ID`; tests skip gracefully when either is unset
- Add `ARUBACLOUD_LOCATION` to the optional-var prompt list in `run-acceptance-tests.sh`

## Affected tests
- `TestAccElasticipResource`
- `TestAccKeypairResource`
- `TestAccKmsResource`
- `TestAccVpcResource_DetectsDriftAfterOutOfBandDelete`

## Test plan
- [ ] Set `ARUBACLOUD_LOCATION=ITBG-Bergamo` (or your region) and confirm the tests run without the 400 location error

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)