### PR TITLE
fix: replace sdk WaitUntilReady with WaitForResourceActive for containerregistry (#292) and subnet (#322)

### DIFF
--- a/internal/provider/complex_resource_helpers_test.go
+++ b/internal/provider/complex_resource_helpers_test.go
@@ -190,9 +190,9 @@ func TestResourceCreate_Success_ComplexResources(t *testing.T) {
 		{"securityrule", NewSecurityRuleResource, createSuccessHandler},
 		// dbaas: needs full plan (storage + network objects non-null).
 		{"dbaas", NewDBaaSResource, createSuccessHandler},
-		// containerregistry is excluded: its SDK WaitUntilReady uses a poll interval
-		// of several minutes (matching the 20-40 min provisioning time), which
-		// exceeds unit-test timeouts.  The Create path is covered by acceptance tests.
+		// containerregistry: Create now uses WaitForResourceActive (fast, overridable
+		// poll interval) instead of the SDK's WaitUntilReady, so it's safe here.
+		{"containerregistry", NewContainerRegistryResource, createSuccessHandler},
 		// schedulejob: needs full plan (properties object with schedule_job_type).
 		{"schedulejob", NewScheduleJobResource, createSuccessHandler},
 		// vpnroute: needs full plan (properties object with cloud_subnet).

--- a/internal/provider/containerregistry_resource.go
+++ b/internal/provider/containerregistry_resource.go
@@ -303,7 +303,14 @@ func (r *ContainerRegistryResource) Create(ctx context.Context, req resource.Cre
 		return
 	}
 
-	if waitErr := registry.WaitUntilReady(ctx, sdkWaitOptions(effectiveTimeout(data.Timeout, r.client.ResourceTimeout))...); waitErr != nil {
+	crChecker := func(ctx context.Context) (string, error) {
+		reg, getErr := r.client.Client.FromContainer().ContainerRegistry().Get(ctx, containerRegistryRef(&data))
+		if provErr := CheckResponseErr("read", "ContainerRegistry", getErr); provErr != nil {
+			return "", provErr
+		}
+		return string(reg.State()), nil
+	}
+	if waitErr := WaitForResourceActive(ctx, crChecker, "ContainerRegistry", data.Id.ValueString(), effectiveTimeout(data.Timeout, r.client.ResourceTimeout)); waitErr != nil {
 		ReportWaitResult(&resp.Diagnostics, waitErr, "ContainerRegistry", data.Id.ValueString())
 		return
 	}
@@ -352,7 +359,14 @@ func (r *ContainerRegistryResource) Read(ctx context.Context, req resource.ReadR
 			fmt.Sprintf("ContainerRegistry %q is in a terminal failure state (%s). "+
 				"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", data.Id.ValueString(), st))
 	case IsCreatingState(st):
-		if waitErr := registry.WaitUntilReady(ctx, sdkWaitOptions(r.client.ResourceTimeout)...); waitErr != nil {
+		crChecker := func(ctx context.Context) (string, error) {
+			reg, getErr := r.client.Client.FromContainer().ContainerRegistry().Get(ctx, containerRegistryRef(&data))
+			if provErr := CheckResponseErr("read", "ContainerRegistry", getErr); provErr != nil {
+				return "", provErr
+			}
+			return string(reg.State()), nil
+		}
+		if waitErr := WaitForResourceActive(ctx, crChecker, "ContainerRegistry", data.Id.ValueString(), r.client.ResourceTimeout); waitErr != nil {
 			ReportWaitResult(&resp.Diagnostics, waitErr, "ContainerRegistry", data.Id.ValueString())
 			return
 		}

--- a/internal/provider/subnet_resource.go
+++ b/internal/provider/subnet_resource.go
@@ -539,7 +539,14 @@ func (r *SubnetResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	if waitErr := subnet.WaitUntilReady(ctx, sdkWaitOptions(effectiveTimeout(data.Timeout, r.client.ResourceTimeout))...); waitErr != nil {
+	subnetChecker := func(ctx context.Context) (string, error) {
+		fresh, getErr := r.client.Client.FromNetwork().Subnets().Get(ctx, subnetRef(&data))
+		if provErr := CheckResponseErr("read", "Subnet", getErr); provErr != nil {
+			return "", provErr
+		}
+		return string(fresh.State()), nil
+	}
+	if waitErr := WaitForResourceActive(ctx, subnetChecker, "Subnet", data.Id.ValueString(), effectiveTimeout(data.Timeout, r.client.ResourceTimeout)); waitErr != nil {
 		ReportWaitResult(&resp.Diagnostics, waitErr, "Subnet", data.Id.ValueString())
 		return
 	}
@@ -590,7 +597,14 @@ func (r *SubnetResource) Read(ctx context.Context, req resource.ReadRequest, res
 			fmt.Sprintf("Subnet %q is in a terminal failure state (%s). "+
 				"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", data.Id.ValueString(), st))
 	case IsCreatingState(st):
-		if waitErr := subnet.WaitUntilReady(ctx, sdkWaitOptions(r.client.ResourceTimeout)...); waitErr != nil {
+		subnetChecker := func(ctx context.Context) (string, error) {
+			fresh, getErr := r.client.Client.FromNetwork().Subnets().Get(ctx, subnetRef(&data))
+			if provErr := CheckResponseErr("read", "Subnet", getErr); provErr != nil {
+				return "", provErr
+			}
+			return string(fresh.State()), nil
+		}
+		if waitErr := WaitForResourceActive(ctx, subnetChecker, "Subnet", data.Id.ValueString(), r.client.ResourceTimeout); waitErr != nil {
 			ReportWaitResult(&resp.Diagnostics, waitErr, "Subnet", data.Id.ValueString())
 			return
 		}

--- a/internal/provider/subnet_resource.go
+++ b/internal/provider/subnet_resource.go
@@ -540,11 +540,12 @@ func (r *SubnetResource) Create(ctx context.Context, req resource.CreateRequest,
 	}
 
 	subnetChecker := func(ctx context.Context) (string, error) {
-		fresh, getErr := r.client.Client.FromNetwork().Subnets().Get(ctx, subnetRef(&data))
+		ref := aruba.SubnetRef(data.ProjectId.ValueString(), data.VpcId.ValueString(), data.Id.ValueString())
+		s, getErr := r.client.Client.FromNetwork().Subnets().Get(ctx, ref)
 		if provErr := CheckResponseErr("read", "Subnet", getErr); provErr != nil {
 			return "", provErr
 		}
-		return string(fresh.State()), nil
+		return string(s.State()), nil
 	}
 	if waitErr := WaitForResourceActive(ctx, subnetChecker, "Subnet", data.Id.ValueString(), effectiveTimeout(data.Timeout, r.client.ResourceTimeout)); waitErr != nil {
 		ReportWaitResult(&resp.Diagnostics, waitErr, "Subnet", data.Id.ValueString())
@@ -598,11 +599,12 @@ func (r *SubnetResource) Read(ctx context.Context, req resource.ReadRequest, res
 				"Run `terraform destroy` to clean it up, or `terraform apply -replace=<address>` to recreate it.", data.Id.ValueString(), st))
 	case IsCreatingState(st):
 		subnetChecker := func(ctx context.Context) (string, error) {
-			fresh, getErr := r.client.Client.FromNetwork().Subnets().Get(ctx, subnetRef(&data))
+			ref := aruba.SubnetRef(data.ProjectId.ValueString(), data.VpcId.ValueString(), data.Id.ValueString())
+			s, getErr := r.client.Client.FromNetwork().Subnets().Get(ctx, ref)
 			if provErr := CheckResponseErr("read", "Subnet", getErr); provErr != nil {
 				return "", provErr
 			}
-			return string(fresh.State()), nil
+			return string(s.State()), nil
 		}
 		if waitErr := WaitForResourceActive(ctx, subnetChecker, "Subnet", data.Id.ValueString(), r.client.ResourceTimeout); waitErr != nil {
 			ReportWaitResult(&resp.Diagnostics, waitErr, "Subnet", data.Id.ValueString())


### PR DESCRIPTION
## Summary

- **#292 — ContainerRegistry Read fails with ID parsing error**: the SDK stores the API-returned URI (`/providers/Aruba.Container/containerRegistries/...`) in the internal refresh callback, but `containerRegistryIDsFromRef` only recognises the `registries` path segment. Every `WaitUntilReady` poll triggered an internal `Get` with the wrong URI → *cannot determine registry ID from Ref*. Fix: replace `registry.WaitUntilReady()` with `WaitForResourceActive()` backed by a checker that always calls `Get` via `containerRegistryRef()`, which builds the correct `registries/...` path from the stored ID.

- **#322 — Subnet WaitUntilReady can hang**: the SDK's `async.WaitFor` treats a check result of `(true, err)` (unexpected settled state) as non-terminal and retries for all configured attempts instead of terminating. Fix: replace `subnet.WaitUntilReady()` with `WaitForResourceActive()`, which handles terminal and unexpected states correctly and respects context cancellation at each tick.

Both fixes applied to `Create` and to the `IsCreatingState` branch in `Read`. The `containerregistry` resource is re-enabled in `TestResourceCreate_Success_ComplexResources` now that `WaitForResourceActive` uses the overridable `waitForActivePollInterval`.

## Test plan

- [ ] Run unit tests: `go test ./internal/provider/...`
- [ ] Run acceptance tests for containerregistry: `TF_ACC=1 go test ./internal/acctest/ -run TestAccContainerregistryResource`
- [ ] Run acceptance tests for subnet: `TF_ACC=1 go test ./internal/acctest/ -run TestAccSubnetDataSource`
- [ ] Verify no regression in other resources

Closes #292
Closes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)