### PR TITLE
fix(securityrule): default port to "*" so Any/ICMP rules apply consistently

### DIFF
--- a/internal/provider/securityrule_resource.go
+++ b/internal/provider/securityrule_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -161,8 +162,10 @@ func (r *SecurityRuleResource) Schema(ctx context.Context, req resource.SchemaRe
 						},
 					},
 					"port": schema.StringAttribute{
-						MarkdownDescription: "Port or port range for TCP/UDP (e.g., `80` or `8080-8090`). Use `0` for ICMP or ANY. (Immutable — changing this value forces the resource to be destroyed and re-created.)",
+						MarkdownDescription: "Port or port range for TCP/UDP (e.g., `80` or `8080-8090`). Defaults to `*` (all ports) when omitted — the API normalises an omitted port to `*`, so the default keeps plan and state consistent. (Immutable — changing this value forces the resource to be destroyed and re-created.)",
 						Optional:            true,
+						Computed:            true,
+						Default:             stringdefault.StaticString("*"),
 						PlanModifiers: []planmodifier.String{
 							stringplanmodifier.RequiresReplace(),
 						},
@@ -375,7 +378,10 @@ func (r *SecurityRuleResource) Create(ctx context.Context, req resource.CreateRe
 		WithDirection(aruba.RuleDirection(direction)).
 		WithProtocol(aruba.RuleProtocol(protocol))
 
-	if port != "" {
+	// "*" is the schema default (= all ports) and also what the API returns
+	// for an omitted port — do not send it, mirroring the previous behaviour
+	// for empty/cleared ports.
+	if port != "" && port != "*" {
 		builder = builder.WithPort(port)
 	}
 


### PR DESCRIPTION
Fixes #339.

Creating an `arubacloud_securityrule` with `protocol = "Any"` (or `"ICMP"`) and no `port` fails with *"Provider produced inconsistent result after apply — `.properties.port`: was null, but now `cty.StringVal(\"*\")`"*: the provider omits the port from the create request (and force-clears it for Any/ICMP), the API normalises the omitted port to `*`, and the post-create state then carries `*` where the plan had `null` — which the plugin framework rightly rejects for a non-computed attribute. The rule **is** created remotely but never recorded in state, so retries pile up orphaned rules.

### Change

- `port` becomes `Optional + Computed` with `Default: stringdefault.StaticString("*")` — matching what the API returns for an omitted port, so plan and state agree in every phase (create, read, import).
- The default is **not** sent to the API (same behaviour as the previous empty-port path); explicit ports like `"443"` are unaffected.
- Docs string updated accordingly.

### Validation

- `go build ./...`, `go vet ./internal/provider/` clean
- existing unit tests pass (`go test ./internal/provider/ -run 'SecurityRule|Schema'`) — they build raw plan values and still exercise the Any/ICMP port-clearing path
- reproduced the original failure and verified the fixed behaviour against the live API (zone bring-up with 4 Any-rules; before: 4× inconsistent-result + orphaned remote rules, after: config with explicit `"*"` applies cleanly)

### Note for maintainers

For `ICMP` we could not verify what the API returns as port (we only hit the `Any` case live). If ICMP responds with something other than `*`, the same inconsistency would remain there and the default may need protocol-specific handling — an acceptance test run on your side would settle it.