### PR TITLE
test(kaas): add required node_pool to KaaS test configs

### DIFF
--- a/internal/provider/kaas_data_source_test.go
+++ b/internal/provider/kaas_data_source_test.go
@@ -13,8 +13,10 @@ import (
 
 func TestAccKaasDataSource(t *testing.T) {
 	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
-	if projectID == "" {
-		t.Skip("ARUBACLOUD_PROJECT_ID must be set for acceptance tests")
+	zone := os.Getenv("ARUBACLOUD_ZONE")
+	nodeInstance := os.Getenv("ARUBACLOUD_KAAS_NODE_INSTANCE")
+	if projectID == "" || zone == "" || nodeInstance == "" {
+		t.Skip("ARUBACLOUD_PROJECT_ID, ARUBACLOUD_ZONE, and ARUBACLOUD_KAAS_NODE_INSTANCE must be set for acceptance tests")
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -22,7 +24,7 @@ func TestAccKaasDataSource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKaasDataSourceConfig(projectID),
+				Config: testAccKaasDataSourceConfig(projectID, zone, nodeInstance),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"data.arubacloud_kaas.test",
@@ -45,7 +47,7 @@ func TestAccKaasDataSource(t *testing.T) {
 	})
 }
 
-func testAccKaasDataSourceConfig(projectID string) string {
+func testAccKaasDataSourceConfig(projectID, zone, nodeInstance string) string {
 	return fmt.Sprintf(`
 resource "arubacloud_vpc" "test" {
   name       = "test-ds-kaas-vpc"
@@ -87,7 +89,14 @@ resource "arubacloud_kaas" "test" {
   settings = {
     kubernetes_version = "1.28"
     ha                 = false
-    node_pools         = []
+    node_pools = [
+      {
+        name     = "default"
+        nodes    = 1
+        instance = %[3]q
+        zone     = %[2]q
+      }
+    ]
   }
 }
 
@@ -95,5 +104,5 @@ data "arubacloud_kaas" "test" {
   id         = arubacloud_kaas.test.id
   project_id = %[1]q
 }
-`, projectID)
+`, projectID, zone, nodeInstance)
 }

--- a/internal/provider/kaas_resource_test.go
+++ b/internal/provider/kaas_resource_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
@@ -14,6 +15,13 @@ import (
 )
 
 func TestAccKaasResource(t *testing.T) {
+	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
+	location := os.Getenv("ARUBACLOUD_LOCATION")
+	zone := os.Getenv("ARUBACLOUD_ZONE")
+	nodeInstance := os.Getenv("ARUBACLOUD_KAAS_NODE_INSTANCE")
+	if projectID == "" || location == "" || zone == "" || nodeInstance == "" {
+		t.Skip("ARUBACLOUD_PROJECT_ID, ARUBACLOUD_LOCATION, ARUBACLOUD_ZONE, and ARUBACLOUD_KAAS_NODE_INSTANCE must be set for acceptance tests")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -21,7 +29,7 @@ func TestAccKaasResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccKaasResourceConfig("test-kaas"),
+				Config: testAccKaasResourceConfig(projectID, location, zone, nodeInstance, "test-kaas"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_kaas.test",
@@ -50,7 +58,7 @@ func TestAccKaasResource(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: testAccKaasResourceConfig("test-kaas-updated"),
+				Config: testAccKaasResourceConfig(projectID, location, zone, nodeInstance, "test-kaas-updated"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_kaas.test",
@@ -87,18 +95,39 @@ func testCheckKaasDestroyed(s *terraform.State) error {
 	return nil
 }
 
-func testAccKaasResourceConfig(name string) string {
+func testAccKaasResourceConfig(projectID, location, zone, nodeInstance, name string) string {
 	return fmt.Sprintf(`
+resource "arubacloud_vpc" "kaas_prereq" {
+  name       = "test-kaas-vpc"
+  location   = %[2]q
+  project_id = %[1]q
+}
+
+resource "arubacloud_subnet" "kaas_prereq" {
+  name       = "test-kaas-subnet"
+  location   = %[2]q
+  project_id = %[1]q
+  vpc_id     = arubacloud_vpc.kaas_prereq.id
+  type       = "Basic"
+}
+
+resource "arubacloud_securitygroup" "kaas_prereq" {
+  name       = "test-kaas-sg"
+  location   = %[2]q
+  project_id = %[1]q
+  vpc_id     = arubacloud_vpc.kaas_prereq.id
+}
+
 resource "arubacloud_kaas" "test" {
-  name           = %[1]q
-  location       = "it-1"
-  project_id     = "test-project-id"
+  name           = %[5]q
+  location       = %[2]q
+  project_id     = %[1]q
   billing_period = "Hour"
 
   network = {
-    vpc_uri_ref         = "test-vpc-uri"
-    subnet_uri_ref      = "test-subnet-uri"
-    security_group_name = "test-sg"
+    vpc_uri_ref         = arubacloud_vpc.kaas_prereq.uri
+    subnet_uri_ref      = arubacloud_subnet.kaas_prereq.uri
+    security_group_name = arubacloud_securitygroup.kaas_prereq.name
     node_cidr = {
       address = "10.0.1.0/24"
       name    = "node-cidr"
@@ -108,8 +137,15 @@ resource "arubacloud_kaas" "test" {
   settings = {
     kubernetes_version = "1.28"
     ha                 = false
-    node_pools = []
+    node_pools = [
+      {
+        name     = "default"
+        nodes    = 1
+        instance = %[4]q
+        zone     = %[3]q
+      }
+    ]
   }
 }
-`, name)
+`, projectID, location, zone, nodeInstance, name)
 }

--- a/run-acceptance-tests.sh
+++ b/run-acceptance-tests.sh
@@ -11,11 +11,13 @@
 #   ARUBACLOUD_PROJECT_ID      Target project
 #
 # Optional env vars (prompt if missing; tests skip gracefully when absent)
-#   ARUBACLOUD_OS_IMAGE_ID     TestAccCloudserverResource, TestAccBlockStorageResource_Bootable,
-#                              TestAccCloudserverDataSource, TestAccSchedulejobDataSource
-#   ARUBACLOUD_DBAAS_ID        TestAccDatabaseResource
-#   ARUBACLOUD_VPNTUNNEL_ID    TestAccVpntunnelDataSource, TestAccVpnrouteDataSource
-#   ARUBACLOUD_VPNROUTE_ID     TestAccVpnrouteDataSource
+#   ARUBACLOUD_ZONE                 TestAccKaasResource, TestAccKaasDataSource
+#   ARUBACLOUD_KAAS_NODE_INSTANCE   TestAccKaasResource, TestAccKaasDataSource
+#   ARUBACLOUD_OS_IMAGE_ID          TestAccCloudserverResource, TestAccBlockStorageResource_Bootable,
+#                                   TestAccCloudserverDataSource, TestAccSchedulejobDataSource
+#   ARUBACLOUD_DBAAS_ID             TestAccDatabaseResource
+#   ARUBACLOUD_VPNTUNNEL_ID         TestAccVpntunnelDataSource, TestAccVpnrouteDataSource
+#   ARUBACLOUD_VPNROUTE_ID          TestAccVpnrouteDataSource
 #
 # Options
 #   -r, --run PATTERN       go -run regex filter     (default: ^TestAcc)
@@ -90,12 +92,16 @@ fi
 # ── optional env vars ─────────────────────────────────────────────────────────
 # Ordered list of optional vars and the tests they gate.
 OPT_VAR_NAMES=(
+    ARUBACLOUD_ZONE
+    ARUBACLOUD_KAAS_NODE_INSTANCE
     ARUBACLOUD_OS_IMAGE_ID
     ARUBACLOUD_DBAAS_ID
     ARUBACLOUD_VPNTUNNEL_ID
     ARUBACLOUD_VPNROUTE_ID
 )
 OPT_VAR_TESTS=(
+    "TestAccKaasResource, TestAccKaasDataSource"
+    "TestAccKaasResource, TestAccKaasDataSource"
     "TestAccCloudserverResource, TestAccBlockStorageResource_Bootable, TestAccCloudserverDataSource, TestAccSchedulejobDataSource"
     "TestAccDatabaseResource"
     "TestAccVpntunnelDataSource, TestAccVpnrouteDataSource"


### PR DESCRIPTION
## Summary

- Both KaaS tests had `node_pools = []` (empty) but the API now requires at least one node pool, causing immediate failures
- The resource test also hardcoded `location = "it-1"` and `project_id = "test-project-id"` (wrong values)
- Add a single default node pool driven by new env vars `ARUBACLOUD_ZONE` and `ARUBACLOUD_KAAS_NODE_INSTANCE`; tests skip gracefully when unset
- Resource test now creates real VPC/subnet/SG prereqs using env vars, matching the pattern used by all other resource tests

## Test plan
- [ ] Set `ARUBACLOUD_ZONE` and `ARUBACLOUD_KAAS_NODE_INSTANCE` and confirm KaaS tests reach the provisioning phase (pass or fail on API logic, not on missing node_pool)

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)