### PR TITLE
fix(blockstorage): require replacement when size_gb shrinks

### DIFF
--- a/docs/resources/blockstorage.md
+++ b/docs/resources/blockstorage.md
@@ -54,7 +54,7 @@ The following arguments are supported:
 - `location` (String) Region identifier (e.g., `ITBG-Bergamo`). See the [available locations and zones](https://api.arubacloud.com/docs/metadata/#location-and-data-center). (Immutable — changing this value forces the resource to be destroyed and re-created.)
 - `name` (String) Display name for the block storage volume.
 - `project_id` (String) ID of the project that owns this resource. (Immutable — changing this value forces the resource to be destroyed and re-created.)
-- `size_gb` (Number) Size of the block storage volume in GiB. Must be a positive integer.
+- `size_gb` (Number) Size of the block storage volume in GiB. Must be a positive integer. Growing a volume is applied in place; **shrinking forces the volume to be destroyed and re-created**, because the API rejects a smaller size (`Validation: Size: invalid`). A replacement discards the volume's contents — check the plan before applying.
 - `type` (String) Storage type. Accepted values: `Standard`, `Performance`. (Immutable — changing this value forces the resource to be destroyed and re-created.)
 
 #### Optional

--- a/internal/provider/blockstorage_resource.go
+++ b/internal/provider/blockstorage_resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -82,8 +83,29 @@ func (r *BlockStorageResource) Schema(ctx context.Context, req resource.SchemaRe
 				},
 			},
 			"size_gb": schema.Int64Attribute{
-				MarkdownDescription: "Size of the block storage volume in GiB. Must be a positive integer.",
-				Required:            true,
+				MarkdownDescription: "Size of the block storage volume in GiB. Must be a positive integer. " +
+					"Growing a volume is applied in place; **shrinking forces the volume to be destroyed and re-created**, " +
+					"because the API rejects a smaller size (`Validation: Size: invalid`). A replacement discards the " +
+					"volume's contents — check the plan before applying.",
+				Required: true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.RequiresReplaceIf(
+						func(ctx context.Context, req planmodifier.Int64Request, resp *int64planmodifier.RequiresReplaceIfFuncResponse) {
+							// Only a shrink needs replacement. The API grows a volume
+							// happily but rejects any smaller size, so without this the
+							// plan shows an in-place update that can never succeed —
+							// the apply fails and the configuration stays unappliable.
+							if req.StateValue.IsNull() || req.PlanValue.IsNull() || req.PlanValue.IsUnknown() {
+								return
+							}
+							if req.PlanValue.ValueInt64() < req.StateValue.ValueInt64() {
+								resp.RequiresReplace = true
+							}
+						},
+						"Shrinking a block storage volume requires it to be replaced.",
+						"Shrinking a block storage volume requires it to be replaced (the API rejects a smaller size).",
+					),
+				},
 			},
 			"billing_period": schema.StringAttribute{
 				MarkdownDescription: "Billing cycle. Accepted values: `Hour`, `Month`, `Year`.",


### PR DESCRIPTION
### The bug

Reducing `size_gb` produces a plan that Terraform can never apply. The provider issues an **in-place update**, and the API rejects it:

```
failed to update "BlockStorage", status_code: 400, category: semantic,
title: One or more validation errors occurred., detail: Validation: Size: invalid
```

Every subsequent apply fails identically, so the configuration stays unappliable until the volume is tainted or replaced by hand.

### The fix

`RequiresReplaceIf`, not an unconditional `RequiresReplace`.

Growing a volume works and should stay an in-place update — an unconditional replace would destroy and re-create a volume on **every growth**, which is considerably worse than the bug it fixes. Only the shrink needs replacement.

```go
if req.PlanValue.ValueInt64() < req.StateValue.ValueInt64() {
    resp.RequiresReplace = true
}
```

Null/unknown values are skipped so creation and computed plans behave as before.

### Side benefit

The plan now states the replacement explicitly, which surfaces the **data loss** a shrink implies. Today that consequence is hidden behind a failed apply — the operator learns about it only when the volume is already in an inconsistent plan state. The attribute description says so too.

`go build ./...` and `go vet ./internal/provider/` pass.

### Context

Found while shrinking a connector boot volume from 80 GB to 40 GB in a storage zone we run on Aruba Cloud. Related: #339 / #340 (securityrule port default), #341 (expose private IP), #342 (VPN tunnel PSK docs).