### PR TITLE
test(kaas): fix zone check path in resource test (#277)

### DIFF
--- a/internal/provider/kaas_resource_test.go
+++ b/internal/provider/kaas_resource_test.go
@@ -57,7 +57,7 @@ func TestAccKaasResource(t *testing.T) {
 					),
 					statecheck.ExpectKnownValue(
 						"arubacloud_kaas.test",
-						tfjsonpath.New("zone"),
+						tfjsonpath.New("settings").AtMapKey("node_pools").AtSliceIndex(0).AtMapKey("zone"),
 						knownvalue.NotNull(),
 					),
 				},


### PR DESCRIPTION
Closes #277

## Summary
The KaaS resource has no top-level zone attribute. The zone is nested inside settings.node_pools[0].zone. The test was checking a nonexistent top-level key, causing:

  path not found: specified key zone not found in map at zone

Fixed the tfjsonpath to use the correct nested path.

## Test plan
- [ ] TestAccKaasResource step 1 state check should pass without path not found error

Generated with Claude Code