### PR TITLE
test(dbaasuser,databasegrant): read password from env var in data source tests (#273)

### DIFF
--- a/internal/provider/databasegrant_data_source_test.go
+++ b/internal/provider/databasegrant_data_source_test.go
@@ -16,13 +16,14 @@ func TestAccDatabasegrantDataSource(t *testing.T) {
 	if projectID == "" {
 		t.Skip("ARUBACLOUD_PROJECT_ID must be set for acceptance tests")
 	}
+	password := testAccDBaaSPassword(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatabasegrantDataSourceConfig(projectID),
+				Config: testAccDatabasegrantDataSourceConfig(projectID, password),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"data.arubacloud_databasegrant.test",
@@ -60,7 +61,7 @@ func TestAccDatabasegrantDataSource(t *testing.T) {
 	})
 }
 
-func testAccDatabasegrantDataSourceConfig(projectID string) string {
+func testAccDatabasegrantDataSourceConfig(projectID, password string) string {
 	return fmt.Sprintf(`
 resource "arubacloud_vpc" "test" {
   name       = "test-ds-dbgrant-vpc"
@@ -106,7 +107,7 @@ resource "arubacloud_dbaasuser" "test" {
   project_id = %[1]q
   dbaas_id   = arubacloud_dbaas.test.id
   username   = "testdsgrantuser"
-  password   = "Acc3ptAbl3P@ss#01"
+  password   = %[2]q
 }
 
 resource "arubacloud_database" "test" {
@@ -129,5 +130,5 @@ data "arubacloud_databasegrant" "test" {
   database   = arubacloud_database.test.name
   user_id    = arubacloud_dbaasuser.test.username
 }
-`, projectID)
+`, projectID, password)
 }

--- a/internal/provider/dbaasuser_data_source_test.go
+++ b/internal/provider/dbaasuser_data_source_test.go
@@ -16,13 +16,14 @@ func TestAccDbaasuserDataSource(t *testing.T) {
 	if projectID == "" {
 		t.Skip("ARUBACLOUD_PROJECT_ID must be set for acceptance tests")
 	}
+	password := testAccDBaaSPassword(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDbaasuserDataSourceConfig(projectID),
+				Config: testAccDbaasuserDataSourceConfig(projectID, password),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"data.arubacloud_dbaasuser.test",
@@ -50,7 +51,7 @@ func TestAccDbaasuserDataSource(t *testing.T) {
 	})
 }
 
-func testAccDbaasuserDataSourceConfig(projectID string) string {
+func testAccDbaasuserDataSourceConfig(projectID, password string) string {
 	return fmt.Sprintf(`
 resource "arubacloud_vpc" "test" {
   name       = "test-ds-dbaasuser-vpc"
@@ -96,7 +97,7 @@ resource "arubacloud_dbaasuser" "test" {
   project_id = %[1]q
   dbaas_id   = arubacloud_dbaas.test.id
   username   = "testdsuser"
-  password   = "Acc3ptAbl3P@ss#01"
+  password   = %[2]q
 }
 
 data "arubacloud_dbaasuser" "test" {
@@ -104,5 +105,5 @@ data "arubacloud_dbaasuser" "test" {
   project_id = %[1]q
   dbaas_id   = arubacloud_dbaas.test.id
 }
-`, projectID)
+`, projectID, password)
 }


### PR DESCRIPTION
Closes #273

## Summary
- Data source tests for rubacloud_dbaasuser and rubacloud_databasegrant used a hardcoded password that is rejected when the API tightens its validation
- Applies the same pattern already used by the corresponding resource tests: reads from ARUBACLOUD_DBAAS_PASSWORD via 	estAccDBaaSPassword(t), which skips with a clear message when the variable is absent

## Test plan
- [ ] TestAccDbaasuserDataSource skips cleanly when ARUBACLOUD_DBAAS_PASSWORD is not set
- [ ] TestAccDatabasegrantDataSource skips cleanly when ARUBACLOUD_DBAAS_PASSWORD is not set
- [ ] Both tests pass when ARUBACLOUD_DBAAS_PASSWORD is set to a valid password

Generated with Claude Code