### PR TITLE
fix: surface semantic delete errors, fix containerregistry path, retr…

### DIFF
--- a/ai/ARCHITECTURE.md
+++ b/ai/ARCHITECTURE.md
@@ -116,7 +116,7 @@ Canonical pattern (`cloudserver_resource.go:187-434`, `backup_resource.go:108-26
 2. Extract nested objects and validate required IDs
 3. Build SDK request struct (e.g., `sdktypes.CloudServerRequest`, `sdktypes.StorageBackupRequest`)
 4. Call SDK `Create()`
-5. Check `response.IsError()` → call `FormatAPIError()` → `resp.Diagnostics.AddError()`
+5. Check error via `CheckResponseErr()` → `resp.Diagnostics.AddError()`
 6. Extract `*response.Data.Metadata.ID` → set `data.Id`
 7. **Wait**: call `WaitForResourceActive()` with a checker closure that calls `Get()` and returns `*response.Data.Status.State`
 8. On timeout: save partial state (with ID) so destroy can clean up
@@ -217,23 +217,27 @@ This allows `DeleteResourceWithRetry` to work with any SDK response type without
 
 ---
 
-## API Error Formatting — FormatAPIError
+## API Error Handling — CheckResponseErr
 
-`error_helper.go:14-78` — formats API errors for user-facing diagnostics:
+`provider_error.go` — wraps SDK errors into a structured `*ProviderError` with category classification:
 
 ```go
-FormatAPIError(ctx, response.Error, "Failed to create backup", map[string]interface{}{
-    "project_id": projectID,
-})
+if provErr := CheckResponseErr("create", "Backup", err); provErr != nil {
+    resp.Diagnostics.AddError("API Error", provErr.Error())
+    return
+}
 ```
 
-**Processing**:
-1. Appends `Title` and `Detail` into a readable message
-2. Extracts field-level validation errors from `Extensions["errors"]` array:
-   - Each entry: `{fieldName: "...", errorMessage: "..."}`
-   - Formats as: `"\n  - fieldName: errorMessage"`
-3. Falls back to dumping all `Extensions` keys if not in validation format
-4. Logs full JSON response via `tflog.Error()` for debugging
+**Error categories** (`ProviderErrorCategory`):
+- `Semantic` — HTTP 4xx with field-level validation errors; permanent, never retried
+- `Transient` — HTTP 4xx without validation details; dependency not ready yet, retried by `CreateWithTransientRetry`
+- `Technical` — network/transport failure or HTTP 5xx; retried by `DeleteResourceWithRetry`
+
+**Helpers**:
+- `IsNotFound(err)` — true when status code is 404
+- `ErrorIsSemantic(err)` — true for permanent validation failures; stops delete retry immediately
+- `ErrorIsTransient(err)` — true for transient 4xx; used by `CreateWithTransientRetry`
+- `CheckResponseErrAsError(...)` — returns plain `error` (avoids typed-nil pitfall in closures)
 
 ---
 

--- a/ai/CONVENTIONS.md
+++ b/ai/CONVENTIONS.md
@@ -231,15 +231,21 @@ resp.Diagnostics.AddAttributeError(
 )
 ```
 
-**API error**:
+**API error** (use `CheckResponseErr` from `provider_error.go`):
 ```go
-if response != nil && response.IsError() && response.Error != nil {
-    errorMsg := FormatAPIError(ctx, response.Error, "Failed to create backup", map[string]interface{}{
-        "project_id": projectID,
-    })
-    resp.Diagnostics.AddError("API Error", errorMsg)
+if provErr := CheckResponseErr("create", "Backup", err); provErr != nil {
+    resp.Diagnostics.AddError("API Error", provErr.Error())
     return
 }
+```
+
+Use `CheckResponseErrAsError` in closures passed to `DeleteResourceWithRetry` or `CreateWithTransientRetry`
+to avoid the typed-nil interface bug:
+```go
+err := DeleteResourceWithRetry(ctx, func() error {
+    return CheckResponseErrAsError("delete", "Backup",
+        r.client.Client.FromStorage().Backups().Delete(ctx, ref))
+}, "Backup", backupID, r.client.ResourceTimeout)
 ```
 
 **404 handling in Read** (removes resource from state):

--- a/internal/acctest/cloudserver_data_source_test.go
+++ b/internal/acctest/cloudserver_data_source_test.go
@@ -94,6 +94,7 @@ resource "arubacloud_blockstorage" "boot" {
   type           = "Standard"
   bootable       = true
   image          = %[2]q
+  timeout        = "2h"
 }
 
 resource "arubacloud_cloudserver" "test" {

--- a/internal/acctest/containerregistry_resource_test.go
+++ b/internal/acctest/containerregistry_resource_test.go
@@ -79,7 +79,7 @@ func testCheckContainerregistryDestroyed(s *terraform.State) error {
 			continue
 		}
 		projectID := rs.Primary.Attributes["project_id"]
-		ref := aruba.URI("/projects/" + projectID + "/providers/Aruba.Container/containerRegistries/" + rs.Primary.ID)
+		ref := aruba.URI("/projects/" + projectID + "/providers/Aruba.Container/registries/" + rs.Primary.ID)
 		_, err = client.Client.FromContainer().ContainerRegistry().Get(ctx, ref)
 		if provErr := provider.CheckResponseErr("get", "Containerregistry", err); provErr != nil {
 			if provider.IsNotFound(provErr) {

--- a/internal/provider/databasebackup_resource.go
+++ b/internal/provider/databasebackup_resource.go
@@ -208,8 +208,12 @@ func (r *DatabaseBackupResource) Create(ctx context.Context, req resource.Create
 			break
 		}
 		lastProvErr = pe
-		if !strings.Contains(pe.Error(), "Database name is not found") {
-			break // not a propagation-related error; stop retrying
+		// Retry on "database not yet visible" AND transport-level failures (EOF after
+		// a long database provisioning wait, indicated by zero StatusCode).
+		// HTTP 5xx server errors have a non-zero StatusCode and are not retried.
+		isTransportFailure := pe.StatusCode == 0
+		if !strings.Contains(pe.Error(), "Database name is not found") && !isTransportFailure {
+			break
 		}
 		if attempt == backupMaxRetries {
 			break

--- a/internal/provider/error_helper.go
+++ b/internal/provider/error_helper.go
@@ -1,1 +1,0 @@
-package provider

--- a/internal/provider/resource_wait.go
+++ b/internal/provider/resource_wait.go
@@ -384,6 +384,11 @@ func DeleteResourceWithRetry(
 				tflog.Info(ctx, fmt.Sprintf("%s %s already deleted (404)", resourceType, resourceID))
 				return nil
 			}
+			// Semantic errors (validation failures such as "cannot delete default VPC")
+			// are permanent — retrying with the same inputs will never succeed.
+			if ErrorIsSemantic(err) {
+				return err
+			}
 
 			// Before waiting and retrying, check if the resource is already gone
 			// via GET. This handles APIs that return 400 on a second DELETE of an


### PR DESCRIPTION
Here's a summary of every change on the branch:

internal/provider/resource_wait.go — fixes #295 + #294 hang

Added a semantic error short-circuit in DeleteResourceWithRetry. Errors classified as Semantic (HTTP 4xx with field-level validation details, e.g. "cannot delete default VPC") now return immediately instead of retrying for the full ResourceTimeout. Previously these would loop for 30+ minutes.

internal/acctest/containerregistry_resource_test.go — fixes #292

testCheckContainerregistryDestroyed was building the SDK ref with /containerRegistries/ in the path. The SDK's ID parser requires /registries/ (the same fix already applied in containerRegistryRef). Changed to match.

internal/acctest/cloudserver_data_source_test.go — fixes #293

Added timeout = "2h" to arubacloud_blockstorage.boot in the data-source test config. The boot volume is deleted asynchronously after the CloudServer is destroyed and can take longer than the 10-minute provider default, causing WaitForResourceDeleted to time out during cleanup.

internal/provider/databasebackup_resource.go — fixes #272

The backup-create retry loop now also retries on transport-level failures (pe.StatusCode == 0, e.g. EOF) in addition to "Database name is not found". HTTP 5xx server errors (non-zero status code) still stop the loop immediately, preserving the existing test behaviour.

internal/provider/error_helper.go — fixes #300

File deleted (it was package provider only — FormatAPIError was already removed and billingPeriodFromAPI lives in tag_helpers.go).

ai/ARCHITECTURE.md + ai/CONVENTIONS.md — fixes #300

Removed all stale FormatAPIError references and replaced them with the current CheckResponseErr / CheckResponseErrAsError pattern and its error-category model.