### PR TITLE
docs(vpntunnel): psk.cloud_site / psk.on_prem_site are IKE identities, not keys

### DIFF
--- a/docs/resources/vpntunnel.md
+++ b/docs/resources/vpntunnel.md
@@ -140,8 +140,8 @@ Optional:
 
 Optional:
 
-- `cloud_site` (String) Pre-shared key for the ArubaCloud side of the tunnel.
-- `on_prem_site` (String) Pre-shared key for the on-premises side of the tunnel.
+- `cloud_site` (String) IKE identity of the ArubaCloud side of the tunnel ("PSK ID Aruba Side" in the control panel). This is an **identifier**, not a key — the pre-shared key itself goes into `secret`. Equivalent to `leftid`/`rightid` in strongSwan or the local/remote ID in a Fortinet phase-1 configuration.
+- `on_prem_site` (String) IKE identity of the on-premises side of the tunnel ("PSK ID On Prem Side" in the control panel). This is an **identifier**, not a key — the pre-shared key itself goes into `secret`. With some firewalls (e.g. Fortinet) this must be set to the public IP of the on-premises gateway.
 - `secret` (String) Shared secret used to authenticate the VPN tunnel. Write-only — this value is sent to the API but is not returned in subsequent read responses.
 
 

--- a/internal/provider/vpntunnel_resource.go
+++ b/internal/provider/vpntunnel_resource.go
@@ -211,11 +211,11 @@ func (r *VPNTunnelResource) Schema(ctx context.Context, req resource.SchemaReque
 								Optional:            true,
 								Attributes: map[string]schema.Attribute{
 									"cloud_site": schema.StringAttribute{
-										MarkdownDescription: "Pre-shared key for the ArubaCloud side of the tunnel.",
+										MarkdownDescription: "IKE identity of the ArubaCloud side of the tunnel (\"PSK ID Aruba Side\" in the control panel). This is an **identifier**, not a key — the pre-shared key itself goes into `secret`. Equivalent to `leftid`/`rightid` in strongSwan or the local/remote ID in a Fortinet phase-1 configuration.",
 										Optional:            true,
 									},
 									"on_prem_site": schema.StringAttribute{
-										MarkdownDescription: "Pre-shared key for the on-premises side of the tunnel.",
+										MarkdownDescription: "IKE identity of the on-premises side of the tunnel (\"PSK ID On Prem Side\" in the control panel). This is an **identifier**, not a key — the pre-shared key itself goes into `secret`. With some firewalls (e.g. Fortinet) this must be set to the public IP of the on-premises gateway.",
 										Optional:            true,
 									},
 									"secret": schema.StringAttribute{


### PR DESCRIPTION
### What

`vpn_client_settings.psk.cloud_site` and `.on_prem_site` are documented as *"Pre-shared key for the ArubaCloud / on-premises side of the tunnel"*. They are **not** keys — they are the **IKE identities** each side presents during the exchange. The actual pre-shared key is the sibling attribute `secret`.

### Evidence

The Aruba KB page *Creating a VPN Tunnel* labels these two fields **"PSK ID Aruba Side"** and **"PSK ID On Prem Side"** and describes them as the identifiers used in the VPN connection — not as key material. It also notes that with some firewalls (Fortinet is the KB's example) the on-prem identity has to be set to the public IP of the on-premises gateway.

In strongSwan terms these are `leftid` / `rightid`; in a Fortinet phase-1 configuration they are the local/remote ID.

### Why it matters

Read literally, the current wording tells the operator to put the PSK into all three attributes. The result is an IKE identity mismatch: phase 1 fails, and nothing in the error points back at the configuration — the values look "right" because they match what the docs asked for.

### Change

- rewrites both `MarkdownDescription` strings in `internal/provider/vpntunnel_resource.go` (the source `tfplugindocs` generates from)
- updates the generated `docs/resources/vpntunnel.md` to match
- adds the Fortinet caveat from the KB

Docs/strings only — no behaviour change. `go build ./...` and `go vet ./internal/provider/` pass.

### Context

We are bringing up a storage zone on Aruba Cloud and evaluating `arubacloud_vpntunnel` for site-to-site connectivity; this was the first thing that would have cost us a debugging session. Related: #339 / #340 (securityrule port default), #341 (expose private IP).