### PR TITLE
fix(database): mark name as RequiresReplace — API returns 405 on rename

### DIFF
--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -29,7 +29,7 @@ The following arguments are supported:
 #### Required
 
 - `dbaas_id` (String) ID of the parent DBaaS cluster this database belongs to.
-- `name` (String) Display name for the database.
+- `name` (String) Display name for the database. The database API does not support renaming — changing this value forces the resource to be destroyed and re-created. (Immutable — changing this value forces the resource to be destroyed and re-created.)
 - `project_id` (String) ID of the project that owns this resource.
 
 #### Optional

--- a/internal/provider/database_resource.go
+++ b/internal/provider/database_resource.go
@@ -66,8 +66,11 @@ func (r *DatabaseResource) Schema(ctx context.Context, req resource.SchemaReques
 				Required:            true,
 			},
 			"name": schema.StringAttribute{
-				MarkdownDescription: "Display name for the database.",
+				MarkdownDescription: "Display name for the database. The database API does not support renaming — changing this value forces the resource to be destroyed and re-created. (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"timeout": schema.StringAttribute{
 				MarkdownDescription: "Per-resource timeout override (e.g. `\"15m\"`, `\"1h\"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.",

--- a/internal/provider/database_resource_test.go
+++ b/internal/provider/database_resource_test.go
@@ -53,14 +53,14 @@ func TestAccDatabaseResource(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateIdFunc: importIDFromAttrs("arubacloud_database.test", "project_id", "dbaas_id", "id"),
 			},
-			// Update and Read testing
+			// Replace testing: name is immutable, changing it destroys and re-creates
 			{
-				Config: testAccDatabaseResourceConfig(projectID, dbaasID, "testdatabaseupd"),
+				Config: testAccDatabaseResourceConfig(projectID, dbaasID, "testdatabasenew"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_database.test",
 						tfjsonpath.New("name"),
-						knownvalue.StringExact("testdatabaseupd"),
+						knownvalue.StringExact("testdatabasenew"),
 					),
 				},
 			},


### PR DESCRIPTION
Fixes #250

## Summary

The Database API does not support renaming an existing database (returns  on any update). The  attribute is now marked  so Terraform destroys and re-creates the resource instead of attempting an in-place update. The test is updated accordingly: the old *Update* step (which would call the non-existent update API) is replaced with a *Replace* step that verifies the destroy-and-recreate path works correctly.

## Test plan
- [ ]  passes all 3 steps (create → import → replace)
- [ ] A  with a name change shows  in the plan output

🤖 Generated with [Claude Code](https://claude.com/claude-code)