### PR TITLE
fix(kaas): expose security_group_id computed from API response URI

### DIFF
--- a/docs/data-sources/kaas.md
+++ b/docs/data-sources/kaas.md
@@ -93,6 +93,7 @@ In addition to all arguments above, the following attributes are exported:
 - `node_cidr_name` (String) Human-readable label for the node CIDR block.
 - `node_pools` (Attributes List) Node pools that make up the cluster worker fleet. (see [below for nested schema](#nestedatt--node_pools))
 - `pod_cidr` (String) CIDR block used for pod networking within the cluster.
+- `security_group_id` (String) Unique identifier of the security group created by the KaaS cluster. Use this value as the `id` input to the `arubacloud_securitygroup` data source.
 - `security_group_name` (String) Name of the security group applied to cluster nodes.
 - `subnet_uri_ref` (String) URI of the subnet within the VPC.
 - `tags` (List of String) List of string tags attached to the resource for filtering and organisation.

--- a/docs/resources/kaas.md
+++ b/docs/resources/kaas.md
@@ -118,6 +118,10 @@ Optional:
 
 - `pod_cidr` (String) CIDR block used for pod networking within the cluster (e.g., `10.0.3.0/24`).
 
+Read-Only:
+
+- `security_group_id` (String) Computed by the API. Unique identifier of the security group created by the KaaS cluster. Use this value as the `id` input to the `arubacloud_securitygroup` data source to look up the full security group and obtain its URI.
+
 <a id="nestedatt--network--node_cidr"></a>
 ### Nested Schema for `network.node_cidr`
 

--- a/internal/acctest/kaas_data_source_test.go
+++ b/internal/acctest/kaas_data_source_test.go
@@ -47,6 +47,11 @@ func TestAccKaasDataSource(t *testing.T) {
 						tfjsonpath.New("project_id"),
 						knownvalue.StringExact(projectID),
 					),
+					statecheck.ExpectKnownValue(
+						"data.arubacloud_kaas.test",
+						tfjsonpath.New("security_group_id"),
+						knownvalue.NotNull(),
+					),
 				},
 			},
 		},

--- a/internal/acctest/kaas_resource_test.go
+++ b/internal/acctest/kaas_resource_test.go
@@ -44,12 +44,12 @@ func TestAccKaasResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccKaasResourceConfig(projectID, location, zone, nodeInstance, k8sVersion, sfx, "test-kaas"),
+				Config: testAccKaasResourceConfig(projectID, location, zone, nodeInstance, k8sVersion, sfx, "test-kaas-"+sfx),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_kaas.test",
 						tfjsonpath.New("name"),
-						knownvalue.StringExact("test-kaas"),
+						knownvalue.StringExact("test-kaas-"+sfx),
 					),
 					statecheck.ExpectKnownValue(
 						"arubacloud_kaas.test",
@@ -86,12 +86,12 @@ func TestAccKaasResource(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: testAccKaasResourceConfig(projectID, location, zone, nodeInstance, k8sVersion, sfx, "test-kaas-updated"),
+				Config: testAccKaasResourceConfig(projectID, location, zone, nodeInstance, k8sVersion, sfx, "test-kaas-"+sfx+"-upd"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"arubacloud_kaas.test",
 						tfjsonpath.New("name"),
-						knownvalue.StringExact("test-kaas-updated"),
+						knownvalue.StringExact("test-kaas-"+sfx+"-upd"),
 					),
 				},
 			},

--- a/internal/acctest/kaas_resource_test.go
+++ b/internal/acctest/kaas_resource_test.go
@@ -61,6 +61,12 @@ func TestAccKaasResource(t *testing.T) {
 						tfjsonpath.New("settings").AtMapKey("node_pools").AtSliceIndex(0).AtMapKey("zone"),
 						knownvalue.NotNull(),
 					),
+					// Verify security_group_id is populated after provisioning (issue #333).
+					statecheck.ExpectKnownValue(
+						"arubacloud_kaas.test",
+						tfjsonpath.New("network").AtMapKey("security_group_id"),
+						knownvalue.NotNull(),
+					),
 				},
 			},
 			// ImportState testing
@@ -115,6 +121,118 @@ func testCheckKaasDestroyed(s *terraform.State) error {
 		return fmt.Errorf("KaaS %s still exists", rs.Primary.ID)
 	}
 	return nil
+}
+
+// TestAccKaas_SecurityGroupID verifies that arubacloud_kaas exposes a non-null
+// network.security_group_id after provisioning, and that this ID can be used
+// to look up the auto-generated security group via the arubacloud_securitygroup
+// data source (end-to-end validation of the fix for issue #333).
+func TestAccKaas_SecurityGroupID(t *testing.T) {
+	projectID := os.Getenv("ARUBACLOUD_PROJECT_ID")
+	location := os.Getenv("ARUBACLOUD_LOCATION")
+	zone := os.Getenv("ARUBACLOUD_ZONE")
+	nodeInstance := os.Getenv("ARUBACLOUD_KAAS_NODE_INSTANCE")
+	if projectID == "" || location == "" || zone == "" || nodeInstance == "" {
+		t.Skip("ARUBACLOUD_PROJECT_ID, ARUBACLOUD_LOCATION, ARUBACLOUD_ZONE, and ARUBACLOUD_KAAS_NODE_INSTANCE must be set for acceptance tests")
+	}
+	var sfxBytes [3]byte
+	rand.Read(sfxBytes[:]) //nolint:errcheck
+	sfx := fmt.Sprintf("%x", sfxBytes)
+	k8sVersion := testAccKaasK8sVersion()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
+		CheckDestroy:             testCheckKaasDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKaasSecurityGroupIDConfig(projectID, location, zone, nodeInstance, k8sVersion, sfx),
+				ConfigStateChecks: []statecheck.StateCheck{
+					// 1. security_group_id must be a non-null, non-empty string.
+					statecheck.ExpectKnownValue(
+						"arubacloud_kaas.test",
+						tfjsonpath.New("network").AtMapKey("security_group_id"),
+						knownvalue.NotNull(),
+					),
+					// 2. The arubacloud_securitygroup data source lookup by that ID must succeed.
+					statecheck.ExpectKnownValue(
+						"data.arubacloud_securitygroup.kaas_sg",
+						tfjsonpath.New("id"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(
+						"data.arubacloud_securitygroup.kaas_sg",
+						tfjsonpath.New("uri"),
+						knownvalue.NotNull(),
+					),
+					// 3. The data source's security_group_id in kaas data source must also be populated.
+					statecheck.ExpectKnownValue(
+						"data.arubacloud_kaas.test",
+						tfjsonpath.New("security_group_id"),
+						knownvalue.NotNull(),
+					),
+				},
+			},
+		},
+	})
+}
+
+func testAccKaasSecurityGroupIDConfig(projectID, location, zone, nodeInstance, k8sVersion, sfx string) string {
+	return fmt.Sprintf(`
+resource "arubacloud_vpc" "test" {
+  name       = "test-sgid-vpc-%[6]s"
+  location   = %[2]q
+  project_id = %[1]q
+}
+
+resource "arubacloud_subnet" "test" {
+  name       = "test-sgid-subnet-%[6]s"
+  location   = %[2]q
+  project_id = %[1]q
+  vpc_id     = arubacloud_vpc.test.id
+  type       = "Basic"
+}
+
+resource "arubacloud_kaas" "test" {
+  name           = "test-sgid-%[6]s"
+  location       = %[2]q
+  project_id     = %[1]q
+  billing_period = "Hour"
+
+  network = {
+    vpc_uri_ref         = arubacloud_vpc.test.uri
+    subnet_uri_ref      = arubacloud_subnet.test.uri
+    security_group_name = "kaas-sgid-%[6]s"
+    node_cidr = {
+      address = "10.0.1.0/24"
+      name    = "node-cidr-%[6]s"
+    }
+  }
+
+  settings = {
+    kubernetes_version = %[5]q
+    ha                 = false
+    node_pools = [
+      {
+        name     = "default"
+        nodes    = 1
+        instance = %[4]q
+        zone     = %[3]q
+      }
+    ]
+  }
+}
+
+data "arubacloud_kaas" "test" {
+  id         = arubacloud_kaas.test.id
+  project_id = %[1]q
+}
+
+data "arubacloud_securitygroup" "kaas_sg" {
+  id         = arubacloud_kaas.test.network.security_group_id
+  project_id = %[1]q
+}
+`, projectID, location, zone, nodeInstance, k8sVersion, sfx)
 }
 
 // testAccKaasResourceConfig builds the HCL for the KaaS resource acceptance test.

--- a/internal/acctest/kaas_resource_test.go
+++ b/internal/acctest/kaas_resource_test.go
@@ -231,6 +231,7 @@ data "arubacloud_kaas" "test" {
 data "arubacloud_securitygroup" "kaas_sg" {
   id         = arubacloud_kaas.test.network.security_group_id
   project_id = %[1]q
+  vpc_id     = arubacloud_vpc.test.id
 }
 `, projectID, location, zone, nodeInstance, k8sVersion, sfx)
 }

--- a/internal/provider/kaas_data_source.go
+++ b/internal/provider/kaas_data_source.go
@@ -38,6 +38,7 @@ type KaaSDataSourceModel struct {
 	NodeCIDRAddress   types.String `tfsdk:"node_cidr_address"`
 	NodeCIDRName      types.String `tfsdk:"node_cidr_name"`
 	SecurityGroupName types.String `tfsdk:"security_group_name"`
+	SecurityGroupId   types.String `tfsdk:"security_group_id"`
 	PodCIDR           types.String `tfsdk:"pod_cidr"`
 	// Settings fields (flattened)
 	KubernetesVersion types.String `tfsdk:"kubernetes_version"`
@@ -119,6 +120,10 @@ func (d *KaaSDataSource) Schema(ctx context.Context, req datasource.SchemaReques
 			},
 			"security_group_name": schema.StringAttribute{
 				MarkdownDescription: "Name of the security group applied to cluster nodes.",
+				Computed:            true,
+			},
+			"security_group_id": schema.StringAttribute{
+				MarkdownDescription: "Unique identifier of the security group created by the KaaS cluster. Use this value as the `id` input to the `arubacloud_securitygroup` data source.",
 				Computed:            true,
 			},
 			"pod_cidr": schema.StringAttribute{
@@ -250,6 +255,11 @@ func (d *KaaSDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		data.SecurityGroupName = types.StringValue(v)
 	} else {
 		data.SecurityGroupName = types.StringNull()
+	}
+	if raw != nil && raw.Properties.SecurityGroup.URI != nil && *raw.Properties.SecurityGroup.URI != "" {
+		data.SecurityGroupId = types.StringValue(idFromURI(*raw.Properties.SecurityGroup.URI))
+	} else {
+		data.SecurityGroupId = types.StringNull()
 	}
 	if v := kaas.PodCIDR(); v != "" {
 		data.PodCIDR = types.StringValue(v)

--- a/internal/provider/kaas_resource.go
+++ b/internal/provider/kaas_resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"strings"
 	"time"
 
 	aruba "github.com/Arubacloud/sdk-go/pkg/aruba"
@@ -66,6 +67,7 @@ type KaaSNetworkModel struct {
 	SubnetUriRef      types.String `tfsdk:"subnet_uri_ref"`
 	NodeCIDR          types.Object `tfsdk:"node_cidr"`
 	SecurityGroupName types.String `tfsdk:"security_group_name"`
+	SecurityGroupId   types.String `tfsdk:"security_group_id"`
 	PodCIDR           types.String `tfsdk:"pod_cidr"`
 }
 
@@ -159,6 +161,11 @@ func (r *KaaSResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 						MarkdownDescription: "Name of the security group applied to cluster nodes.",
 						Required:            true,
 					},
+					"security_group_id": schema.StringAttribute{
+						MarkdownDescription: "Computed by the API. Unique identifier of the security group created by the KaaS cluster. Use this value as the `id` input to the `arubacloud_securitygroup` data source to look up the full security group and obtain its URI.",
+						Computed:            true,
+						PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+					},
 					"pod_cidr": schema.StringAttribute{
 						MarkdownDescription: "CIDR block used for pod networking within the cluster (e.g., `10.0.3.0/24`).",
 						Optional:            true,
@@ -236,6 +243,51 @@ func (r *KaaSResource) Configure(ctx context.Context, req resource.ConfigureRequ
 		return
 	}
 	r.client = client
+}
+
+// kaasNetworkAttrTypes returns the attr.Type map for the network nested object.
+func kaasNetworkAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"vpc_uri_ref":         types.StringType,
+		"subnet_uri_ref":      types.StringType,
+		"node_cidr":           types.ObjectType{AttrTypes: map[string]attr.Type{"address": types.StringType, "name": types.StringType}},
+		"security_group_name": types.StringType,
+		"security_group_id":   types.StringType,
+		"pod_cidr":            types.StringType,
+	}
+}
+
+// idFromURI extracts the last path segment of a URI as the resource ID.
+// Returns "" for empty or malformed URIs.
+func idFromURI(uri string) string {
+	uri = strings.TrimRight(uri, "/")
+	if i := strings.LastIndex(uri, "/"); i >= 0 {
+		return uri[i+1:]
+	}
+	return uri
+}
+
+// kaasNetworkWithSGID returns a copy of networkObj with security_group_id set from sgURI.
+// If sgURI is nil or empty the existing value is preserved.
+func kaasNetworkWithSGID(networkObj types.Object, sgURI *string) types.Object {
+	if sgURI == nil || *sgURI == "" {
+		return networkObj
+	}
+	sgID := idFromURI(*sgURI)
+	if sgID == "" {
+		return networkObj
+	}
+	attrs := networkObj.Attributes()
+	newAttrs := make(map[string]attr.Value, len(attrs))
+	for k, v := range attrs {
+		newAttrs[k] = v
+	}
+	newAttrs["security_group_id"] = types.StringValue(sgID)
+	updated, diags := types.ObjectValue(kaasNetworkAttrTypes(), newAttrs)
+	if diags.HasError() {
+		return networkObj
+	}
+	return updated
 }
 
 func kaasRef(data *KaaSResourceModel) aruba.Ref {
@@ -424,6 +476,7 @@ func (r *KaaSResource) Create(ctx context.Context, req resource.CreateRequest, r
 		"vpc_uri_ref":         types.StringValue(networkModel.VpcUriRef.ValueString()),
 		"subnet_uri_ref":      types.StringValue(networkModel.SubnetUriRef.ValueString()),
 		"security_group_name": types.StringValue(networkModel.SecurityGroupName.ValueString()),
+		"security_group_id":   types.StringNull(), // populated after wait from fresh read
 	}
 	if !networkModel.PodCIDR.IsNull() {
 		networkAttrs["pod_cidr"] = types.StringValue(networkModel.PodCIDR.ValueString())
@@ -440,11 +493,7 @@ func (r *KaaSResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 	networkAttrs["node_cidr"] = nodeCIDRObj
-	networkObj, d := types.ObjectValue(map[string]attr.Type{
-		"vpc_uri_ref": types.StringType, "subnet_uri_ref": types.StringType,
-		"node_cidr":           types.ObjectType{AttrTypes: map[string]attr.Type{"address": types.StringType, "name": types.StringType}},
-		"security_group_name": types.StringType, "pod_cidr": types.StringType,
-	}, networkAttrs)
+	networkObj, d := types.ObjectValue(kaasNetworkAttrTypes(), networkAttrs)
 	resp.Diagnostics.Append(d...)
 	if !resp.Diagnostics.HasError() {
 		data.Network = networkObj
@@ -481,7 +530,7 @@ func (r *KaaSResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
-	// Re-read to get management IP.
+	// Re-read to get management IP and security group ID.
 	fresh, freshErr := r.client.Client.FromContainer().KaaS().Get(ctx, kaasRef(&data))
 	if freshErr == nil {
 		raw := fresh.Raw()
@@ -491,6 +540,9 @@ func (r *KaaSResource) Create(ctx context.Context, req resource.CreateRequest, r
 			data.ManagementIP = types.StringNull()
 		}
 		data.Kubeconfig = downloadKubeconfig(ctx, fresh)
+		if raw != nil {
+			data.Network = kaasNetworkWithSGID(data.Network, raw.Properties.SecurityGroup.URI)
+		}
 	} else {
 		data.ManagementIP = types.StringNull()
 		data.Kubeconfig = types.StringNull()
@@ -577,6 +629,7 @@ func (r *KaaSResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		"subnet_uri_ref":      types.StringNull(),
 		"node_cidr":           types.ObjectNull(map[string]attr.Type{"address": types.StringType, "name": types.StringType}),
 		"security_group_name": types.StringNull(),
+		"security_group_id":   types.StringNull(),
 		"pod_cidr":            types.StringNull(),
 	}
 	if v := kaas.VPC(); v != "" {
@@ -591,6 +644,14 @@ func (r *KaaSResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		var origNet KaaSNetworkModel
 		if dd := originalState.Network.As(ctx, &origNet, basetypes.ObjectAsOptions{}); !dd.HasError() && !origNet.SecurityGroupName.IsNull() {
 			networkAttrs["security_group_name"] = origNet.SecurityGroupName
+		}
+	}
+	if sgURI := raw.Properties.SecurityGroup.URI; sgURI != nil && *sgURI != "" {
+		networkAttrs["security_group_id"] = types.StringValue(idFromURI(*sgURI))
+	} else if !originalState.Network.IsNull() {
+		var origNet KaaSNetworkModel
+		if dd := originalState.Network.As(ctx, &origNet, basetypes.ObjectAsOptions{}); !dd.HasError() && !origNet.SecurityGroupId.IsNull() {
+			networkAttrs["security_group_id"] = origNet.SecurityGroupId
 		}
 	}
 	nodeCIDRAddress := raw.Properties.NodeCIDR.Address
@@ -624,11 +685,7 @@ func (r *KaaSResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 			networkAttrs["pod_cidr"] = origNet.PodCIDR
 		}
 	}
-	networkObj, dNet := types.ObjectValue(map[string]attr.Type{
-		"vpc_uri_ref": types.StringType, "subnet_uri_ref": types.StringType,
-		"node_cidr":           types.ObjectType{AttrTypes: map[string]attr.Type{"address": types.StringType, "name": types.StringType}},
-		"security_group_name": types.StringType, "pod_cidr": types.StringType,
-	}, networkAttrs)
+	networkObj, dNet := types.ObjectValue(kaasNetworkAttrTypes(), networkAttrs)
 	resp.Diagnostics.Append(dNet...)
 	if !resp.Diagnostics.HasError() {
 		data.Network = networkObj

--- a/internal/provider/kaas_resource_test.go
+++ b/internal/provider/kaas_resource_test.go
@@ -78,6 +78,7 @@ func buildKaaSCreateReqWithNodePool(ctx context.Context, t *testing.T) resource.
 			"name":    tftypes.NewValue(tftypes.String, "test-cidr"),
 		}),
 		"security_group_name": tftypes.NewValue(tftypes.String, "test-sg"),
+		"security_group_id":   tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
 		"pod_cidr":            tftypes.NewValue(tftypes.String, nil),
 	})
 


### PR DESCRIPTION
## Summary

Fixes #333.

The KaaS API returns a URI for the auto-generated security group in `KaasSecurityGroupPropertiesResponse.URI`, but the provider never read it. Users had no way to reference the security group in an `arubacloud_securitygroup` data source or `arubacloud_securityrule` resource.

- Add computed `security_group_id` attribute to the `network` nested block in both `arubacloud_kaas` resource and data source
- Populate it from `raw.Properties.SecurityGroup.URI` (last path segment extracted by `idFromURI()`) after Create wait and on every Read
- Add `kaasNetworkAttrTypes()` helper to centralise the network object type map (was duplicated inline)
- Add `kaasNetworkWithSGID()` helper to inject the ID into an existing network object after the create wait
- Update `TestKaaSCreate_Success` to include the new computed field as `tftypes.UnknownValue` in the plan

### Usage after this fix

```hcl
resource "arubacloud_kaas" "cluster" {
  # ...
  network {
    security_group_name = "my-sg"
    # ...
  }
}

data "arubacloud_securitygroup" "kaas_sg" {
  project_id = arubacloud_kaas.cluster.project_id
  id         = arubacloud_kaas.cluster.network.security_group_id
}

resource "arubacloud_securityrule" "allow_ssh" {
  security_group_uri_ref = data.arubacloud_securitygroup.kaas_sg.uri
  # ...
}
```

## Test plan

- [x] `go build ./...` — clean
- [x] `go test -race ./...` — all pass
- [ ] Acceptance test against a live KaaS cluster to confirm `security_group_id` is non-null after provisioning
