### PR TITLE
fix(cloudserver): send subnets in Update request (400 subnet cannot be null)

### DIFF
--- a/internal/provider/cloudserver_resource.go
+++ b/internal/provider/cloudserver_resource.go
@@ -582,8 +582,22 @@ func (r *CloudServerResource) Update(ctx context.Context, req resource.UpdateReq
 		server.RetaggedAs(server.Tags()...)
 	}
 
-	// Security groups are not returned by the API on Get, so the server object
-	// would send securityGroup=null in the update payload without this call.
+	// Subnets and security groups are not returned by the API on Get, so the
+	// server object would send null for both fields without these explicit calls,
+	// causing a 400 "subnet/securityGroup cannot be null" error.
+	if !planNetworkModel.SubnetUriRefs.IsNull() && !planNetworkModel.SubnetUriRefs.IsUnknown() {
+		var subnetURIs []string
+		resp.Diagnostics.Append(planNetworkModel.SubnetUriRefs.ElementsAs(ctx, &subnetURIs, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		subnetRefs := make([]aruba.Ref, len(subnetURIs))
+		for i, u := range subnetURIs {
+			subnetRefs[i] = aruba.URI(u)
+		}
+		server.OnSubnets(subnetRefs...)
+	}
+
 	if !planNetworkModel.SecurityGroupUriRefs.IsNull() && !planNetworkModel.SecurityGroupUriRefs.IsUnknown() {
 		var sgURIs []string
 		resp.Diagnostics.Append(planNetworkModel.SecurityGroupUriRefs.ElementsAs(ctx, &sgURIs, false)...)


### PR DESCRIPTION
Fixes #247

## Root cause

The  GET response does not include subnet information. Without an explicit  call before , the SDK sends  in the payload, which the API rejects with:



The same issue was already fixed for security groups in PR #241 (). This PR applies the identical fix for subnets.

## Change

In  , extract subnet URIs from the plan network model and call  before submitting the update — mirroring the existing  call.

## Test plan
- [ ]  passes all 3 steps (create → import → rename)

🤖 Generated with [Claude Code](https://claude.com/claude-code)