### PR TITLE
fix(dbaas,databasebackup): resolve billing_period unknown, correct backup wire format, fix update regressions (#294)

### DIFF
--- a/docs/resources/databasebackup.md
+++ b/docs/resources/databasebackup.md
@@ -35,7 +35,6 @@ The following arguments are supported:
 - `database` (String) Name of the logical database within the DBaaS cluster to back up.
 - `dbaas_id` (String) ID of the DBaaS cluster or database to back up.
 - `location` (String) Region identifier (e.g., `ITBG-Bergamo`). See the [available locations and zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center).
-- `name` (String) Display name for the database backup.
 - `project_id` (String) ID of the project that owns this resource.
 - `zone` (String) Availability zone within the region where the backup is stored.
 
@@ -51,6 +50,7 @@ In addition to all arguments above, the following attributes are exported:
 #### Read-Only
 
 - `id` (String) Computed by the API. Unique identifier for the resource.
+- `name` (String) Auto-generated backup name assigned by the API (e.g. `mysql_wordpress_20260713140736`). The value provided in config is not used — the API always generates its own name.
 - `uri` (String) Computed by the API. Full resource URI used as a reference value in other resources.
 
 

--- a/go.mod
+++ b/go.mod
@@ -81,3 +81,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/utils v0.0.0-20260507154919-ff6756f316d2 // indirect
 )
+
+replace github.com/Arubacloud/sdk-go => ../sdk-go

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Arubacloud/terraform-provider-arubacloud
 go 1.24.0
 
 require (
-	github.com/Arubacloud/sdk-go v1.0.4
+	github.com/Arubacloud/sdk-go v1.0.5
 	github.com/hashicorp/terraform-plugin-framework v1.16.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.29.0
@@ -81,5 +81,3 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/utils v0.0.0-20260507154919-ff6756f316d2 // indirect
 )
-
-replace github.com/Arubacloud/sdk-go => ../sdk-go

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/Arubacloud/sdk-go v1.0.4 h1:RUmmvojnIyHFAY0gE/jujfbbs7qY+ecpgv9fxEcp87w=
-github.com/Arubacloud/sdk-go v1.0.4/go.mod h1:OD2PSOa9uAxrhFwDcYcw+LE7eyZ+OQVaTA2tlHxVE4U=
+github.com/Arubacloud/sdk-go v1.0.5 h1:ElZ9mPTgCPGUQcNylGj+jYfrTfMoF0MJz3RYagjjt38=
+github.com/Arubacloud/sdk-go v1.0.5/go.mod h1:OD2PSOa9uAxrhFwDcYcw+LE7eyZ+OQVaTA2tlHxVE4U=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.1.6 h1:ZcV+Ropw6Qn0AX9brlQLAUXfqLBc7Bl+f/DmNxpLfdw=

--- a/internal/acctest/databasebackup_data_source_test.go
+++ b/internal/acctest/databasebackup_data_source_test.go
@@ -81,6 +81,7 @@ resource "arubacloud_dbaas" "test" {
   engine_id  = "mysql-8.0"
   flavor     = "DBO2A4"
   tags       = ["acceptance-test"]
+  timeout    = "10m"
 
   storage = {
     size_gb = 20

--- a/internal/acctest/databasebackup_data_source_test.go
+++ b/internal/acctest/databasebackup_data_source_test.go
@@ -95,7 +95,7 @@ resource "arubacloud_dbaas" "test" {
 }
 
 resource "arubacloud_database" "test" {
-  name       = "testdb"
+  name       = "testaccbackupds"
   project_id = %[1]q
   dbaas_id   = arubacloud_dbaas.test.id
 }

--- a/internal/acctest/databasebackup_data_source_test.go
+++ b/internal/acctest/databasebackup_data_source_test.go
@@ -14,8 +14,9 @@ import (
 func TestAccDatabasebackupDataSource(t *testing.T) {
 	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
 	dbaasID := os.Getenv("ARUBACLOUD_DBAAS_ID")
-	if projectID == "" || dbaasID == "" {
-		t.Skip("ARUBACLOUD_PROJECT_ID and ARUBACLOUD_DBAAS_ID must be set for acceptance tests")
+	databaseName := os.Getenv("ARUBACLOUD_DATABASE_NAME")
+	if projectID == "" || dbaasID == "" || databaseName == "" {
+		t.Skip("ARUBACLOUD_PROJECT_ID, ARUBACLOUD_DBAAS_ID and ARUBACLOUD_DATABASE_NAME must be set for acceptance tests")
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -23,7 +24,7 @@ func TestAccDatabasebackupDataSource(t *testing.T) {
 		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatabasebackupDataSourceConfig(projectID, dbaasID),
+				Config: testAccDatabasebackupDataSourceConfig(projectID, dbaasID, databaseName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"data.arubacloud_databasebackup.test",
@@ -51,22 +52,14 @@ func TestAccDatabasebackupDataSource(t *testing.T) {
 	})
 }
 
-func testAccDatabasebackupDataSourceConfig(projectID, dbaasID string) string {
+func testAccDatabasebackupDataSourceConfig(projectID, dbaasID, databaseName string) string {
 	return fmt.Sprintf(`
-resource "arubacloud_database" "test" {
-  name       = "testaccbackupds"
-  project_id = %[1]q
-  dbaas_id   = %[2]q
-  timeout    = "15m"
-}
-
 resource "arubacloud_databasebackup" "test" {
-  name           = "test-ds-databasebackup"
   project_id     = %[1]q
   location       = "ITBG-Bergamo"
   zone           = "ITBG-1"
   dbaas_id       = %[2]q
-  database       = arubacloud_database.test.name
+  database       = %[3]q
   billing_period = "Hour"
   tags           = ["acceptance-test"]
 }
@@ -75,5 +68,5 @@ data "arubacloud_databasebackup" "test" {
   id         = arubacloud_databasebackup.test.id
   project_id = %[1]q
 }
-`, projectID, dbaasID)
+`, projectID, dbaasID, databaseName)
 }

--- a/internal/acctest/databasebackup_data_source_test.go
+++ b/internal/acctest/databasebackup_data_source_test.go
@@ -13,8 +13,9 @@ import (
 
 func TestAccDatabasebackupDataSource(t *testing.T) {
 	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
-	if projectID == "" {
-		t.Skip("ARUBACLOUD_PROJECT_ID must be set for acceptance tests")
+	dbaasID := os.Getenv("ARUBACLOUD_DBAAS_ID")
+	if projectID == "" || dbaasID == "" {
+		t.Skip("ARUBACLOUD_PROJECT_ID and ARUBACLOUD_DBAAS_ID must be set for acceptance tests")
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -22,7 +23,7 @@ func TestAccDatabasebackupDataSource(t *testing.T) {
 		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatabasebackupDataSourceConfig(projectID),
+				Config: testAccDatabasebackupDataSourceConfig(projectID, dbaasID),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"data.arubacloud_databasebackup.test",
@@ -50,54 +51,13 @@ func TestAccDatabasebackupDataSource(t *testing.T) {
 	})
 }
 
-func testAccDatabasebackupDataSourceConfig(projectID string) string {
+func testAccDatabasebackupDataSourceConfig(projectID, dbaasID string) string {
 	return fmt.Sprintf(`
-resource "arubacloud_vpc" "test" {
-  name       = "test-ds-dbbackup-vpc"
-  location   = "ITBG-Bergamo"
-  project_id = %[1]q
-}
-
-resource "arubacloud_subnet" "test" {
-  name       = "test-ds-dbbackup-subnet"
-  location   = "ITBG-Bergamo"
-  project_id = %[1]q
-  vpc_id     = arubacloud_vpc.test.id
-  type       = "Basic"
-}
-
-resource "arubacloud_securitygroup" "test" {
-  name       = "test-ds-dbbackup-sg"
-  location   = "ITBG-Bergamo"
-  project_id = %[1]q
-  vpc_id     = arubacloud_vpc.test.id
-}
-
-resource "arubacloud_dbaas" "test" {
-  name       = "test-ds-dbbackup-dbaas"
-  location   = "ITBG-Bergamo"
-  zone       = "ITBG-1"
-  project_id = %[1]q
-  engine_id  = "mysql-8.0"
-  flavor     = "DBO2A4"
-  tags       = ["acceptance-test"]
-  timeout    = "10m"
-
-  storage = {
-    size_gb = 20
-  }
-
-  network = {
-    vpc_uri_ref            = arubacloud_vpc.test.uri
-    subnet_uri_ref         = arubacloud_subnet.test.uri
-    security_group_uri_ref = arubacloud_securitygroup.test.uri
-  }
-}
-
 resource "arubacloud_database" "test" {
   name       = "testaccbackupds"
   project_id = %[1]q
-  dbaas_id   = arubacloud_dbaas.test.id
+  dbaas_id   = %[2]q
+  timeout    = "15m"
 }
 
 resource "arubacloud_databasebackup" "test" {
@@ -105,7 +65,7 @@ resource "arubacloud_databasebackup" "test" {
   project_id     = %[1]q
   location       = "ITBG-Bergamo"
   zone           = "ITBG-1"
-  dbaas_id       = arubacloud_dbaas.test.id
+  dbaas_id       = %[2]q
   database       = arubacloud_database.test.name
   billing_period = "Hour"
   tags           = ["acceptance-test"]
@@ -115,5 +75,5 @@ data "arubacloud_databasebackup" "test" {
   id         = arubacloud_databasebackup.test.id
   project_id = %[1]q
 }
-`, projectID)
+`, projectID, dbaasID)
 }

--- a/internal/acctest/databasebackup_resource_test.go
+++ b/internal/acctest/databasebackup_resource_test.go
@@ -96,6 +96,7 @@ resource "arubacloud_database" "dbbackup_prereq" {
   name       = "testaccdbbackupdb"
   project_id = %[1]q
   dbaas_id   = %[2]q
+  timeout    = "15m"
 }
 
 resource "arubacloud_databasebackup" "test" {

--- a/internal/acctest/databasebackup_resource_test.go
+++ b/internal/acctest/databasebackup_resource_test.go
@@ -18,8 +18,9 @@ import (
 func TestAccDatabasebackupResource(t *testing.T) {
 	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
 	dbaasID := os.Getenv("ARUBACLOUD_DBAAS_ID")
-	if projectID == "" || dbaasID == "" {
-		t.Skip("ARUBACLOUD_PROJECT_ID and ARUBACLOUD_DBAAS_ID must be set for acceptance tests")
+	databaseName := os.Getenv("ARUBACLOUD_DATABASE_NAME")
+	if projectID == "" || dbaasID == "" || databaseName == "" {
+		t.Skip("ARUBACLOUD_PROJECT_ID, ARUBACLOUD_DBAAS_ID and ARUBACLOUD_DATABASE_NAME must be set for acceptance tests")
 	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { PreCheck(t) },
@@ -27,12 +28,12 @@ func TestAccDatabasebackupResource(t *testing.T) {
 		CheckDestroy:             testCheckDatabasebackupDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatabasebackupResourceConfig(projectID, dbaasID, "test-databasebackup"),
+				Config: testAccDatabasebackupResourceConfig(projectID, dbaasID, databaseName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_databasebackup.test",
 						tfjsonpath.New("name"),
-						knownvalue.StringExact("test-databasebackup"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						"arubacloud_databasebackup.test",
@@ -53,12 +54,14 @@ func TestAccDatabasebackupResource(t *testing.T) {
 				ImportStateIdFunc: ImportIDFromAttrs("arubacloud_databasebackup.test", "project_id", "id"),
 			},
 			{
-				Config: testAccDatabasebackupResourceConfig(projectID, dbaasID, "test-databasebackup-updated"),
+				// Backup Update is a no-op (API has no update endpoint); verify
+				// the resource stays stable on a second apply.
+				Config: testAccDatabasebackupResourceConfig(projectID, dbaasID, databaseName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_databasebackup.test",
 						tfjsonpath.New("name"),
-						knownvalue.StringExact("test-databasebackup-updated"),
+						knownvalue.NotNull(),
 					),
 				},
 			},
@@ -90,23 +93,15 @@ func testCheckDatabasebackupDestroyed(s *terraform.State) error {
 	return nil
 }
 
-func testAccDatabasebackupResourceConfig(projectID, dbaasID, name string) string {
+func testAccDatabasebackupResourceConfig(projectID, dbaasID, databaseName string) string {
 	return fmt.Sprintf(`
-resource "arubacloud_database" "dbbackup_prereq" {
-  name       = "testaccdbbackupdb"
-  project_id = %[1]q
-  dbaas_id   = %[2]q
-  timeout    = "15m"
-}
-
 resource "arubacloud_databasebackup" "test" {
-  name           = %[3]q
   project_id     = %[1]q
   location       = "ITBG-Bergamo"
   zone           = "ITBG-1"
   dbaas_id       = %[2]q
-  database       = arubacloud_database.dbbackup_prereq.name
+  database       = %[3]q
   billing_period = "Hour"
 }
-`, projectID, dbaasID, name)
+`, projectID, dbaasID, databaseName)
 }

--- a/internal/provider/databasebackup_resource.go
+++ b/internal/provider/databasebackup_resource.go
@@ -208,8 +208,10 @@ func (r *DatabaseBackupResource) Create(ctx context.Context, req resource.Create
 			break
 		}
 		lastProvErr = pe
-		if !strings.Contains(pe.Error(), "Database name is not found") {
-			break // not a propagation-related error; stop retrying
+		// Retry "database not yet visible to the backup API" propagation errors and
+		// pure transport failures (EOF / connection reset, StatusCode == 0).
+		if !strings.Contains(pe.Error(), "Database name is not found") && !ErrorIsTransportFailure(pe) {
+			break
 		}
 		if attempt == backupMaxRetries {
 			break

--- a/internal/provider/databasebackup_resource.go
+++ b/internal/provider/databasebackup_resource.go
@@ -183,9 +183,10 @@ func (r *DatabaseBackupResource) Create(ctx context.Context, req resource.Create
 	}
 
 	// The backup API may take additional time to index the database even after
-	// Databases.Get() succeeds. Retry Create on "Database name not found" errors.
-	const backupRetryInterval = 10 * time.Second
-	const backupMaxRetries = 18 // additional 180 s
+	// Databases.Get() succeeds (the two APIs use separate indexes). Retry Create
+	// on "Database name not found" errors and transport failures for up to 15 min.
+	const backupRetryInterval = 15 * time.Second
+	const backupMaxRetries = 60 // up to 15 min additional
 
 	backupBuilder := aruba.NewDBaaSBackup().
 		Named(data.Name.ValueString()).

--- a/internal/provider/databasebackup_resource.go
+++ b/internal/provider/databasebackup_resource.go
@@ -70,8 +70,11 @@ func (r *DatabaseBackupResource) Schema(ctx context.Context, req resource.Schema
 				Required:            true,
 			},
 			"name": schema.StringAttribute{
-				MarkdownDescription: "Display name for the database backup.",
-				Required:            true,
+				MarkdownDescription: "Auto-generated backup name assigned by the API (e.g. `mysql_wordpress_20260713140736`). The value provided in config is not used — the API always generates its own name.",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"location": schema.StringAttribute{
 				MarkdownDescription: "Region identifier (e.g., `ITBG-Bergamo`). See the [available locations and zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center).",
@@ -182,11 +185,11 @@ func (r *DatabaseBackupResource) Create(ctx context.Context, req resource.Create
 		}
 	}
 
-	// The backup API may take additional time to index the database even after
-	// Databases.Get() succeeds (the two APIs use separate indexes). Retry Create
-	// on "Database name not found" errors and transport failures for up to 15 min.
+	// The backup API indexes databases separately from Databases.Get() and can lag
+	// by 20–30 min after the database becomes visible. Retry until the effective
+	// resource timeout is exhausted rather than capping at a fixed count.
 	const backupRetryInterval = 15 * time.Second
-	const backupMaxRetries = 60 // up to 15 min additional
+	backupDeadline := time.Now().Add(effectiveTimeout(data.Timeout, r.client.ResourceTimeout))
 
 	backupBuilder := aruba.NewDBaaSBackup().
 		Named(data.Name.ValueString()).
@@ -200,7 +203,7 @@ func (r *DatabaseBackupResource) Create(ctx context.Context, req resource.Create
 
 	var backup *aruba.DBaaSBackup
 	var lastProvErr error
-	for attempt := 0; attempt <= backupMaxRetries; attempt++ {
+	for attempt := 0; ; attempt++ {
 		var createErr error
 		backup, createErr = r.client.Client.FromDatabase().Backups().Create(ctx, backupBuilder)
 		pe := CheckResponseErr("create", "DatabaseBackup", createErr)
@@ -209,15 +212,16 @@ func (r *DatabaseBackupResource) Create(ctx context.Context, req resource.Create
 			break
 		}
 		lastProvErr = pe
-		// Retry "database not yet visible to the backup API" propagation errors and
-		// pure transport failures (EOF / connection reset, StatusCode == 0).
-		if !strings.Contains(pe.Error(), "Database name is not found") && !ErrorIsTransportFailure(pe) {
+		// Retry transient 400s (dependency not yet ready) and transport failures
+		// (EOF / connection reset, StatusCode == 0). Semantic errors (wrong database
+		// name, invalid billing period, etc.) are permanent — break immediately.
+		if !ErrorIsTransient(pe) && !ErrorIsTransportFailure(pe) {
 			break
 		}
-		if attempt == backupMaxRetries {
+		if time.Now().After(backupDeadline) {
 			break
 		}
-		tflog.Info(ctx, "database not yet visible to backup API, retrying", map[string]interface{}{
+		tflog.Info(ctx, "backup dependency not yet ready, retrying", map[string]interface{}{
 			"database": databaseName,
 			"attempt":  attempt + 1,
 		})
@@ -235,6 +239,11 @@ func (r *DatabaseBackupResource) Create(ctx context.Context, req resource.Create
 
 	data.Id = types.StringValue(backup.ID())
 	data.Uri = strVal(backup.URI())
+	// The API auto-generates the backup name (ignoring the requested name).
+	// Hydrate from the response so state never drifts on subsequent refreshes.
+	if n := backup.Name(); n != "" {
+		data.Name = types.StringValue(n)
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
@@ -305,7 +314,17 @@ func (r *DatabaseBackupResource) Read(ctx context.Context, req resource.ReadRequ
 	if bp := billingPeriodFromAPI(string(backup.BillingPeriod())); bp != "" {
 		data.BillingPeriod = types.StringValue(bp)
 	}
-	// DBaaSID and Database are preserved from state (not in API response directly).
+	// dbaas_id: extract from the dbaas URI returned in the response
+	// (e.g. "/projects/.../dbaas/{id}").
+	if dbaasURI := backup.DBaaSURI(); dbaasURI != "" {
+		if idx := strings.LastIndex(dbaasURI, "/dbaas/"); idx >= 0 {
+			data.DBaaSID = types.StringValue(dbaasURI[idx+len("/dbaas/"):])
+		}
+	}
+	// database: the SDK now stores the plain name in DatabaseURI() after our fix.
+	if dbName := backup.DatabaseURI(); dbName != "" {
+		data.Database = types.StringValue(dbName)
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/databasebackup_resource.go
+++ b/internal/provider/databasebackup_resource.go
@@ -321,8 +321,7 @@ func (r *DatabaseBackupResource) Read(ctx context.Context, req resource.ReadRequ
 			data.DBaaSID = types.StringValue(dbaasURI[idx+len("/dbaas/"):])
 		}
 	}
-	// database: the SDK now stores the plain name in DatabaseURI() after our fix.
-	if dbName := backup.DatabaseURI(); dbName != "" {
+	if dbName := backup.DatabaseName(); dbName != "" {
 		data.Database = types.StringValue(dbName)
 	}
 

--- a/internal/provider/dbaas_resource.go
+++ b/internal/provider/dbaas_resource.go
@@ -334,6 +334,12 @@ func (r *DBaaSResource) Create(ctx context.Context, req resource.CreateRequest, 
 
 	data.Id = types.StringValue(dbaas.ID())
 	data.Uri = strVal(dbaas.URI())
+	// Resolve unknown billing_period to null before saving partial state so that
+	// if WaitUntilReady times out (exits with a warning) the state never holds an
+	// unknown value, which Terraform rejects ("all values must be known after apply").
+	if data.BillingPeriod.IsUnknown() {
+		data.BillingPeriod = types.StringNull()
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/dbaas_resource.go
+++ b/internal/provider/dbaas_resource.go
@@ -508,13 +508,6 @@ func (r *DBaaSResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 
-	// engine_id is not returned by the GET response (see Read), but the UPDATE
-	// API uses it for catalog product validation. Re-inject it from state so
-	// the PUT body carries a valid engineId and the lookup succeeds.
-	if !state.EngineID.IsNull() && state.EngineID.ValueString() != "" {
-		dbaas.OfEngine(aruba.DatabaseEngine(state.EngineID.ValueString()))
-	}
-
 	dbaas.Named(data.Name.ValueString())
 	if tags != nil {
 		dbaas.RetaggedAs(tags...)
@@ -522,11 +515,22 @@ func (r *DBaaSResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		dbaas.RetaggedAs(dbaas.Tags()...)
 	}
 
-	// Update storage size if changed.
+	// Update storage size only when it actually changed. Calling SizedGB with the
+	// same value as state triggers a catalog product validation in the UPDATE endpoint
+	// that fails when the flavor is absent from the update catalog ("Product not found
+	// in catalog"). Skip it for name/tag-only updates.
 	if !data.Storage.IsNull() {
 		storageAttrs := data.Storage.Attributes()
 		if sizeAttr, ok := storageAttrs["size_gb"].(types.Int64); ok && !sizeAttr.IsNull() {
-			dbaas.SizedGB(int(sizeAttr.ValueInt64()))
+			var stateSize int64
+			if !state.Storage.IsNull() {
+				if sv, ok2 := state.Storage.Attributes()["size_gb"].(types.Int64); ok2 && !sv.IsNull() {
+					stateSize = sv.ValueInt64()
+				}
+			}
+			if sizeAttr.ValueInt64() != stateSize {
+				dbaas.SizedGB(int(sizeAttr.ValueInt64()))
+			}
 		}
 		// Update autoscaling if provided.
 		if asAttr, ok := storageAttrs["autoscaling"]; ok {

--- a/internal/provider/dbaas_resource.go
+++ b/internal/provider/dbaas_resource.go
@@ -508,6 +508,13 @@ func (r *DBaaSResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 
+	// engine_id is not returned by the GET response (see Read), but the UPDATE
+	// API uses it for catalog product validation. Re-inject it from state so
+	// the PUT body carries a valid engineId and the lookup succeeds.
+	if !state.EngineID.IsNull() && state.EngineID.ValueString() != "" {
+		dbaas.OfEngine(aruba.DatabaseEngine(state.EngineID.ValueString()))
+	}
+
 	dbaas.Named(data.Name.ValueString())
 	if tags != nil {
 		dbaas.RetaggedAs(tags...)

--- a/internal/provider/dbaas_resource.go
+++ b/internal/provider/dbaas_resource.go
@@ -508,6 +508,21 @@ func (r *DBaaSResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 
+	// fromResponse hydrates d.engine from Engine.Type ("mysql"), not the catalog ID
+	// ("mysql-8.0"), so the PUT body would contain engine.id="mysql" which the
+	// UPDATE catalog lookup rejects with "Product not found in catalog".
+	// Override from state which holds the correct engine_id value.
+	if !state.EngineID.IsNull() && state.EngineID.ValueString() != "" {
+		dbaas.OfEngine(aruba.DatabaseEngine(state.EngineID.ValueString()))
+	}
+	// fromResponse never calls inZone (only inRegion), so d.zone = nil and the PUT
+	// body omits properties.dataCenter. The API treats an absent zone in a PUT as
+	// "change to null" and rejects with "DataCenter cannot be modified".
+	// Re-inject from state to keep the zone unchanged.
+	if !state.Zone.IsNull() && state.Zone.ValueString() != "" {
+		dbaas.InZone(aruba.Zone(state.Zone.ValueString()))
+	}
+
 	dbaas.Named(data.Name.ValueString())
 	if tags != nil {
 		dbaas.RetaggedAs(tags...)

--- a/internal/provider/provider_error.go
+++ b/internal/provider/provider_error.go
@@ -262,3 +262,12 @@ func ErrorIsTechnical(err error) bool {
 	var provErr *ProviderError
 	return errors.As(err, &provErr) && provErr != nil && provErr.Category == ProviderErrorCategoryTechnical
 }
+
+// ErrorIsTransportFailure reports whether err is a network-level failure with no
+// HTTP status code (e.g. EOF, connection reset). StatusCode == 0 means no response
+// was received, so the server almost certainly never processed the request and
+// retrying the same POST is safe.
+func ErrorIsTransportFailure(err error) bool {
+	var provErr *ProviderError
+	return errors.As(err, &provErr) && provErr != nil && provErr.StatusCode == 0
+}

--- a/internal/provider/resource_update_rich_test.go
+++ b/internal/provider/resource_update_rich_test.go
@@ -273,7 +273,7 @@ func TestDatabaseBackupRead_WithProperties(t *testing.T) {
 		`"uri":"/backups/test-id","location":{"value":"test-loc"},` +
 		`"tags":["env:test"]},` +
 		`"status":{"state":"Active"},` +
-		`"properties":{"billingPeriod":"Hour","dbaas":{"uri":"/dbaas/test"},"database":{"uri":"/db/test"}}}`
+		`"properties":{"billingPeriod":"Hour","dbaas":{"uri":"/dbaas/test"},"database":{"name":"testdb"}}}`
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {

--- a/internal/provider/resource_wait.go
+++ b/internal/provider/resource_wait.go
@@ -296,7 +296,10 @@ func CreateWithTransientRetry(
 		if err == nil {
 			return nil
 		}
-		if !ErrorIsTransient(err) {
+		// Retry transient 4xx (dependency not ready) and pure transport failures
+		// (EOF / connection reset — StatusCode == 0 means the server never processed
+		// the request so retrying the POST is safe).
+		if !ErrorIsTransient(err) && !ErrorIsTransportFailure(err) {
 			return err
 		}
 

--- a/run-acceptance-tests.sh
+++ b/run-acceptance-tests.sh
@@ -17,7 +17,8 @@
 #   ARUBACLOUD_KAAS_NODE_INSTANCE   TestAccKaasResource, TestAccKaasDataSource
 #   ARUBACLOUD_OS_IMAGE_ID          TestAccCloudserverResource, TestAccBlockStorageResource_Bootable,
 #                                   TestAccCloudserverDataSource, TestAccSchedulejobDataSource
-#   ARUBACLOUD_DBAAS_ID             TestAccDatabaseResource
+#   ARUBACLOUD_DBAAS_ID             TestAccDatabaseResource, TestAccDatabasebackupDataSource, TestAccDatabasebackupResource
+#   ARUBACLOUD_DATABASE_NAME        TestAccDatabasebackupDataSource, TestAccDatabasebackupResource
 #   ARUBACLOUD_VPNTUNNEL_ID         TestAccVpntunnelDataSource, TestAccVpnrouteDataSource
 #   ARUBACLOUD_VPNROUTE_ID          TestAccVpnrouteDataSource
 #
@@ -99,6 +100,7 @@ OPT_VAR_NAMES=(
     ARUBACLOUD_KAAS_NODE_INSTANCE
     ARUBACLOUD_OS_IMAGE_ID
     ARUBACLOUD_DBAAS_ID
+    ARUBACLOUD_DATABASE_NAME
     ARUBACLOUD_VPNTUNNEL_ID
     ARUBACLOUD_VPNROUTE_ID
 )
@@ -107,7 +109,8 @@ OPT_VAR_TESTS=(
     "TestAccKaasResource, TestAccKaasDataSource"
     "TestAccKaasResource, TestAccKaasDataSource"
     "TestAccCloudserverResource, TestAccBlockStorageResource_Bootable, TestAccCloudserverDataSource, TestAccSchedulejobDataSource"
-    "TestAccDatabaseResource"
+    "TestAccDatabaseResource, TestAccDatabasebackupDataSource, TestAccDatabasebackupResource"
+    "TestAccDatabasebackupDataSource, TestAccDatabasebackupResource"
     "TestAccVpntunnelDataSource, TestAccVpnrouteDataSource"
     "TestAccVpnrouteDataSource"
 )


### PR DESCRIPTION
## Summary

Closes #294. Three independent bugs on the DBaaS/DatabaseBackup resource stack are resolved.

### 1. `billing_period` unknown after apply (core #294)

`dbaas_resource.go Create()` now sets `billing_period` to `null` (instead of leaving it `unknown`) before writing partial state when `WaitUntilReady` times out. Terraform no longer errors with *all values must be known after apply*.

### 2. DBaaS Update regressions

- **`engine_id` dropped on Update** — `fromResponse` hydrates engine from the type slug (`mysql`) not the catalog ID (`mysql-8.0`), causing the PUT body to fail catalog lookup. Engine ID is now re-injected from state.
- **`zone` dropped on Update** — `fromResponse` never calls `inZone`, so `properties.dataCenter` was absent from the PUT body. Zone is now re-injected from state.
- **Spurious storage update** — `SizedGB` was called even when storage size was unchanged, triggering unnecessary catalog validation. It is now skipped when planned size equals state size.

### 3. DatabaseBackup wire format (sdk-go v1.0.5)

The backup API expects `"database":{"name":"<db-name>"}`, not `"database":{"uri":"..."}`. The SDK sent the wrong format, producing a `400 semantic` error (*Specified Database name is not found*). Fixed in [sdk-go#340](https://github.com/Arubacloud/sdk-go/pull/340) and consumed via the v1.0.5 upgrade.

Additional provider-side fixes for DatabaseBackup:
- `name` is now `Computed` — the API auto-generates it (e.g. `mysql_wordpress_20260713140736`) regardless of what is requested; hydrated from the Create response so state never drifts
- `Read()` now extracts `dbaas_id` from the response URI and `database` from the response name, enabling full `ImportStateVerify`
- Retry loop uses a deadline derived from `effectiveTimeout` (replaces hardcoded 60-attempt cap) and retries `ErrorIsTransient` instead of a stale substring match
- Both backup tests (`DataSource` + `Resource`) refactored to use `ARUBACLOUD_DATABASE_NAME` (pre-existing database) and `ARUBACLOUD_DBAAS_ID` directly, avoiding unreliable same-apply database creation

### 4. Retry robustness

`CreateWithTransientRetry` and the backup retry loop now also retry pure transport failures (EOF / connection reset, `StatusCode == 0`).

## Test plan

- [x] `TestAccDatabasebackupDataSource` — PASS (24 s)
- [x] `TestAccDatabasebackupResource` — PASS (34 s, includes create + import + stable refresh)
- [x] `TestAccDatabaseResource` — PASS (14 s)
- [x] `TestAccDatabaseDataSource` — PASS (595 s)
- [x] All provider unit tests — PASS

## Environment variables required for backup acceptance tests

```
ARUBACLOUD_DBAAS_ID=<existing-dbaas-id>
ARUBACLOUD_DATABASE_NAME=<database-name-on-that-dbaas>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
