### PR TITLE
fix/(containerregistry): changed public_ip_uri_ref to optional (#355)

### DIFF
--- a/docs/resources/containerregistry.md
+++ b/docs/resources/containerregistry.md
@@ -82,10 +82,13 @@ In addition to all arguments above, the following attributes are exported:
 
 Required:
 
-- `public_ip_uri_ref` (String) URI of the Elastic IP that exposes the registry endpoint (e.g., `arubacloud_elasticip.example.uri`).
 - `security_group_uri_ref` (String) URI of the security group controlling registry traffic (e.g., `arubacloud_securitygroup.example.uri`).
 - `subnet_uri_ref` (String) URI of the subnet within the VPC (e.g., `arubacloud_subnet.example.uri`).
 - `vpc_uri_ref` (String) URI of the VPC that hosts the registry (e.g., `arubacloud_vpc.example.uri`).
+
+Optional:
+
+- `public_ip_uri_ref` (String) URI of the Elastic IP that exposes the registry endpoint (e.g., `arubacloud_elasticip.example.uri`). It can be omitted if not necessary
 
 
 <a id="nestedatt--settings"></a>

--- a/internal/provider/containerregistry_resource.go
+++ b/internal/provider/containerregistry_resource.go
@@ -106,8 +106,8 @@ func (r *ContainerRegistryResource) Schema(ctx context.Context, req resource.Sch
 				Required:            true,
 				Attributes: map[string]schema.Attribute{
 					"public_ip_uri_ref": schema.StringAttribute{
-						MarkdownDescription: "URI of the Elastic IP that exposes the registry endpoint (e.g., `arubacloud_elasticip.example.uri`).",
-						Required:            true,
+						MarkdownDescription: "URI of the Elastic IP that exposes the registry endpoint (e.g., `arubacloud_elasticip.example.uri`). It can be omitted if not necessary",
+						Optional:            true,
 						PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 					},
 					"vpc_uri_ref": schema.StringAttribute{
@@ -208,7 +208,7 @@ func applyContainerRegistryToModel(reg *aruba.ContainerRegistry, data *Container
 			"security_group_uri_ref": types.StringType,
 		},
 		map[string]attr.Value{
-			"public_ip_uri_ref":      types.StringValue(reg.ElasticIP()),
+			"public_ip_uri_ref":      strVal(reg.ElasticIP()),
 			"vpc_uri_ref":            types.StringValue(reg.VPC()),
 			"subnet_uri_ref":         types.StringValue(reg.Subnet()),
 			"security_group_uri_ref": types.StringValue(reg.SecurityGroup()),
@@ -265,11 +265,14 @@ func (r *ContainerRegistryResource) Create(ctx context.Context, req resource.Cre
 		InProject(aruba.URI("/projects/" + projectID)).
 		InRegion(aruba.Region(data.Location.ValueString())).
 		Tagged(tags...).
-		WithElasticIP(aruba.URI(networkModel.PublicIpUriRef.ValueString())).
 		WithVPC(aruba.URI(networkModel.VpcUriRef.ValueString())).
 		WithSubnet(aruba.URI(networkModel.SubnetUriRef.ValueString())).
 		WithSecurityGroup(aruba.URI(networkModel.SecurityGroupUriRef.ValueString())).
 		WithBlockStorage(aruba.URI(storageModel.BlockStorageUriRef.ValueString()))
+
+	if !networkModel.PublicIpUriRef.IsNull() && networkModel.PublicIpUriRef.ValueString() != "" {
+		builder = builder.WithElasticIP(aruba.URI(networkModel.PublicIpUriRef.ValueString()))
+	}
 
 	if !data.BillingPeriod.IsNull() && !data.BillingPeriod.IsUnknown() {
 		builder = builder.BilledBy(aruba.BillingPeriod(data.BillingPeriod.ValueString()))
@@ -421,8 +424,10 @@ func (r *ContainerRegistryResource) Update(ctx context.Context, req resource.Upd
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		registry.WithElasticIP(aruba.URI(networkModel.PublicIpUriRef.ValueString())).
-			WithVPC(aruba.URI(networkModel.VpcUriRef.ValueString())).
+		if !networkModel.PublicIpUriRef.IsNull() && networkModel.PublicIpUriRef.ValueString() != "" {
+			registry.WithElasticIP(aruba.URI(networkModel.PublicIpUriRef.ValueString()))
+		}
+		registry.WithVPC(aruba.URI(networkModel.VpcUriRef.ValueString())).
 			WithSubnet(aruba.URI(networkModel.SubnetUriRef.ValueString())).
 			WithSecurityGroup(aruba.URI(networkModel.SecurityGroupUriRef.ValueString()))
 	}


### PR DESCRIPTION
## Related Issue

Fixes #335 

## Description

This PR makes `public_ip_uri_ref` optional on `arubacloud_containerregistry`, matching the API/GUI behavior (a registry can be created with no public endpoint, resulting in a private container registry).

Three related changes were needed:
1. **Schema**: `public_ip_uri_ref` changed from `Required` to `Optional`.
2. **Request**:  (Create and Update): `WithElasticIP(...)` is now only called when the field is set.
3. **State consistency** (`applyContainerRegistryToModel`): use `strVal()` helper instead of `types.StringValue()`, so an empty API response is represented as `null` in state — otherwise Terraform reports "Provider produced inconsistent result after apply" (was null, but now cty.StringVal("")).

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes
