### PR TITLE
fix(schedulejob): treat state=Deleted as gone in deletion poll (#280)

### DIFF
--- a/internal/provider/schedulejob_resource.go
+++ b/internal/provider/schedulejob_resource.go
@@ -493,6 +493,12 @@ func (r *ScheduleJobResource) Read(ctx context.Context, req resource.ReadRequest
 
 	st := string(job.State())
 	switch {
+	case st == "Deleted":
+		// API bug workaround: the backend returns HTTP 200 with state=Deleted instead
+		// of 404 for jobs that have been deleted. Treat as gone so Read does not
+		// leave a stale entry in state.
+		resp.State.RemoveResource(ctx)
+		return
 	case isFailedState(st):
 		resp.Diagnostics.AddWarning("Resource in Failed State",
 			fmt.Sprintf("ScheduleJob %q is in a terminal failure state (%s). "+
@@ -602,13 +608,21 @@ func (r *ScheduleJobResource) Delete(ctx context.Context, req resource.DeleteReq
 			}
 			return false, provErr
 		}
-		// The API may acknowledge DELETE without transitioning the resource to
-		// 404 when the job is already in a terminal failure state.  Treat this
-		// as "gone" so we do not block indefinitely, but surface a warning so
-		// operators can verify the resource was actually removed from the project.
-		if job != nil && isFailedState(string(job.State())) {
-			failedAfterDelete = true
-			return true, nil
+		if job != nil {
+			st := string(job.State())
+			// API bug workaround: the backend returns HTTP 200 with state=Deleted
+			// instead of 404 for jobs that have been deleted. Treat as gone.
+			// Also treat Deleting as terminal to avoid infinite polling when the
+			// API acknowledges DELETE but never transitions to 404.
+			if st == "Deleted" || st == "Deleting" {
+				return true, nil
+			}
+			// If the job is in a terminal failure state after delete, surface a
+			// warning so operators can verify the resource was actually removed.
+			if isFailedState(st) {
+				failedAfterDelete = true
+				return true, nil
+			}
 		}
 		return false, nil
 	}


### PR DESCRIPTION
Closes #280

## Summary

**API bug workaround** (tracked internally, API fix pending):

The ArubaCloud backend returns HTTP 200 with  for already-deleted jobs instead of 404. This caused  to poll indefinitely (until the 2-hour test timeout) because the 404 check never triggered.

### Changes
- **Deletion checker** now recognises  (API bug workaround) and  as terminal success conditions - the deletion poll exits immediately
- **Read** now calls  when it observes , preventing a stale Terraform state entry if Read is called after deletion

## Test plan
- [ ]  should no longer hang - the WaitForResourceDeleted call exits as soon as the API returns 
- [ ] Delete step should complete within the normal resource timeout instead of requiring the 2-hour test timeout to fire

Generated with Claude Code