### PR TITLE
fix(kaas): preserve management_ip and pod_cidr from state when API omits them (#276)

### DIFF
--- a/internal/provider/kaas_resource.go
+++ b/internal/provider/kaas_resource.go
@@ -562,6 +562,10 @@ func (r *KaaSResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	}
 	if raw.Properties.ManagementIP != nil && *raw.Properties.ManagementIP != "" {
 		data.ManagementIP = types.StringValue(*raw.Properties.ManagementIP)
+	} else if !originalState.ManagementIP.IsNull() {
+		// API does not always return ManagementIP after initial provisioning;
+		// preserve from state to avoid perpetual drift.
+		data.ManagementIP = originalState.ManagementIP
 	} else {
 		data.ManagementIP = types.StringNull()
 	}
@@ -612,6 +616,13 @@ func (r *KaaSResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	}
 	if v := kaas.PodCIDR(); v != "" {
 		networkAttrs["pod_cidr"] = types.StringValue(v)
+	} else if !originalState.Network.IsNull() {
+		// API does not reliably return pod_cidr after initial provisioning;
+		// fall back to the state value to avoid perpetual drift.
+		var origNet KaaSNetworkModel
+		if dd := originalState.Network.As(ctx, &origNet, basetypes.ObjectAsOptions{}); !dd.HasError() && !origNet.PodCIDR.IsNull() {
+			networkAttrs["pod_cidr"] = origNet.PodCIDR
+		}
 	}
 	networkObj, dNet := types.ObjectValue(map[string]attr.Type{
 		"vpc_uri_ref": types.StringType, "subnet_uri_ref": types.StringType,


### PR DESCRIPTION
Closes #276

## Summary
The API does not reliably return management_ip or pod_cidr in GET responses after the cluster is provisioned. Previously Read set both to null when the API returned empty values, causing perpetual drift.

### Changes
- management_ip: preserved from prior state when API returns empty/nil, cleared only if state was already null
- pod_cidr: same pattern, also checking original network state
- Follows the same approach already used for security_group_name and node_cidr.name in the same Read function

## Test plan
- [ ] TestAccKaasDataSource: post-apply refresh plan should be empty (no management_ip or pod_cidr drift)
- [ ] TestAccKaasResource: all steps should pass without perpetual diff on these fields

Generated with Claude Code