### PR TITLE
fix(securityrule): normalise target.kind at plan time; add location to import ID

### DIFF
--- a/docs/resources/securityrule.md
+++ b/docs/resources/securityrule.md
@@ -101,7 +101,7 @@ Optional:
 
 Required:
 
-- `kind` (String) Type of the target endpoint. Accepted values: `IP`, `SecurityGroup`. (Immutable — changing this value forces the resource to be destroyed and re-created.)
+- `kind` (String) Type of the target endpoint. Accepted values: `IP`, `SecurityGroup` (case-insensitive at plan time — all variants are normalised to `IP` or `SecurityGroup`). (Immutable — changing this value forces the resource to be destroyed and re-created.)
 - `value` (String) Source (inbound) or destination (outbound) CIDR in notation like `0.0.0.0/0`, or SecurityGroup URI. (Immutable — changing this value forces the resource to be destroyed and re-created.)
 
 

--- a/internal/provider/securityrule_resource.go
+++ b/internal/provider/securityrule_resource.go
@@ -42,6 +42,39 @@ func (m protocolNormalizePlanModifier) PlanModifyString(ctx context.Context, req
 	}
 }
 
+// targetKindNormalizePlanModifier normalizes target.kind values at plan time so
+// that user-written "Ip", "ip", "IP" all plan as "IP" and "SecurityGroup",
+// "securitygroup" etc. plan as "SecurityGroup".  The state value is preserved
+// when it is already canonical-equivalent to avoid spurious RequiresReplace
+// diffs for resources created before this modifier was introduced.
+type targetKindNormalizePlanModifier struct{}
+
+func (m targetKindNormalizePlanModifier) Description(_ context.Context) string {
+	return "Normalizes target.kind values (Ip/ip/IP → IP; SecurityGroup variants → SecurityGroup)"
+}
+
+func (m targetKindNormalizePlanModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m targetKindNormalizePlanModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	if req.PlanValue.IsNull() || req.PlanValue.IsUnknown() {
+		if !req.StateValue.IsNull() && !req.StateValue.IsUnknown() {
+			resp.PlanValue = req.StateValue
+		}
+		return
+	}
+	normalized := normalizeTargetKind(req.PlanValue.ValueString())
+	// If the existing state is already equivalent (case-insensitive), keep the
+	// state value as the plan value so no diff is generated for old state.
+	if !req.StateValue.IsNull() && !req.StateValue.IsUnknown() &&
+		strings.EqualFold(req.StateValue.ValueString(), normalized) {
+		resp.PlanValue = req.StateValue
+		return
+	}
+	resp.PlanValue = types.StringValue(normalized)
+}
+
 // normalizeProtocol normalizes protocol strings to the canonical API form.
 func normalizeProtocol(p string) string {
 	switch strings.ToLower(p) {
@@ -196,9 +229,10 @@ func (r *SecurityRuleResource) Schema(ctx context.Context, req resource.SchemaRe
 						Required:            true,
 						Attributes: map[string]schema.Attribute{
 							"kind": schema.StringAttribute{
-								MarkdownDescription: "Type of the target endpoint. Accepted values: `IP`, `SecurityGroup`. (Immutable — changing this value forces the resource to be destroyed and re-created.)",
+								MarkdownDescription: "Type of the target endpoint. Accepted values: `IP`, `SecurityGroup` (case-insensitive at plan time — all variants are normalised to `IP` or `SecurityGroup`). (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 								Required:            true,
 								PlanModifiers: []planmodifier.String{
+									targetKindNormalizePlanModifier{},
 									stringplanmodifier.RequiresReplace(),
 								},
 							},
@@ -576,13 +610,28 @@ func (r *SecurityRuleResource) Delete(ctx context.Context, req resource.DeleteRe
 }
 
 func (r *SecurityRuleResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	parts, err := parseImportID(req.ID, "<project_id>/<vpc_id>/<sg_id>/<rule_id>", "proj-abc/vpc-xyz/sg-xyz/rule-xyz", 4)
-	if err != nil {
-		resp.Diagnostics.AddError("Invalid Import ID", err.Error())
+	// Accept "<project_id>/<vpc_id>/<sg_id>/<rule_id>" or the 5-segment form
+	// "<project_id>/<vpc_id>/<sg_id>/<rule_id>/<location>".  Location must be
+	// supplied when the operator needs location in state after import (the API
+	// does not return it in the GET response).
+	rawParts := strings.Split(req.ID, "/")
+	if len(rawParts) < 4 || len(rawParts) > 5 {
+		resp.Diagnostics.AddError("Invalid Import ID",
+			fmt.Sprintf(
+				"expected %q (e.g. %q) or %q (e.g. %q), got %q",
+				"<project_id>/<vpc_id>/<sg_id>/<rule_id>",
+				"proj-abc/vpc-xyz/sg-xyz/rule-xyz",
+				"<project_id>/<vpc_id>/<sg_id>/<rule_id>/<location>",
+				"proj-abc/vpc-xyz/sg-xyz/rule-xyz/ITBG-Bergamo",
+				req.ID,
+			))
 		return
 	}
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("project_id"), parts[0])...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("vpc_id"), parts[1])...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("security_group_id"), parts[2])...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), parts[3])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("project_id"), rawParts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("vpc_id"), rawParts[1])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("security_group_id"), rawParts[2])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), rawParts[3])...)
+	if len(rawParts) == 5 && rawParts[4] != "" {
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("location"), rawParts[4])...)
+	}
 }

--- a/internal/provider/securityrule_resource_test.go
+++ b/internal/provider/securityrule_resource_test.go
@@ -124,6 +124,87 @@ func TestProtocolNormalizePlanModifier(t *testing.T) {
 	}
 }
 
+func TestTargetKindNormalizePlanModifier(t *testing.T) {
+	ctx := context.Background()
+	m := targetKindNormalizePlanModifier{}
+
+	cases := []struct {
+		name       string
+		planValue  types.String
+		stateValue types.String
+		wantValue  string
+		wantNull   bool
+	}{
+		{
+			name:      "Ip is normalized to IP (no prior state)",
+			planValue: types.StringValue("Ip"),
+			wantValue: "IP",
+		},
+		{
+			name:      "ip is normalized to IP",
+			planValue: types.StringValue("ip"),
+			wantValue: "IP",
+		},
+		{
+			name:      "IP stays IP",
+			planValue: types.StringValue("IP"),
+			wantValue: "IP",
+		},
+		{
+			name:      "securitygroup normalized to SecurityGroup",
+			planValue: types.StringValue("securitygroup"),
+			wantValue: "SecurityGroup",
+		},
+		{
+			name:       "Ip in plan with Ip in state — preserves state value (no spurious replace)",
+			planValue:  types.StringValue("Ip"),
+			stateValue: types.StringValue("Ip"),
+			wantValue:  "Ip",
+		},
+		{
+			name:       "Ip in plan with IP in state (post-import) — plan becomes IP, no drift",
+			planValue:  types.StringValue("Ip"),
+			stateValue: types.StringValue("IP"),
+			wantValue:  "IP",
+		},
+		{
+			name:       "null plan falls back to state",
+			planValue:  types.StringNull(),
+			stateValue: types.StringValue("IP"),
+			wantValue:  "IP",
+		},
+		{
+			name:       "null plan and null state — stays null",
+			planValue:  types.StringNull(),
+			stateValue: types.StringNull(),
+			wantNull:   true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stateVal := tc.stateValue
+			if stateVal == (types.String{}) {
+				stateVal = types.StringNull()
+			}
+			req := planmodifier.StringRequest{
+				PlanValue:  tc.planValue,
+				StateValue: stateVal,
+			}
+			resp := &planmodifier.StringResponse{PlanValue: tc.planValue}
+			m.PlanModifyString(ctx, req, resp)
+			if tc.wantNull {
+				if !resp.PlanValue.IsNull() {
+					t.Errorf("expected null, got %q", resp.PlanValue.ValueString())
+				}
+				return
+			}
+			if resp.PlanValue.ValueString() != tc.wantValue {
+				t.Errorf("PlanModifyString: got %q, want %q", resp.PlanValue.ValueString(), tc.wantValue)
+			}
+		})
+	}
+}
+
 func TestAccSecurityruleResource(t *testing.T) {
 	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
 	if projectID == "" {
@@ -165,7 +246,7 @@ func TestAccSecurityruleResource(t *testing.T) {
 				ResourceName:      "arubacloud_securityrule.test",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: importIDFromAttrs("arubacloud_securityrule.test", "project_id", "vpc_id", "security_group_id", "id"),
+				ImportStateIdFunc: importIDFromAttrs("arubacloud_securityrule.test", "project_id", "vpc_id", "security_group_id", "id", "location"),
 			},
 			// Update and Read testing
 			{


### PR DESCRIPTION
Fixes #257

## Root causes

### 1 —  drift after import
The API returns  on the wire.  normalises this to  when there is no prior state (e.g. fresh import). Configs that write  saw a perpetual diff after import: state  vs. plan .

**Fix**: add  to the  attribute. It normalises the config value at plan time ( → ). When the existing state already holds an equivalent value (case-insensitive), the plan value is set to the state value — so pre-existing resources with  in state are **not** destroyed and re-created.

### 2 —  missing after import
 only wired , , , and uid=1948168(amedeo.palopoli) gid=1049089 groups=1049089. The SecurityRule GET response does not include the region field, so  cannot populate  from the API — it relies on the value already being in state. After a fresh import the state had no location, leaving it null and causing a  diff on the next plan.

**Fix**: extend the import ID format to accept an optional 5th segment: . The acceptance test supplies location via .

## Test plan
- [ ]  passes all 3 steps (create, import, update)
- [ ]  — all 8 cases pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)