### PR TITLE
fix(backup): mark retention_days as RequiresReplace (#269)

### DIFF
--- a/docs/resources/backup.md
+++ b/docs/resources/backup.md
@@ -46,7 +46,7 @@ The following arguments are supported:
 #### Optional
 
 - `billing_period` (String) Billing cycle. Accepted values: `Hour`, `Month`, `Year`.
-- `retention_days` (Number) Number of days to retain the backup before automatic deletion. Optional — if omitted, the backup is retained indefinitely.
+- `retention_days` (Number) Number of days to retain the backup before automatic deletion. Optional — if omitted, the backup is retained indefinitely. (Immutable — changing this value forces the resource to be destroyed and re-created, because the API does not apply retention_days changes in update requests.)
 - `tags` (List of String) List of string tags attached to the resource for filtering and organisation.
 - `timeout` (String) Per-resource timeout override (e.g. `"15m"`, `"1h"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.
 

--- a/internal/provider/backup_resource.go
+++ b/internal/provider/backup_resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -106,8 +107,11 @@ func (r *BackupResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				},
 			},
 			"retention_days": schema.Int64Attribute{
-				MarkdownDescription: "Number of days to retain the backup before automatic deletion. Optional — if omitted, the backup is retained indefinitely.",
+				MarkdownDescription: "Number of days to retain the backup before automatic deletion. Optional — if omitted, the backup is retained indefinitely. (Immutable — changing this value forces the resource to be destroyed and re-created, because the API does not apply retention_days changes in update requests.)",
 				Optional:            true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.RequiresReplace(),
+				},
 			},
 			"billing_period": schema.StringAttribute{
 				MarkdownDescription: "Billing cycle. Accepted values: `Hour`, `Month`, `Year`.",
@@ -356,7 +360,7 @@ func (r *BackupResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	// Preserve truly immutable fields from state.
+	// Preserve immutable fields from state.
 	data.Id = state.Id
 	data.ProjectID = state.ProjectID
 	data.Uri = state.Uri
@@ -364,7 +368,7 @@ func (r *BackupResource) Update(ctx context.Context, req resource.UpdateRequest,
 	data.Type = state.Type
 	data.BillingPeriod = state.BillingPeriod
 	data.Location = state.Location
-	// retention_days is mutable: keep the plan value (already in data).
+	data.RetentionDays = state.RetentionDays
 	data.Name = types.StringValue(updated.Name())
 	data.Tags = TagsToListPreserveNull(updated.Tags(), data.Tags)
 


### PR DESCRIPTION
Closes #269

## Summary
The API silently ignores  in update payloads. After an update the subsequent Read refreshes state from the GET response which carries the old value, causing a perpetual plan diff (state reverts from 60 back to 30 on every refresh).

### Changes
-  is now  so Terraform destroys and re-creates the backup when the value changes
-  also explicitly preserves the state value for retention_days as belt-and-suspenders

## Breaking change
Users who were changing  via update will now see a destroy+create plan instead of an in-place update. This is the correct behaviour since the API does not support in-place updates of this field.

## Test plan
- [ ] Changing retention_days in TestAccBackupResource step 3 should trigger a destroy+create plan and succeed
- [ ] Post-apply refresh plan should be empty (no drift)

Generated with Claude Code