### PR TITLE
test(vpc): poll until 404 in drift test to reliably detect out-of-band deletion (#279)

### DIFF
--- a/internal/provider/provider_drift_test.go
+++ b/internal/provider/provider_drift_test.go
@@ -60,9 +60,21 @@ resource "arubacloud_vpc" "drift" {
 					if err != nil {
 						return
 					}
+					ctx := context.Background()
 					ref := aruba.URI("/projects/" + projectID + "/network/vpcs/" + capturedID)
-					_ = client.Client.FromNetwork().VPCs().Delete(context.Background(), ref)
-					time.Sleep(15 * time.Second)
+					_ = client.Client.FromNetwork().VPCs().Delete(ctx, ref)
+					// Poll until the API returns 404 so that Read() reliably detects
+					// the drift via the 404 path rather than a transient Deleting state.
+					deadline := time.Now().Add(5 * time.Minute)
+					for time.Now().Before(deadline) {
+						time.Sleep(5 * time.Second)
+						_, getErr := client.Client.FromNetwork().VPCs().Get(ctx, ref)
+						if provErr := CheckResponseErr("get", "VPC", getErr); provErr != nil {
+							if IsNotFound(provErr) {
+								return
+							}
+						}
+					}
 				},
 				Config:             cfg,
 				PlanOnly:           true,

--- a/internal/provider/vpc_resource.go
+++ b/internal/provider/vpc_resource.go
@@ -195,6 +195,10 @@ func (r *VPCResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 	case isFailedState(st):
 		resp.Diagnostics.AddWarning("Resource in Failed State",
 			fmt.Sprintf("VPC %q is in a terminal failure state (%s).", data.Id.ValueString(), st))
+	case st == "Deleting":
+		// VPC was deleted outside of Terraform; remove from state so drift is detected.
+		resp.State.RemoveResource(ctx)
+		return
 	case IsCreatingState(st):
 		if waitErr := vpc.WaitUntilReady(ctx, sdkWaitOptions(r.client.ResourceTimeout)...); waitErr != nil {
 			ReportWaitResult(&resp.Diagnostics, waitErr, "VPC", data.Id.ValueString())

--- a/internal/provider/vpc_resource.go
+++ b/internal/provider/vpc_resource.go
@@ -195,10 +195,6 @@ func (r *VPCResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 	case isFailedState(st):
 		resp.Diagnostics.AddWarning("Resource in Failed State",
 			fmt.Sprintf("VPC %q is in a terminal failure state (%s).", data.Id.ValueString(), st))
-	case st == "Deleting":
-		// VPC was deleted outside of Terraform; remove from state so drift is detected.
-		resp.State.RemoveResource(ctx)
-		return
 	case IsCreatingState(st):
 		if waitErr := vpc.WaitUntilReady(ctx, sdkWaitOptions(r.client.ResourceTimeout)...); waitErr != nil {
 			ReportWaitResult(&resp.Diagnostics, waitErr, "VPC", data.Id.ValueString())


### PR DESCRIPTION
Closes #279

## Summary

The original approach treated state=Deleting as gone inside VPCResource.Read, but this is incorrect: Deleting is a transient state — the deletion could fail and the VPC might revert to Active. Removing the resource from state prematurely would cause Terraform to lose track of it.

The root cause was in the acceptance test: after deleting the VPC out-of-band, it only slept 15 seconds before running the refresh plan. That is not long enough for the deletion to propagate, so the API still returned the VPC in Deleting state rather than 404, and no drift was detected.

## Changes

- provider_drift_test.go: replaced time.Sleep(15s) with a poll loop that retries every 5 s for up to 5 min, waiting until the API returns 404 before proceeding. This ensures the test always hits the existing 404 branch in Read, which already calls resp.State.RemoveResource and triggers the expected non-empty plan.
- vpc_resource.go: no provider logic changed.

## Test plan
- [ ] TestAccVpcResource_DetectsDriftAfterOutOfBandDelete step 2 should now produce a non-empty refresh plan consistently, regardless of how long VPC deletion takes

Generated with Claude Code
