### PR TITLE
test(dbaasuser): read password from ARUBACLOUD_DBAAS_PASSWORD env var

### DIFF
--- a/internal/provider/databasegrant_resource_test.go
+++ b/internal/provider/databasegrant_resource_test.go
@@ -20,13 +20,14 @@ func TestAccDatabasegrantResource(t *testing.T) {
 	if projectID == "" || dbaasID == "" {
 		t.Skip("ARUBACLOUD_PROJECT_ID and ARUBACLOUD_DBAAS_ID must be set for acceptance tests")
 	}
+	password := testAccDBaaSPassword(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testCheckDatabasegrantDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatabasegrantResourceConfig(projectID, dbaasID, "read"),
+				Config: testAccDatabasegrantResourceConfig(projectID, dbaasID, "read", password),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_databasegrant.test",
@@ -52,7 +53,7 @@ func TestAccDatabasegrantResource(t *testing.T) {
 				ImportStateIdFunc: importIDFromAttrs("arubacloud_databasegrant.test", "project_id", "dbaas_id", "database", "user_id"),
 			},
 			{
-				Config: testAccDatabasegrantResourceConfig(projectID, dbaasID, "write"),
+				Config: testAccDatabasegrantResourceConfig(projectID, dbaasID, "write", password),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_databasegrant.test",
@@ -92,13 +93,13 @@ func testCheckDatabasegrantDestroyed(s *terraform.State) error {
 	return nil
 }
 
-func testAccDatabasegrantResourceConfig(projectID, dbaasID, role string) string {
+func testAccDatabasegrantResourceConfig(projectID, dbaasID, role, password string) string {
 	return fmt.Sprintf(`
 resource "arubacloud_dbaasuser" "dbgrant_prereq" {
   project_id = %[1]q
   dbaas_id   = %[2]q
   username   = "testaccgrantuser"
-  password   = "TestAcc0untP4ss!"
+  password   = %[4]q
 }
 
 resource "arubacloud_database" "dbgrant_prereq" {
@@ -114,5 +115,5 @@ resource "arubacloud_databasegrant" "test" {
   user_id    = arubacloud_dbaasuser.dbgrant_prereq.username
   role       = %[3]q
 }
-`, projectID, dbaasID, role)
+`, projectID, dbaasID, role, password)
 }

--- a/internal/provider/dbaasuser_resource_test.go
+++ b/internal/provider/dbaasuser_resource_test.go
@@ -14,19 +14,33 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
+// testAccDBaaSPassword returns the password to use for DBaaS user acceptance tests.
+// The password is read from ARUBACLOUD_DBAAS_PASSWORD; the test is skipped if the
+// var is unset so callers can provide a password that satisfies the current API policy
+// without requiring code changes.
+func testAccDBaaSPassword(t *testing.T) string {
+	t.Helper()
+	pw := os.Getenv("ARUBACLOUD_DBAAS_PASSWORD")
+	if pw == "" {
+		t.Skip("ARUBACLOUD_DBAAS_PASSWORD must be set for acceptance tests that create DBaaS users")
+	}
+	return pw
+}
+
 func TestAccDbaasuserResource(t *testing.T) {
 	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
 	dbaasID := os.Getenv("ARUBACLOUD_DBAAS_ID")
 	if projectID == "" || dbaasID == "" {
 		t.Skip("ARUBACLOUD_PROJECT_ID and ARUBACLOUD_DBAAS_ID must be set for acceptance tests")
 	}
+	password := testAccDBaaSPassword(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testCheckDbaasuserDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDbaasuserResourceConfig(projectID, dbaasID, "testaccdbuser"),
+				Config: testAccDbaasuserResourceConfig(projectID, dbaasID, "testaccdbuser", password),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_dbaasuser.test",
@@ -81,13 +95,13 @@ func testCheckDbaasuserDestroyed(s *terraform.State) error {
 	return nil
 }
 
-func testAccDbaasuserResourceConfig(projectID, dbaasID, username string) string {
+func testAccDbaasuserResourceConfig(projectID, dbaasID, username, password string) string {
 	return fmt.Sprintf(`
 resource "arubacloud_dbaasuser" "test" {
   project_id = %[1]q
   dbaas_id   = %[2]q
   username   = %[3]q
-  password   = "TestAcc0untP4ss!"
+  password   = %[4]q
 }
-`, projectID, dbaasID, username)
+`, projectID, dbaasID, username, password)
 }


### PR DESCRIPTION
Fixes #252

## Summary
- Hardcoded DBaaS user passwords are rejected whenever the API updates its password policy, requiring a code change to unblock CI each time.
- The last attempt () was still rejected by the API in the Jul 1 test run.
- Replace the fixed string with  — a shared helper that reads  and skips the test with a clear message if the variable is absent.
- Both  and  are updated.

## Test plan
- [ ] Set  to a password that satisfies the current API policy and run 
- [ ] Run  with the same var set

🤖 Generated with [Claude Code](https://claude.com/claude-code)