### PR TITLE
test(database): fix invalid database name and update password

### DIFF
--- a/internal/provider/database_resource_test.go
+++ b/internal/provider/database_resource_test.go
@@ -27,12 +27,12 @@ func TestAccDatabaseResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccDatabaseResourceConfig(projectID, dbaasID, "test-database"),
+				Config: testAccDatabaseResourceConfig(projectID, dbaasID, "testdatabase"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_database.test",
 						tfjsonpath.New("name"),
-						knownvalue.StringExact("test-database"),
+						knownvalue.StringExact("testdatabase"),
 					),
 					statecheck.ExpectKnownValue(
 						"arubacloud_database.test",
@@ -55,12 +55,12 @@ func TestAccDatabaseResource(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: testAccDatabaseResourceConfig(projectID, dbaasID, "test-database-updated"),
+				Config: testAccDatabaseResourceConfig(projectID, dbaasID, "testdatabaseupd"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_database.test",
 						tfjsonpath.New("name"),
-						knownvalue.StringExact("test-database-updated"),
+						knownvalue.StringExact("testdatabaseupd"),
 					),
 				},
 			},

--- a/internal/provider/databasegrant_resource_test.go
+++ b/internal/provider/databasegrant_resource_test.go
@@ -98,7 +98,7 @@ resource "arubacloud_dbaasuser" "dbgrant_prereq" {
   project_id = %[1]q
   dbaas_id   = %[2]q
   username   = "testaccgrantuser"
-  password   = "Acc3ptAbl3P@ss#01"
+  password   = "TestAcc0untP4ss!"
 }
 
 resource "arubacloud_database" "dbgrant_prereq" {

--- a/internal/provider/dbaasuser_resource_test.go
+++ b/internal/provider/dbaasuser_resource_test.go
@@ -87,7 +87,7 @@ resource "arubacloud_dbaasuser" "test" {
   project_id = %[1]q
   dbaas_id   = %[2]q
   username   = %[3]q
-  password   = "Acc3ptAbl3P@ss#01"
+  password   = "TestAcc0untP4ss!"
 }
 `, projectID, dbaasID, username)
 }


### PR DESCRIPTION
## Summary

Two issues caused immediate 400 failures in DBaaS-related tests:

1. **Invalid name**: `testAccDatabaseResourceConfig` used name `"test-database"` which contains a hyphen — the API rejects it with _"Name contains one or more invalid character."_ → changed to `testdatabase` / `testdatabaseupd` (alphanumeric only)

2. **Password rejected**: `"Acc3ptAbl3P@ss#01"` was rejected with _"Password does not match the minimum requirements."_ — likely because the API's character allowlist excludes `@` and `#` → changed to `"TestAcc0untP4ss!"` using only `!` as the special character

## Test plan
- [ ] `TestAccDatabaseResource` step 1 creates the database without a 400 error
- [ ] `TestAccDbaasuserResource` step 1 creates the user without a 400 error
- [ ] `TestAccDatabasegrantResource` step 1 creates the user prerequisite without a 400 error

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)