### PR TITLE
fix(cloudserver): mark all API-backed fields RequiresReplace (#270)

### DIFF
--- a/docs/resources/cloudserver.md
+++ b/docs/resources/cloudserver.md
@@ -51,7 +51,7 @@ The following arguments are supported:
 #### Required
 
 - `location` (String) Region identifier for the resource (e.g., `ITBG-Bergamo`). See the [available locations and zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center). Changing this value forces a new resource.
-- `name` (String) Display name for the CloudServer.
+- `name` (String) Display name for the CloudServer. Changing this value forces a new resource.
 - `network` (Attributes) Network configuration for the CloudServer. (see [below for nested schema](#nestedatt--network))
 - `project_id` (String) ID of the project that owns this resource. Changing this value forces a new resource.
 - `settings` (Attributes) Compute and access settings for the CloudServer. (see [below for nested schema](#nestedatt--settings))
@@ -60,7 +60,7 @@ The following arguments are supported:
 
 #### Optional
 
-- `tags` (List of String) List of string tags attached to the resource for filtering and organisation.
+- `tags` (List of String) List of string tags attached to the resource for filtering and organisation. Changing this value forces a new resource.
 - `timeout` (String) Per-resource timeout override (e.g. `"15m"`, `"1h"`). Overrides the provider-level `resource_timeout` for this resource's Create and Delete operations. Uses Go duration syntax.
 
 ### Attributes Reference
@@ -91,11 +91,11 @@ Optional:
 
 Required:
 
-- `flavor_name` (String) Compute flavour name (e.g., `CSO4A8` for 4 vCPU / 8 GB RAM). See [available flavours](https://api.arubacloud.com/docs/metadata/#cloudserver-flavors).
+- `flavor_name` (String) Compute flavour name (e.g., `CSO4A8` for 4 vCPU / 8 GB RAM). See [available flavours](https://api.arubacloud.com/docs/metadata/#cloudserver-flavors). Changing this value forces a new resource.
 
 Optional:
 
-- `key_pair_uri_ref` (String) URI of the SSH key pair to inject at boot. Reference the `uri` attribute of an `arubacloud_keypair` resource.
+- `key_pair_uri_ref` (String) URI of the SSH key pair to inject at boot. Reference the `uri` attribute of an `arubacloud_keypair` resource. Changing this value forces a new resource.
 - `user_data` (String, Sensitive) Cloud-Init configuration passed verbatim to the instance at first boot (raw YAML or shell-script). Write-only — this value is sent to the API but is not returned in subsequent read responses. Changing this value forces a new resource.
 
 

--- a/internal/provider/cloudserver_resource.go
+++ b/internal/provider/cloudserver_resource.go
@@ -84,8 +84,11 @@ func (r *CloudServerResource) Schema(ctx context.Context, req resource.SchemaReq
 				},
 			},
 			"name": schema.StringAttribute{
-				MarkdownDescription: "Display name for the CloudServer.",
+				MarkdownDescription: "Display name for the CloudServer. Changing this value forces a new resource.",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"location": schema.StringAttribute{
 				MarkdownDescription: "Region identifier for the resource (e.g., `ITBG-Bergamo`). See the [available locations and zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center). Changing this value forces a new resource.",
@@ -110,8 +113,11 @@ func (r *CloudServerResource) Schema(ctx context.Context, req resource.SchemaReq
 			},
 			"tags": schema.ListAttribute{
 				ElementType:         types.StringType,
-				MarkdownDescription: "List of string tags attached to the resource for filtering and organisation.",
+				MarkdownDescription: "List of string tags attached to the resource for filtering and organisation. Changing this value forces a new resource.",
 				Optional:            true,
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.RequiresReplace(),
+				},
 			},
 			"network": schema.SingleNestedAttribute{
 				MarkdownDescription: "Network configuration for the CloudServer.",
@@ -156,14 +162,18 @@ func (r *CloudServerResource) Schema(ctx context.Context, req resource.SchemaReq
 				Required:            true,
 				Attributes: map[string]schema.Attribute{
 					"flavor_name": schema.StringAttribute{
-						MarkdownDescription: "Compute flavour name (e.g., `CSO4A8` for 4 vCPU / 8 GB RAM). See [available flavours](https://api.arubacloud.com/docs/metadata/#cloudserver-flavors).",
+						MarkdownDescription: "Compute flavour name (e.g., `CSO4A8` for 4 vCPU / 8 GB RAM). See [available flavours](https://api.arubacloud.com/docs/metadata/#cloudserver-flavors). Changing this value forces a new resource.",
 						Required:            true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.RequiresReplace(),
+						},
 					},
 					"key_pair_uri_ref": schema.StringAttribute{
-						MarkdownDescription: "URI of the SSH key pair to inject at boot. Reference the `uri` attribute of an `arubacloud_keypair` resource.",
+						MarkdownDescription: "URI of the SSH key pair to inject at boot. Reference the `uri` attribute of an `arubacloud_keypair` resource. Changing this value forces a new resource.",
 						Optional:            true,
 						PlanModifiers: []planmodifier.String{
 							stringplanmodifier.UseStateForUnknown(),
+							stringplanmodifier.RequiresReplace(),
 						},
 					},
 					"user_data": schema.StringAttribute{
@@ -536,128 +546,15 @@ func csStorageAttrTypes() map[string]attr.Type {
 func (r *CloudServerResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var data CloudServerResourceModel
 	var state CloudServerResourceModel
-
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	// Extract nested plan models for state reconstruction.
-	var planNetworkModel CloudServerNetworkModel
-	resp.Diagnostics.Append(data.Network.As(ctx, &planNetworkModel, basetypes.ObjectAsOptions{})...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	var planSettingsModel CloudServerSettingsModel
-	resp.Diagnostics.Append(data.Settings.As(ctx, &planSettingsModel, basetypes.ObjectAsOptions{})...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	var planStorageModel CloudServerStorageModel
-	resp.Diagnostics.Append(data.Storage.As(ctx, &planStorageModel, basetypes.ObjectAsOptions{})...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	tags := ListToTags(ctx, data.Tags, &resp.Diagnostics)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// Fetch-mutate-update: get current wrapper, apply name/tag mutations, submit.
-	server, err := r.client.Client.FromCompute().CloudServers().Get(ctx, cloudServerRef(&state))
-	if provErr := CheckResponseErr("read", "CloudServer", err); provErr != nil {
-		resp.Diagnostics.AddError("API Error", provErr.Error())
-		return
-	}
-
-	server.Named(data.Name.ValueString())
-	if tags != nil {
-		server.RetaggedAs(tags...)
-	} else {
-		server.RetaggedAs(server.Tags()...)
-	}
-
-	// Subnets and security groups are not returned by the API on Get, so the
-	// server object would send null for both fields without these explicit calls,
-	// causing a 400 "subnet/securityGroup cannot be null" error.
-	if !planNetworkModel.SubnetUriRefs.IsNull() && !planNetworkModel.SubnetUriRefs.IsUnknown() {
-		var subnetURIs []string
-		resp.Diagnostics.Append(planNetworkModel.SubnetUriRefs.ElementsAs(ctx, &subnetURIs, false)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-		subnetRefs := make([]aruba.Ref, len(subnetURIs))
-		for i, u := range subnetURIs {
-			subnetRefs[i] = aruba.URI(u)
-		}
-		server.OnSubnets(subnetRefs...)
-	}
-
-	if !planNetworkModel.SecurityGroupUriRefs.IsNull() && !planNetworkModel.SecurityGroupUriRefs.IsUnknown() {
-		var sgURIs []string
-		resp.Diagnostics.Append(planNetworkModel.SecurityGroupUriRefs.ElementsAs(ctx, &sgURIs, false)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-		sgRefs := make([]aruba.Ref, len(sgURIs))
-		for i, u := range sgURIs {
-			sgRefs[i] = aruba.URI(u)
-		}
-		server.WithSecurityGroups(sgRefs...)
-	}
-
-	updated, err := r.client.Client.FromCompute().CloudServers().Update(ctx, server)
-	if provErr := CheckResponseErr("update", "CloudServer", err); provErr != nil {
-		resp.Diagnostics.AddError("API Error", provErr.Error())
-		return
-	}
-
-	if waitErr := updated.WaitUntilReady(ctx, sdkWaitOptions(r.client.ResourceTimeout)...); waitErr != nil {
-		ReportWaitResult(&resp.Diagnostics, waitErr, "CloudServer", state.Id.ValueString())
-		return
-	}
-
-	if n := updated.Name(); n != "" {
-		data.Name = types.StringValue(n)
-	}
-	data.Tags = TagsToListPreserveNull(updated.Tags(), data.Tags)
-
-	// Preserve immutable fields from state.
+	// All API-backed fields carry RequiresReplace; Update() is only reached
+	// when the local-only `timeout` field changes. Preserve computed fields.
 	data.Id = state.Id
 	data.Uri = state.Uri
-	data.ProjectID = state.ProjectID
-	data.Zone = state.Zone
-
-	// Rebuild nested objects from plan values.
-	networkAttrs := map[string]attr.Value{
-		"vpc_uri_ref":            planNetworkModel.VpcUriRef,
-		"elastic_ip_uri_ref":     planNetworkModel.ElasticIpUriRef,
-		"subnet_uri_refs":        planNetworkModel.SubnetUriRefs,
-		"securitygroup_uri_refs": planNetworkModel.SecurityGroupUriRefs,
-	}
-	networkObj, d := types.ObjectValue(csNetworkAttrTypes(), networkAttrs)
-	resp.Diagnostics.Append(d...)
-	data.Network = networkObj
-
-	settingsAttrs := map[string]attr.Value{
-		"flavor_name":      planSettingsModel.FlavorName,
-		"key_pair_uri_ref": planSettingsModel.KeyPairUriRef,
-		"user_data":        planSettingsModel.UserData,
-	}
-	settingsObj, d := types.ObjectValue(csSettingsAttrTypes(), settingsAttrs)
-	resp.Diagnostics.Append(d...)
-	data.Settings = settingsObj
-
-	storageAttrs := map[string]attr.Value{"boot_volume_uri_ref": planStorageModel.BootVolumeUriRef}
-	storageObj, d := types.ObjectValue(csStorageAttrTypes(), storageAttrs)
-	resp.Diagnostics.Append(d...)
-	data.Storage = storageObj
-
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 

--- a/internal/provider/resource_update_test.go
+++ b/internal/provider/resource_update_test.go
@@ -70,9 +70,10 @@ func updateSuccessHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // resourcesWithAPIUpdate is the subset of allResources25 whose Update()
-// makes at least one SDK API call.  DatabaseBackup.Update() is a documented
-// no-op (adds a warning and saves state unchanged) so it is excluded from
-// error-path assertions that expect an error diagnostic.
+// makes at least one SDK API call.  Excluded resources:
+//   - databasebackup: documented no-op (adds a warning and saves state unchanged)
+//   - cloudserver:    all API-backed fields carry RequiresReplace(); Update() is a
+//     local-only no-op that never calls the API (see #270)
 var resourcesWithAPIUpdate = []struct {
 	name string
 	newR func() resource.Resource
@@ -89,7 +90,6 @@ var resourcesWithAPIUpdate = []struct {
 	{"restore", NewRestoreResource},
 	{"kms", NewKMSResource},
 	{"project", NewProjectResource},
-	{"cloudserver", NewCloudServerResource},
 	{"vpcpeering", NewVpcPeeringResource},
 	{"vpcpeeringroute", NewVpcPeeringRouteResource},
 	{"vpntunnel", NewVPNTunnelResource},


### PR DESCRIPTION
## Summary

- The ArubaCloud API does not support in-place updates of a running CloudServer; any attribute change returns `400 BootVolume in use`
- Added `RequiresReplace()` to the four fields that previously lacked it: `name`, `tags`, `settings.flavor_name`, and `settings.key_pair_uri_ref`
- Simplified `Update()` to a no-op pass-through — since every API-backed field now forces replacement, `Update()` is only reachable when the local-only `timeout` field changes, requiring no API call

## Test plan

- [ ] Build passes: `go build ./...`
- [ ] Unit tests pass: `make test`
- [ ] No acceptance tests needed: `RequiresReplace()` is enforced at plan time by the Terraform framework itself, requiring no real API credentials
- [ ] Docs regenerated: `make generate` run and `docs/resources/cloudserver.md` updated

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)
