### PR TITLE
bump: sdk-go v1.0.9 — fix DBaaS user password encoding (release v1.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.0.1 (July 28, 2026)
+
+BUG FIXES:
+
+* `arubacloud_dbaasuser`: Fixed `Create` and `Update` always failing with HTTP 400 `"Password does not match the minimum requirements"`. The underlying SDK was base64-encoding the password before sending it to the API, causing the encoded string (which contains only alphanumeric characters) to fail the API's password policy. Fixed by upgrading to `sdk-go` v1.0.9, which sends the password as plain text ([#351](https://github.com/Arubacloud/sdk-go/issues/351), [sdk-go#352](https://github.com/Arubacloud/sdk-go/pull/352)).
+
+INTERNAL:
+
+* Bumped `sdk-go` to v1.0.9.
+
 ## 1.0.0 (July 22, 2026)
 
 NOTES:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Arubacloud/terraform-provider-arubacloud
 go 1.24.0
 
 require (
-	github.com/Arubacloud/sdk-go v1.0.7
+	github.com/Arubacloud/sdk-go v1.0.9
 	github.com/hashicorp/terraform-plugin-framework v1.16.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.29.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/Arubacloud/sdk-go v1.0.7 h1:egS1pufvlwh821grDV9DGDydhJDrcWEmiOBt2X1jYkw=
-github.com/Arubacloud/sdk-go v1.0.7/go.mod h1:OD2PSOa9uAxrhFwDcYcw+LE7eyZ+OQVaTA2tlHxVE4U=
+github.com/Arubacloud/sdk-go v1.0.9 h1:fBCIg5lybz+g4ckLc6Zd4sx6dgTkZcdRL/wdIikxyKI=
+github.com/Arubacloud/sdk-go v1.0.9/go.mod h1:OD2PSOa9uAxrhFwDcYcw+LE7eyZ+OQVaTA2tlHxVE4U=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.1.6 h1:ZcV+Ropw6Qn0AX9brlQLAUXfqLBc7Bl+f/DmNxpLfdw=


### PR DESCRIPTION
## Summary

- Bumps `sdk-go` from v1.0.7 → v1.0.9
- Adds CHANGELOG entry for v1.0.1

## Why

`arubacloud_dbaasuser` `Create` and `Update` always returned HTTP 400 `"Password does not match the minimum requirements"`. Root cause was in the SDK: `toRequest()` in `pkg/aruba/resource_user.go` was calling `base64.StdEncoding.EncodeToString` on the password before placing it in the JSON body. The API expects plaintext; the base64 output contains only alphanumeric characters and no special characters, which the API password policy requires.

Fixed in sdk-go [#352](https://github.com/Arubacloud/sdk-go/pull/352) (released as v1.0.9). This PR picks up the fix with a `go get` bump.

Evidence from `TF_LOG_PROVIDER_ARUBACLOUD_SDK=DEBUG`:
```
Request body:  {"username":"ghost","password":"UTJ4dmRXUWpTVzVwZERJMw=="}   ← base64 of base64("Cloud#Init27")
Response body: {"errors":[{"fieldName":"Password","errorMessage":"Password does not match the minimum requirements."}]}
```

Tracked in [sdk-go#351](https://github.com/Arubacloud/sdk-go/issues/351).

## Test plan

- [ ] `terraform apply` with `arubacloud_dbaasuser` creates the user without HTTP 400
- [ ] `terraform apply` with a password update succeeds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
