### PR TITLE
test(dbaas): ignore zone, engine_id, network.* in ImportStateVerify (#274)

### DIFF
--- a/internal/provider/dbaas_resource_test.go
+++ b/internal/provider/dbaas_resource_test.go
@@ -49,6 +49,19 @@ func TestAccDbaasResource(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: importIDFromAttrs("arubacloud_dbaas.test", "project_id", "id"),
+				// zone, engine_id and network.* are not returned by the API GET response.
+				// Read preserves them from prior state, but on import the initial state
+				// only has project_id + id so they remain null after the first Read.
+				// Users must re-specify these values in their config after import.
+				ImportStateVerifyIgnore: []string{
+					"zone",
+					"engine_id",
+					"network.%",
+					"network.vpc_uri_ref",
+					"network.subnet_uri_ref",
+					"network.security_group_uri_ref",
+					"network.elastic_ip_uri_ref",
+				},
 			},
 			{
 				Config: testAccDbaasResourceConfig(projectID, "test-dbaas-updated"),


### PR DESCRIPTION
Closes #274

## Summary
- zone, engine_id, and all 
etwork.* sub-attributes are not returned by the API GET response
- Read preserves them from the existing Terraform state, but on 	erraform import the initial state only contains project_id and id, so these fields are null after the first Read
- Added ImportStateVerifyIgnore for these fields with an inline comment documenting why
- Users must re-specify zone, engine_id, and 
etwork in their Terraform config after 	erraform import

## Test plan
- [ ] TestAccDbaasResource import step should now pass without ImportStateVerify mismatch errors
- [ ] Create and update steps should be unaffected

Generated with Claude Code