### PR TITLE
test(keypair): generate RSA key instead of placeholder SSH string

### DIFF
--- a/internal/provider/keypair_resource_test.go
+++ b/internal/provider/keypair_resource_test.go
@@ -2,8 +2,11 @@ package provider
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
@@ -12,7 +15,26 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"golang.org/x/crypto/ssh"
 )
+
+// testAccSSHPublicKey returns a valid SSH public key for acceptance tests.
+// It prefers ARUBACLOUD_SSH_PUBLIC_KEY env var; falls back to a freshly generated RSA-2048 key.
+func testAccSSHPublicKey(t *testing.T) string {
+	t.Helper()
+	if key := os.Getenv("ARUBACLOUD_SSH_PUBLIC_KEY"); key != "" {
+		return strings.TrimSpace(key)
+	}
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+	pub, err := ssh.NewPublicKey(&privKey.PublicKey)
+	if err != nil {
+		t.Fatalf("failed to derive SSH public key: %v", err)
+	}
+	return strings.TrimSpace(string(ssh.MarshalAuthorizedKey(pub)))
+}
 
 func TestAccKeypairResource(t *testing.T) {
 	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
@@ -20,6 +42,7 @@ func TestAccKeypairResource(t *testing.T) {
 	if projectID == "" || location == "" {
 		t.Skip("ARUBACLOUD_PROJECT_ID and ARUBACLOUD_LOCATION must be set for acceptance tests")
 	}
+	pubKey := testAccSSHPublicKey(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -27,7 +50,7 @@ func TestAccKeypairResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccKeypairResourceConfig(projectID, location, "test-keypair"),
+				Config: testAccKeypairResourceConfig(projectID, location, "test-keypair", pubKey),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_keypair.test",
@@ -51,7 +74,7 @@ func TestAccKeypairResource(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: testAccKeypairResourceConfig(projectID, location, "test-keypair-updated"),
+				Config: testAccKeypairResourceConfig(projectID, location, "test-keypair-updated", pubKey),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_keypair.test",
@@ -88,13 +111,13 @@ func testCheckKeypairDestroyed(s *terraform.State) error {
 	return nil
 }
 
-func testAccKeypairResourceConfig(projectID, location, name string) string {
+func testAccKeypairResourceConfig(projectID, location, name, pubKey string) string {
 	return fmt.Sprintf(`
 resource "arubacloud_keypair" "test" {
   name       = %[3]q
   location   = %[2]q
   project_id = %[1]q
-  value      = "ssh-rsa AAAAB3NzaC1yc2EAAAA..."
+  value      = %[4]q
 }
-`, projectID, location, name)
+`, projectID, location, name, pubKey)
 }


### PR DESCRIPTION
Fixes #254

## Summary
-  was failing immediately because the test config used  — a truncated placeholder that the API correctly rejects as malformed.
- The fix generates a fresh **RSA-2048** key pair at test time using  +  (already a transitive dependency).
- Operators can also provide their own key via  env var, which takes precedence.

## Test plan
- [ ]  passes (key is accepted by API)
- [ ] When  is set the env-var value is used instead of the generated key

🤖 Generated with [Claude Code](https://claude.com/claude-code)