### PR TITLE
fix(dbaasuser,databasegrant): mark all attributes RequiresReplace — no update API

### DIFF
--- a/docs/resources/databasegrant.md
+++ b/docs/resources/databasegrant.md
@@ -32,11 +32,11 @@ The following arguments are supported:
 
 #### Required
 
-- `database` (String) ID of the database this grant applies to.
-- `dbaas_id` (String) ID of the parent DBaaS cluster this grant belongs to.
-- `project_id` (String) ID of the project that owns this resource.
-- `role` (String) Privilege level granted. Accepted values depend on the database engine (e.g., `ALL`, `READ`, `WRITE`).
-- `user_id` (String) Name or ID of the DBaaS user receiving the grant.
+- `database` (String) ID of the database this grant applies to. (Immutable — changing this value forces the resource to be destroyed and re-created.)
+- `dbaas_id` (String) ID of the parent DBaaS cluster this grant belongs to. (Immutable — changing this value forces the resource to be destroyed and re-created.)
+- `project_id` (String) ID of the project that owns this resource. (Immutable — changing this value forces the resource to be destroyed and re-created.)
+- `role` (String) Privilege level granted. Accepted values depend on the database engine (e.g., `ALL`, `READ`, `WRITE`). The DBaaS grant API does not support in-place role changes. (Immutable — changing this value forces the resource to be destroyed and re-created.)
+- `user_id` (String) Name or ID of the DBaaS user receiving the grant. (Immutable — changing this value forces the resource to be destroyed and re-created.)
 
 #### Optional
 

--- a/docs/resources/dbaasuser.md
+++ b/docs/resources/dbaasuser.md
@@ -30,10 +30,10 @@ The following arguments are supported:
 
 #### Required
 
-- `dbaas_id` (String) ID of the parent DBaaS cluster this user belongs to.
-- `password` (String, Sensitive) Password for the DBaaS user. Write-only — this value is sent to the API but is not returned in subsequent read responses.
-- `project_id` (String) ID of the project that owns this resource.
-- `username` (String) Display name for the DBaaS user.
+- `dbaas_id` (String) ID of the parent DBaaS cluster this user belongs to. (Immutable — changing this value forces the resource to be destroyed and re-created.)
+- `password` (String, Sensitive) Password for the DBaaS user. Write-only — this value is sent to the API but is not returned in subsequent read responses. The DBaaS user API does not support password updates. (Immutable — changing this value forces the resource to be destroyed and re-created.)
+- `project_id` (String) ID of the project that owns this resource. (Immutable — changing this value forces the resource to be destroyed and re-created.)
+- `username` (String) Username for the DBaaS user. The DBaaS user API does not support renaming users. (Immutable — changing this value forces the resource to be destroyed and re-created.)
 
 #### Optional
 

--- a/internal/provider/databasegrant_resource.go
+++ b/internal/provider/databasegrant_resource.go
@@ -60,24 +60,39 @@ func (r *DatabaseGrantResource) Schema(ctx context.Context, req resource.SchemaR
 				},
 			},
 			"project_id": schema.StringAttribute{
-				MarkdownDescription: "ID of the project that owns this resource.",
+				MarkdownDescription: "ID of the project that owns this resource. (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"dbaas_id": schema.StringAttribute{
-				MarkdownDescription: "ID of the parent DBaaS cluster this grant belongs to.",
+				MarkdownDescription: "ID of the parent DBaaS cluster this grant belongs to. (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"database": schema.StringAttribute{
-				MarkdownDescription: "ID of the database this grant applies to.",
+				MarkdownDescription: "ID of the database this grant applies to. (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"user_id": schema.StringAttribute{
-				MarkdownDescription: "Name or ID of the DBaaS user receiving the grant.",
+				MarkdownDescription: "Name or ID of the DBaaS user receiving the grant. (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"role": schema.StringAttribute{
-				MarkdownDescription: "Privilege level granted. Accepted values depend on the database engine (e.g., `ALL`, `READ`, `WRITE`).",
+				MarkdownDescription: "Privilege level granted. Accepted values depend on the database engine (e.g., `ALL`, `READ`, `WRITE`). The DBaaS grant API does not support in-place role changes. (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"timeout": schema.StringAttribute{
 				MarkdownDescription: "Per-resource timeout override (e.g. `\"15m\"`, `\"1h\"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.",
@@ -183,40 +198,14 @@ func (r *DatabaseGrantResource) Read(ctx context.Context, req resource.ReadReque
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func (r *DatabaseGrantResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var data DatabaseGrantResourceModel
-	var state DatabaseGrantResourceModel
-
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
-	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	grant, err := r.client.Client.FromDatabase().Grants().Get(ctx, grantRefFromModel(&state))
-	if provErr := CheckResponseErr("read", "DatabaseGrant", err); provErr != nil {
-		resp.Diagnostics.AddError("API Error", provErr.Error())
-		return
-	}
-
-	grant.OfRole(data.Role.ValueString())
-
-	updated, err := r.client.Client.FromDatabase().Grants().Update(ctx, grant)
-	if provErr := CheckResponseErr("update", "DatabaseGrant", err); provErr != nil {
-		resp.Diagnostics.AddError("API Error", provErr.Error())
-		return
-	}
-
-	data.Id = state.Id
-	data.ProjectID = state.ProjectID
-	data.DBaaSID = state.DBaaSID
-	data.Database = state.Database
-	data.UserID = state.UserID
-	data.Role = types.StringValue(updated.RoleName())
-	data.Uri = strVal(updated.URI())
-
-	tflog.Trace(ctx, "updated a Database Grant resource", map[string]interface{}{"grant_id": data.Id.ValueString()})
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+// Update is unreachable: all attributes carry RequiresReplace so Terraform
+// will never call Update — any change triggers a destroy + create cycle.
+func (r *DatabaseGrantResource) Update(_ context.Context, _ resource.UpdateRequest, resp *resource.UpdateResponse) {
+	resp.Diagnostics.AddError(
+		"Update Not Supported",
+		"The ArubaCloud DBaaS grant API does not support in-place updates. "+
+			"All attribute changes force a new resource (RequiresReplace).",
+	)
 }
 
 func (r *DatabaseGrantResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/databasegrant_resource_test.go
+++ b/internal/provider/databasegrant_resource_test.go
@@ -20,13 +20,14 @@ func TestAccDatabasegrantResource(t *testing.T) {
 	if projectID == "" || dbaasID == "" {
 		t.Skip("ARUBACLOUD_PROJECT_ID and ARUBACLOUD_DBAAS_ID must be set for acceptance tests")
 	}
+	password := testAccDBaaSPassword(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testCheckDatabasegrantDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatabasegrantResourceConfig(projectID, dbaasID, "read"),
+				Config: testAccDatabasegrantResourceConfig(projectID, dbaasID, "read", password),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_databasegrant.test",
@@ -51,8 +52,9 @@ func TestAccDatabasegrantResource(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateIdFunc: importIDFromAttrs("arubacloud_databasegrant.test", "project_id", "dbaas_id", "database", "user_id"),
 			},
+			// Replace testing: role is immutable, changing it destroys and re-creates
 			{
-				Config: testAccDatabasegrantResourceConfig(projectID, dbaasID, "write"),
+				Config: testAccDatabasegrantResourceConfig(projectID, dbaasID, "write", password),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_databasegrant.test",
@@ -92,13 +94,13 @@ func testCheckDatabasegrantDestroyed(s *terraform.State) error {
 	return nil
 }
 
-func testAccDatabasegrantResourceConfig(projectID, dbaasID, role string) string {
+func testAccDatabasegrantResourceConfig(projectID, dbaasID, role, password string) string {
 	return fmt.Sprintf(`
 resource "arubacloud_dbaasuser" "dbgrant_prereq" {
   project_id = %[1]q
   dbaas_id   = %[2]q
   username   = "testaccgrantuser"
-  password   = "TestAcc0untP4ss!"
+  password   = %[4]q
 }
 
 resource "arubacloud_database" "dbgrant_prereq" {
@@ -114,5 +116,5 @@ resource "arubacloud_databasegrant" "test" {
   user_id    = arubacloud_dbaasuser.dbgrant_prereq.username
   role       = %[3]q
 }
-`, projectID, dbaasID, role)
+`, projectID, dbaasID, role, password)
 }

--- a/internal/provider/dbaasuser_resource.go
+++ b/internal/provider/dbaasuser_resource.go
@@ -60,21 +60,33 @@ func (r *DBaaSUserResource) Schema(ctx context.Context, req resource.SchemaReque
 				},
 			},
 			"project_id": schema.StringAttribute{
-				MarkdownDescription: "ID of the project that owns this resource.",
+				MarkdownDescription: "ID of the project that owns this resource. (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"dbaas_id": schema.StringAttribute{
-				MarkdownDescription: "ID of the parent DBaaS cluster this user belongs to.",
+				MarkdownDescription: "ID of the parent DBaaS cluster this user belongs to. (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"username": schema.StringAttribute{
-				MarkdownDescription: "Display name for the DBaaS user.",
+				MarkdownDescription: "Username for the DBaaS user. The DBaaS user API does not support renaming users. (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"password": schema.StringAttribute{
-				MarkdownDescription: "Password for the DBaaS user. Write-only — this value is sent to the API but is not returned in subsequent read responses.",
+				MarkdownDescription: "Password for the DBaaS user. Write-only — this value is sent to the API but is not returned in subsequent read responses. The DBaaS user API does not support password updates. (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 				Required:            true,
 				Sensitive:           true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"timeout": schema.StringAttribute{
 				MarkdownDescription: "Per-resource timeout override (e.g. `\"15m\"`, `\"1h\"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.",
@@ -224,39 +236,14 @@ func (r *DBaaSUserResource) Read(ctx context.Context, req resource.ReadRequest, 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func (r *DBaaSUserResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var data DBaaSUserResourceModel
-	var state DBaaSUserResourceModel
-
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
-	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	passwordBase64 := base64.StdEncoding.EncodeToString([]byte(data.Password.ValueString()))
-
-	user, err := r.client.Client.FromDatabase().Users().Get(ctx, dbaasUserRef(&state))
-	if provErr := CheckResponseErr("read", "DBaaSUser", err); provErr != nil {
-		resp.Diagnostics.AddError("API Error", provErr.Error())
-		return
-	}
-
-	user.WithPassword(passwordBase64)
-
-	updated, err := r.client.Client.FromDatabase().Users().Update(ctx, user)
-	if provErr := CheckResponseErr("update", "DBaaSUser", err); provErr != nil {
-		resp.Diagnostics.AddError("API Error", provErr.Error())
-		return
-	}
-
-	data.Id = state.Id
-	data.ProjectID = state.ProjectID
-	data.DBaaSID = state.DBaaSID
-	data.Username = types.StringValue(updated.Username())
-	data.Uri = strVal(updated.URI())
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+// Update is unreachable: all attributes carry RequiresReplace so Terraform
+// will never call Update — any change triggers a destroy + create cycle.
+func (r *DBaaSUserResource) Update(_ context.Context, _ resource.UpdateRequest, resp *resource.UpdateResponse) {
+	resp.Diagnostics.AddError(
+		"Update Not Supported",
+		"The ArubaCloud DBaaS user API does not support in-place updates. "+
+			"All attribute changes force a new resource (RequiresReplace).",
+	)
 }
 
 func (r *DBaaSUserResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/dbaasuser_resource_test.go
+++ b/internal/provider/dbaasuser_resource_test.go
@@ -14,19 +14,33 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
+// testAccDBaaSPassword returns the password to use for DBaaS user acceptance tests.
+// The password is read from ARUBACLOUD_DBAAS_PASSWORD; the test is skipped if the
+// var is unset so callers can provide a password that satisfies the current API
+// policy without requiring a code change.
+func testAccDBaaSPassword(t *testing.T) string {
+	t.Helper()
+	pw := os.Getenv("ARUBACLOUD_DBAAS_PASSWORD")
+	if pw == "" {
+		t.Skip("ARUBACLOUD_DBAAS_PASSWORD must be set for acceptance tests that create DBaaS users")
+	}
+	return pw
+}
+
 func TestAccDbaasuserResource(t *testing.T) {
 	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
 	dbaasID := os.Getenv("ARUBACLOUD_DBAAS_ID")
 	if projectID == "" || dbaasID == "" {
 		t.Skip("ARUBACLOUD_PROJECT_ID and ARUBACLOUD_DBAAS_ID must be set for acceptance tests")
 	}
+	password := testAccDBaaSPassword(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testCheckDbaasuserDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDbaasuserResourceConfig(projectID, dbaasID, "testaccdbuser"),
+				Config: testAccDbaasuserResourceConfig(projectID, dbaasID, "testaccdbuser", password),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_dbaasuser.test",
@@ -81,13 +95,13 @@ func testCheckDbaasuserDestroyed(s *terraform.State) error {
 	return nil
 }
 
-func testAccDbaasuserResourceConfig(projectID, dbaasID, username string) string {
+func testAccDbaasuserResourceConfig(projectID, dbaasID, username, password string) string {
 	return fmt.Sprintf(`
 resource "arubacloud_dbaasuser" "test" {
   project_id = %[1]q
   dbaas_id   = %[2]q
   username   = %[3]q
-  password   = "TestAcc0untP4ss!"
+  password   = %[4]q
 }
-`, projectID, dbaasID, username)
+`, projectID, dbaasID, username, password)
 }

--- a/internal/provider/resource_update_rich_test.go
+++ b/internal/provider/resource_update_rich_test.go
@@ -222,27 +222,23 @@ func TestVPCPeeringRouteUpdate_RichMetadata(t *testing.T) {
 	}
 }
 
-// TestDBaaSUserUpdate_RichMetadata covers dbaasuser Update() with rich JSON.
+// TestDBaaSUserUpdate_RichMetadata verifies that dbaasuser Update() returns an
+// error because the API does not support in-place updates (all fields carry
+// RequiresReplace; Terraform will never actually call Update in practice).
 func TestDBaaSUserUpdate_RichMetadata(t *testing.T) {
 	ctx := context.Background()
 
-	dbaasUserUpdateJSON := `{"username":"test-user","status":{"state":"Active"}}`
-
-	handler := func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
+	_, mockClient := newMockArubaClient(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(dbaasUserUpdateJSON)) //nolint:errcheck
-	}
-
-	_, mockClient := newMockArubaClient(t, handler)
+	})
 	res := NewDBaaSUserResource()
 	configureResource(ctx, t, res, mockClient)
 
 	req, resp := resourceUpdateReqFull(ctx, t, res)
 	res.Update(ctx, req, resp)
 
-	if resp.Diagnostics.HasError() {
-		t.Errorf("dbaasuser Update() error: %v", resp.Diagnostics)
+	if !resp.Diagnostics.HasError() {
+		t.Error("dbaasuser Update() should return an error because update is not supported")
 	}
 }
 


### PR DESCRIPTION
Closes #252. Supersedes PR #261 (which only addressed the password env-var; this PR also fixes the root cause).

## Root cause

The ArubaCloud DBaaS user and grant APIs have **no update endpoint**. Any change attempt returns a non-2xx error. The provider was exposing mutable fields that it could never actually update.

## Changes

****
- , , ,  → 
-  replaced with a stub that returns a clear diagnostic error

****
- , , , ,  → 
-  replaced with a stub that returns a clear diagnostic error

**Tests**
-  now asserts  returns an error
-  step 3 (role change) is documented as a *replace* step
- Both acceptance tests use  env var for the user password via  (defined in )

## Test plan
- [ ]  passes
- [ ]  (set )
- [ ]  (set )
- [ ]  with a username/password/role change shows 

🤖 Generated with [Claude Code](https://claude.com/claude-code)