### PR TITLE
test(schedulejob): randomise prereq resource names to avoid same-name conflicts

### DIFF
--- a/internal/provider/schedulejob_data_source_test.go
+++ b/internal/provider/schedulejob_data_source_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"crypto/rand"
 	"fmt"
 	"os"
 	"testing"
@@ -11,6 +12,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
+// testAccRandSuffix returns a short random hex string for use in resource names
+// so that parallel or repeated test runs do not collide on unique-name constraints.
+func testAccRandSuffix() string {
+	b := make([]byte, 3)
+	_, _ = rand.Read(b)
+	return fmt.Sprintf("%x", b)
+}
+
 func TestAccSchedulejobDataSource(t *testing.T) {
 	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
 	osImageID := os.Getenv("ARUBACLOUD_OS_IMAGE_ID")
@@ -18,12 +27,15 @@ func TestAccSchedulejobDataSource(t *testing.T) {
 		t.Skip("ARUBACLOUD_PROJECT_ID and ARUBACLOUD_OS_IMAGE_ID must be set for acceptance tests")
 	}
 
+	suffix := testAccRandSuffix()
+	sjName := "test-ds-sj-" + suffix
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSchedulejobDataSourceConfig(projectID, osImageID),
+				Config: testAccSchedulejobDataSourceConfig(projectID, osImageID, suffix),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"data.arubacloud_schedulejob.test",
@@ -33,7 +45,7 @@ func TestAccSchedulejobDataSource(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						"data.arubacloud_schedulejob.test",
 						tfjsonpath.New("name"),
-						knownvalue.StringExact("test-ds-schedulejob"),
+						knownvalue.StringExact(sjName),
 					),
 					statecheck.ExpectKnownValue(
 						"data.arubacloud_schedulejob.test",
@@ -46,16 +58,16 @@ func TestAccSchedulejobDataSource(t *testing.T) {
 	})
 }
 
-func testAccSchedulejobDataSourceConfig(projectID, osImageID string) string {
+func testAccSchedulejobDataSourceConfig(projectID, osImageID, suffix string) string {
 	return fmt.Sprintf(`
 resource "arubacloud_vpc" "sj_prereq" {
-  name       = "test-ds-sj-vpc"
+  name       = "test-ds-sj-vpc-%[3]s"
   location   = "ITBG-Bergamo"
   project_id = %[1]q
 }
 
 resource "arubacloud_subnet" "sj_prereq" {
-  name       = "test-ds-sj-subnet"
+  name       = "test-ds-sj-subnet-%[3]s"
   location   = "ITBG-Bergamo"
   project_id = %[1]q
   vpc_id     = arubacloud_vpc.sj_prereq.id
@@ -63,14 +75,14 @@ resource "arubacloud_subnet" "sj_prereq" {
 }
 
 resource "arubacloud_securitygroup" "sj_prereq" {
-  name       = "test-ds-sj-sg"
+  name       = "test-ds-sj-sg-%[3]s"
   location   = "ITBG-Bergamo"
   project_id = %[1]q
   vpc_id     = arubacloud_vpc.sj_prereq.id
 }
 
 resource "arubacloud_blockstorage" "sj_boot" {
-  name           = "test-ds-sj-boot"
+  name           = "test-ds-sj-boot-%[3]s"
   project_id     = %[1]q
   location       = "ITBG-Bergamo"
   size_gb        = 30
@@ -82,7 +94,7 @@ resource "arubacloud_blockstorage" "sj_boot" {
 }
 
 resource "arubacloud_cloudserver" "sj_prereq" {
-  name       = "test-ds-sj-server"
+  name       = "test-ds-sj-srv-%[3]s"
   location   = "ITBG-Bergamo"
   project_id = %[1]q
   zone       = "ITBG-1"
@@ -103,7 +115,7 @@ resource "arubacloud_cloudserver" "sj_prereq" {
 }
 
 resource "arubacloud_schedulejob" "test" {
-  name       = "test-ds-schedulejob"
+  name       = "test-ds-sj-%[3]s"
   project_id = %[1]q
   location   = "ITBG-Bergamo"
   tags       = []
@@ -128,5 +140,5 @@ data "arubacloud_schedulejob" "test" {
   id         = arubacloud_schedulejob.test.id
   project_id = %[1]q
 }
-`, projectID, osImageID)
+`, projectID, osImageID, suffix)
 }


### PR DESCRIPTION
Fixes #255

## Summary
The schedulejob data source test creates a whole stack of prerequisite resources (VPC, subnet, SG, block storage, cloud server) with fixed names like . When a previous run was interrupted those resources are left behind, and the next run fails immediately with a 400: *resource with the same name already exists*.

Fix: generate a 6-char hex random suffix via  at test start and append it to every static resource name. The schedulejob name is also randomised, and the  is updated to expect the suffixed name.

## Test plan
- [ ] Run  twice in a row **without** destroying between runs — second run should succeed because names no longer conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)