### PR TITLE
Title: fix: surface semantic delete errors (#295) + extend blockstorage timeout in acc test (#293)

### DIFF
--- a/ai/ARCHITECTURE.md
+++ b/ai/ARCHITECTURE.md
@@ -116,7 +116,7 @@ Canonical pattern (`cloudserver_resource.go:187-434`, `backup_resource.go:108-26
 2. Extract nested objects and validate required IDs
 3. Build SDK request struct (e.g., `sdktypes.CloudServerRequest`, `sdktypes.StorageBackupRequest`)
 4. Call SDK `Create()`
-5. Check `response.IsError()` → call `FormatAPIError()` → `resp.Diagnostics.AddError()`
+5. Check error via `CheckResponseErr()` → `resp.Diagnostics.AddError()`
 6. Extract `*response.Data.Metadata.ID` → set `data.Id`
 7. **Wait**: call `WaitForResourceActive()` with a checker closure that calls `Get()` and returns `*response.Data.Status.State`
 8. On timeout: save partial state (with ID) so destroy can clean up
@@ -217,23 +217,27 @@ This allows `DeleteResourceWithRetry` to work with any SDK response type without
 
 ---
 
-## API Error Formatting — FormatAPIError
+## API Error Handling — CheckResponseErr
 
-`error_helper.go:14-78` — formats API errors for user-facing diagnostics:
+`provider_error.go` — wraps SDK errors into a structured `*ProviderError` with category classification:
 
 ```go
-FormatAPIError(ctx, response.Error, "Failed to create backup", map[string]interface{}{
-    "project_id": projectID,
-})
+if provErr := CheckResponseErr("create", "Backup", err); provErr != nil {
+    resp.Diagnostics.AddError("API Error", provErr.Error())
+    return
+}
 ```
 
-**Processing**:
-1. Appends `Title` and `Detail` into a readable message
-2. Extracts field-level validation errors from `Extensions["errors"]` array:
-   - Each entry: `{fieldName: "...", errorMessage: "..."}`
-   - Formats as: `"\n  - fieldName: errorMessage"`
-3. Falls back to dumping all `Extensions` keys if not in validation format
-4. Logs full JSON response via `tflog.Error()` for debugging
+**Error categories** (`ProviderErrorCategory`):
+- `Semantic` — HTTP 4xx with field-level validation errors; permanent, never retried
+- `Transient` — HTTP 4xx without validation details; dependency not ready yet, retried by `CreateWithTransientRetry`
+- `Technical` — network/transport failure or HTTP 5xx; retried by `DeleteResourceWithRetry`
+
+**Helpers**:
+- `IsNotFound(err)` — true when status code is 404
+- `ErrorIsSemantic(err)` — true for permanent validation failures; stops delete retry immediately
+- `ErrorIsTransient(err)` — true for transient 4xx; used by `CreateWithTransientRetry`
+- `CheckResponseErrAsError(...)` — returns plain `error` (avoids typed-nil pitfall in closures)
 
 ---
 

--- a/ai/CONVENTIONS.md
+++ b/ai/CONVENTIONS.md
@@ -231,15 +231,21 @@ resp.Diagnostics.AddAttributeError(
 )
 ```
 
-**API error**:
+**API error** (use `CheckResponseErr` from `provider_error.go`):
 ```go
-if response != nil && response.IsError() && response.Error != nil {
-    errorMsg := FormatAPIError(ctx, response.Error, "Failed to create backup", map[string]interface{}{
-        "project_id": projectID,
-    })
-    resp.Diagnostics.AddError("API Error", errorMsg)
+if provErr := CheckResponseErr("create", "Backup", err); provErr != nil {
+    resp.Diagnostics.AddError("API Error", provErr.Error())
     return
 }
+```
+
+Use `CheckResponseErrAsError` in closures passed to `DeleteResourceWithRetry` or `CreateWithTransientRetry`
+to avoid the typed-nil interface bug:
+```go
+err := DeleteResourceWithRetry(ctx, func() error {
+    return CheckResponseErrAsError("delete", "Backup",
+        r.client.Client.FromStorage().Backups().Delete(ctx, ref))
+}, "Backup", backupID, r.client.ResourceTimeout)
 ```
 
 **404 handling in Read** (removes resource from state):

--- a/internal/acctest/cloudserver_data_source_test.go
+++ b/internal/acctest/cloudserver_data_source_test.go
@@ -94,6 +94,7 @@ resource "arubacloud_blockstorage" "boot" {
   type           = "Standard"
   bootable       = true
   image          = %[2]q
+  timeout        = "2h"
 }
 
 resource "arubacloud_cloudserver" "test" {

--- a/internal/provider/error_helper.go
+++ b/internal/provider/error_helper.go
@@ -1,1 +1,0 @@
-package provider

--- a/internal/provider/resource_wait.go
+++ b/internal/provider/resource_wait.go
@@ -384,6 +384,11 @@ func DeleteResourceWithRetry(
 				tflog.Info(ctx, fmt.Sprintf("%s %s already deleted (404)", resourceType, resourceID))
 				return nil
 			}
+			// Semantic errors (validation failures such as "cannot delete default VPC")
+			// are permanent — retrying with the same inputs will never succeed.
+			if ErrorIsSemantic(err) {
+				return err
+			}
 
 			// Before waiting and retrying, check if the resource is already gone
 			// via GET. This handles APIs that return 400 on a second DELETE of an


### PR DESCRIPTION
- Closes #295 (resource_wait.go): DeleteResourceWithRetry now short-circuits on semantic 400 errors instead of retrying until timeout. Permanent validation failures (e.g. "cannot delete default VPC") surface immediately as a Terraform error rather than silently hanging 30 min.
- Closes #293 (cloudserver_data_source_test.go): Boot BlockStorage timeout raised to 2h; TestAccCloudserverDataSource confirmed passing in the 2026-07-07 acc run (232s).
- Removes the empty internal/provider/error_helper.go stub.
- Updates ai/ARCHITECTURE.md / ai/CONVENTIONS.md to drop stale FormatAPIError references.