### PR TITLE
fix(schedulejob): warn operator when Failed state persists after delete

### DIFF
--- a/internal/provider/schedulejob_resource.go
+++ b/internal/provider/schedulejob_resource.go
@@ -589,6 +589,11 @@ func (r *ScheduleJobResource) Delete(ctx context.Context, req resource.DeleteReq
 	ref := jobRef(&data)
 	jobID := data.Id.ValueString()
 
+	// failedAfterDelete records whether the job was observed in a terminal
+	// failure state during the post-delete poll.  Captured inside the checker
+	// closure so the outer Delete function can emit an operator-visible warning.
+	var failedAfterDelete bool
+
 	deletionChecker := func(ctx context.Context) (bool, error) {
 		job, getErr := r.client.Client.FromSchedule().Jobs().Get(ctx, ref)
 		if provErr := CheckResponseErr("get", "ScheduleJob", getErr); provErr != nil {
@@ -597,9 +602,12 @@ func (r *ScheduleJobResource) Delete(ctx context.Context, req resource.DeleteReq
 			}
 			return false, provErr
 		}
+		// The API may acknowledge DELETE without transitioning the resource to
+		// 404 when the job is already in a terminal failure state.  Treat this
+		// as "gone" so we do not block indefinitely, but surface a warning so
+		// operators can verify the resource was actually removed from the project.
 		if job != nil && isFailedState(string(job.State())) {
-			tflog.Info(ctx, "ScheduleJob is in terminal failure state after delete; treating as deleted",
-				map[string]interface{}{"job_id": jobID})
+			failedAfterDelete = true
 			return true, nil
 		}
 		return false, nil
@@ -626,6 +634,16 @@ func (r *ScheduleJobResource) Delete(ctx context.Context, req resource.DeleteReq
 			resp.Diagnostics.AddError("Error waiting for ScheduleJob deletion", waitErr.Error())
 			return
 		}
+	}
+
+	if failedAfterDelete {
+		resp.Diagnostics.AddWarning(
+			"ScheduleJob Left in Failed State",
+			fmt.Sprintf("ScheduleJob %q was in a terminal failure state when the delete poll completed. "+
+				"The DELETE request was sent, but the API did not confirm removal via 404. "+
+				"Verify in the ArubaCloud console that the resource has been removed from the project — "+
+				"a stuck Failed resource may block project deletion.", jobID),
+		)
 	}
 
 	tflog.Trace(ctx, "deleted a Schedule Job resource", map[string]interface{}{"job_id": jobID})


### PR DESCRIPTION
## Background

PR #237 stopped WaitForResourceDeleted from hanging by treating a terminal Failed state as confirmed deleted. The DELETE API call is always made first — the Failed state check only affects the polling loop that follows.

## Problem with the previous fix

If the API accepts DELETE without error yet never transitions the resource to 404 (a known pattern for stuck resources — see ContainerRegistry PR #227: the API continues returning 200 for the stuck resource), the resource could silently remain in the project and block project deletion, with no visibility to the operator.

## This fix

Keeps the hang-prevention behaviour (Terraform removes the resource from state, destroy is unblocked) but captures the Failed state observation and emits an explicit Terraform warning at the end of Delete() directing the operator to verify in the console.

## What is guaranteed

- DELETE API call: always sent regardless of resource state
- Terraform state: resource removed (destroy unblocked)
- 404 confirmed: warning NOT shown (clean deletion)
- Failed state after delete: warning shown so operator can verify in console

Co-authored-by: Claude Sonnet 4.6